### PR TITLE
Add Zone Label to Pods

### DIFF
--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -55,6 +55,9 @@ const MinIOCertPath = "/tmp/certs"
 // TenantLabel is applied to all components of a Tenant cluster
 const TenantLabel = "v1.min.io/tenant"
 
+// ZoneLabel is applied to all components in a Zone of a Tenant cluster
+const ZoneLabel = "v1.min.io/zone"
+
 // MinIOPort specifies the default Tenant port number.
 const MinIOPort = 9000
 

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -100,7 +100,7 @@ func minioEnvironmentVars(t *miniov1.Tenant) []corev1.EnvVar {
 // Returns the MinIO pods metadata set in configuration.
 // If a user specifies metadata in the spec we return that
 // metadata.
-func minioMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
+func minioMetadata(t *miniov1.Tenant, zone *miniov1.Zone) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{}
 	if t.HasMetadata() {
 		meta = *t.Spec.Metadata
@@ -112,6 +112,8 @@ func minioMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
 	for k, v := range t.MinIOPodLabels() {
 		meta.Labels[k] = v
 	}
+	// Add information labels, such as which zone we are building this pod about
+	meta.Labels[miniov1.ZoneLabel] = zone.Name
 	return meta
 }
 
@@ -363,7 +365,7 @@ func NewForMinIOZone(t *miniov1.Tenant, zone *miniov1.Zone, serviceName string, 
 			ServiceName:         serviceName,
 			Replicas:            &replicas,
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: minioMetadata(t),
+				ObjectMeta: minioMetadata(t, zone),
 				Spec: corev1.PodSpec{
 					Containers:         containers,
 					Volumes:            podVolumes,


### PR DESCRIPTION
This PR introduces a label `v1.min.io/zone` on the pods for each Zone so they can be identified properly. This is also needed for Affinity control purposes 