### PR TITLE
Fix TLS and CSR related issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-minio-operator
+operator
 !minio-operator/
 .idea/
 dist/

--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -101,6 +101,10 @@ const LivenessPeriod = 1
 // LivenessTimeout specifies the timeout for the liveness probe to expect a response
 const LivenessTimeout = 1
 
+// LivenessFailureThreshold specifies the number of times the liveness probe can fail before
+// the probe to be considered failed.
+const LivenessFailureThreshold = 1
+
 // Console Related Constants
 
 // DefaultConsoleImage specifies the latest Console Docker hub image

--- a/pkg/apis/minio.min.io/v1/globals.go
+++ b/pkg/apis/minio.min.io/v1/globals.go
@@ -22,9 +22,6 @@ import "github.com/minio/minio/pkg/env"
 // ClusterDomain is used to store the Kubernetes cluster domain
 var ClusterDomain string
 
-// ClusterSecure indicates if TLS based deployment
-var ClusterSecure bool
-
 // KESIdentity is the public identity generated for MinIO Server based on
 // Used only during KES Deployments
 var KESIdentity string
@@ -32,5 +29,4 @@ var KESIdentity string
 // InitGlobals initiates the global variables while Operator starts
 func InitGlobals(t *Tenant) {
 	ClusterDomain = env.Get("CLUSTER_DOMAIN", "cluster.local")
-	ClusterSecure = t.AutoCert() || t.ExternalCert()
 }

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -234,10 +234,10 @@ func (t *Tenant) MinIOEndpoints(hostsTemplate string) (endpoints []string) {
 	}
 
 	for _, host := range hosts {
-		if ClusterSecure {
-			endpoints = append(endpoints, "https://%s", host)
+		if t.TLS() {
+			endpoints = append(endpoints, "https://"+host)
 		} else {
-			endpoints = append(endpoints, "http://%s", host)
+			endpoints = append(endpoints, "http://"+host)
 		}
 	}
 
@@ -324,7 +324,7 @@ func (t *Tenant) KESHosts() []string {
 // KESServiceEndpoint similar to KESServiceHost but a URL with current scheme
 func (t *Tenant) KESServiceEndpoint() string {
 	scheme := "http"
-	if ClusterSecure {
+	if t.TLS() {
 		scheme = "https"
 	}
 	u := &url.URL{
@@ -388,7 +388,7 @@ func (t *Tenant) MinIOServerHostAddress() string {
 // MinIOServerEndpoint similar to MinIOServerHostAddress but a URL with current scheme
 func (t *Tenant) MinIOServerEndpoint() string {
 	scheme := "http"
-	if ClusterSecure {
+	if t.TLS() {
 		scheme = "https"
 	}
 	u := &url.URL{
@@ -462,7 +462,7 @@ func (t *Tenant) NewMinIOAdmin(minioSecret map[string][]byte) (*madmin.AdminClie
 	}
 
 	opts := &madmin.Options{
-		Secure: ClusterSecure,
+		Secure: t.TLS(),
 		Creds:  credentials.NewStaticV4(string(accessKey), string(secretKey), ""),
 	}
 
@@ -632,4 +632,9 @@ func (t *Tenant) OwnerRef() []metav1.OwnerReference {
 			Kind:    MinIOCRDResourceKind,
 		}),
 	}
+}
+
+// TLS indicates whether TLS is enabled for this tenant
+func (t *Tenant) TLS() bool {
+	return t.AutoCert() || t.ExternalCert()
 }

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -66,8 +66,10 @@ func (t *Tenant) MinIOCIServiceName() string {
 }
 
 // MinIOCSRName returns the name of CSR that is generated if AutoTLS is enabled
+// Namespace adds uniqueness to the CSR name (single MinIO tenant per namsepace)
+// since CSR is not a namespaced resource
 func (t *Tenant) MinIOCSRName() string {
-	return t.Name + CSRNameSuffix
+	return t.Name + "-" + t.Namespace + CSRNameSuffix
 }
 
 // MinIOClientCSRName returns the name of CSR that is generated for Client side authentication
@@ -111,8 +113,10 @@ func (t *Tenant) KESTLSSecretName() string {
 }
 
 // KESCSRName returns the name of CSR that generated if AutoTLS is enabled for KES
+// Namespace adds uniqueness to the CSR name (single KES tenant per namsepace)
+// since CSR is not a namespaced resource
 func (t *Tenant) KESCSRName() string {
-	return t.KESStatefulSetName() + CSRNameSuffix
+	return t.KESStatefulSetName() + "-" + t.Namespace + CSRNameSuffix
 }
 
 // Console Related Names

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -32,7 +32,7 @@ func consoleEnvVars(t *miniov1.Tenant) []corev1.EnvVar {
 			Value: t.MinIOServerEndpoint(),
 		},
 	}
-	if miniov1.ClusterSecure {
+	if t.TLS() {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "CONSOLE_MINIO_SERVER_TLS_SKIP_VERIFICATION",
 			Value: "on", // FIXME: should be trusted

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -157,7 +157,7 @@ func volumeMounts(t *miniov1.Tenant, zone *miniov1.Zone) (mounts []corev1.Volume
 
 func probes(t *miniov1.Tenant) (liveness *corev1.Probe) {
 	scheme := corev1.URISchemeHTTP
-	if miniov1.ClusterSecure {
+	if t.TLS() {
 		scheme = corev1.URISchemeHTTPS
 	}
 	port := intstr.IntOrString{
@@ -176,6 +176,7 @@ func probes(t *miniov1.Tenant) (liveness *corev1.Probe) {
 			InitialDelaySeconds: t.Spec.Liveness.InitialDelaySeconds,
 			PeriodSeconds:       t.Spec.Liveness.PeriodSeconds,
 			TimeoutSeconds:      t.Spec.Liveness.TimeoutSeconds,
+			FailureThreshold:    miniov1.LivenessFailureThreshold,
 		}
 	}
 


### PR DESCRIPTION
- Remove global TLS variable, instead use per tenant TLS method.

- Fix CSR name to be unique per namespace (hence per tenant). This
is required to avoid name collision because CSR is not a
namespaced resource.

- Use 1 as the failure threshold for Liveness probe. This is because
we should stop sending requests to a failed pod as soon as we detect
it.