### PR TITLE
fix: cleanups and consolidate repeated code

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,11 @@ release:
 
 before:
   hooks:
+    - make clean
+    - go generate ./...
     - go mod tidy
+    - go mod download
+
 builds:
   -
     goos:
@@ -23,6 +27,7 @@ builds:
       - -s -w -X main.Version={{.Tag}}
     flags:
       - -trimpath
+
 dockers:
   -
     # GOOS of the built binary that should be used.

--- a/examples/kes-config-secret.yaml
+++ b/examples/kes-config-secret.yaml
@@ -21,7 +21,7 @@ stringData:
         - /v1/key/generate/*
         - /v1/key/decrypt/*
         identities:
-        - ${MINIO_ID}
+        - ${MINIO_KES_IDENTITY}
     cache:
       expiry:
         any: 5m0s

--- a/minioinstance-kustomize/kes-secret.yaml
+++ b/minioinstance-kustomize/kes-secret.yaml
@@ -21,7 +21,7 @@ stringData:
         - /v1/key/generate/*
         - /v1/key/decrypt/*
         identities:
-        - ${MINIO_ID}
+        - ${MINIO_KES_IDENTITY}
     cache:
       expiry:
         any: 5m0s

--- a/pkg/apis/minio.min.io/v1/globals.go
+++ b/pkg/apis/minio.min.io/v1/globals.go
@@ -17,38 +17,20 @@
 
 package v1
 
-import (
-	"os"
-)
+import "github.com/minio/minio/pkg/env"
 
 // ClusterDomain is used to store the Kubernetes cluster domain
 var ClusterDomain string
 
-// Scheme indicates communication over http or https
-var Scheme string
+// ClusterSecure indicates if TLS based deployment
+var ClusterSecure bool
 
-// Identity is the public identity generated for MinIO Server based on
+// KESIdentity is the public identity generated for MinIO Server based on
 // Used only during KES Deployments
-var Identity string
-
-func getEnv(key string) string {
-	value, ok := os.LookupEnv(key)
-	if !ok {
-		return "cluster.local"
-	}
-	return value
-}
-
-func identifyScheme(t *Tenant) string {
-	scheme := "http"
-	if t.AutoCert() || t.ExternalCert() {
-		scheme = "https"
-	}
-	return scheme
-}
+var KESIdentity string
 
 // InitGlobals initiates the global variables while Operator starts
 func InitGlobals(t *Tenant) {
-	ClusterDomain = getEnv("CLUSTER_DOMAIN")
-	Scheme = identifyScheme(t)
+	ClusterDomain = env.Get("CLUSTER_DOMAIN", "cluster.local")
+	ClusterSecure = t.AutoCert() || t.ExternalCert()
 }

--- a/pkg/apis/minio.min.io/v1/helper_test.go
+++ b/pkg/apis/minio.min.io/v1/helper_test.go
@@ -84,7 +84,7 @@ func TestTemplateVariables(t *testing.T) {
 
 	t.Run("Ellipsis", func(t *testing.T) {
 		hosts := mt.TemplatedMinIOHosts("{{.Ellipsis}}")
-		assert.Contains(t, hosts, ellipsis(0, servers-1))
+		assert.Contains(t, hosts, genEllipsis(0, servers-1))
 	})
 
 	t.Run("Domain", func(t *testing.T) {

--- a/pkg/controller/cluster/kes-csr.go
+++ b/pkg/controller/cluster/kes-csr.go
@@ -136,7 +136,7 @@ func (c *Controller) createMinIOClientTLSCSR(ctx context.Context, mi *miniov1.Te
 	}
 
 	// Store the Identity to be used later during KES container creation
-	miniov1.Identity = hex.EncodeToString(h.Sum(nil))
+	miniov1.KESIdentity = hex.EncodeToString(h.Sum(nil))
 
 	// PEM encode private ECDSA key
 	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -18,9 +18,6 @@
 package deployments
 
 import (
-	"net"
-	"strconv"
-
 	miniov1 "github.com/minio/operator/pkg/apis/minio.min.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,13 +29,13 @@ func consoleEnvVars(t *miniov1.Tenant) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "CONSOLE_MINIO_SERVER",
-			Value: miniov1.Scheme + "://" + net.JoinHostPort(t.MinIOCIServiceHost(), strconv.Itoa(miniov1.MinIOPort)),
+			Value: t.MinIOServerEndpoint(),
 		},
 	}
-	if miniov1.Scheme == "https" {
+	if miniov1.ClusterSecure {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "CONSOLE_MINIO_SERVER_TLS_SKIP_VERIFICATION",
-			Value: "on",
+			Value: "on", // FIXME: should be trusted
 		})
 	}
 	// Add all the environment variables

--- a/pkg/resources/statefulsets/kes-statefulset.go
+++ b/pkg/resources/statefulsets/kes-statefulset.go
@@ -63,8 +63,8 @@ func KESEnvironmentVars(t *miniov1.Tenant) []corev1.EnvVar {
 	// pass the identity created while generating the MinIO client cert
 	return []corev1.EnvVar{
 		{
-			Name:  "MINIO_ID",
-			Value: miniov1.Identity,
+			Name:  "MINIO_KES_IDENTITY",
+			Value: miniov1.KESIdentity,
 		},
 	}
 }


### PR DESCRIPTION
Bonus add cluster healthcheck to make sure that
we deploy console only when cluster is in stable
state after it has been deployed to avoid,
unnecessary requests to go to the server. Also
avoid binary updates if the cluster doesn't
have enough quorum to begin with.