### PR TITLE
fix regression in operator crd for env and tolerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 operator
+minio-operator
 !minio-operator/
 .idea/
 dist/

--- a/examples/tenant-console.yaml
+++ b/examples/tenant-console.yaml
@@ -91,22 +91,30 @@ spec:
     commonName: ""
     organizationName: []
     dnsNames: []
-      ## Used to specify a toleration for a pod
-      # tolerations:
-      #  - effect: NoSchedule
-      #    key: dedicated
-      #    operator: Equal
-      #    value: storage
-      ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
-      # env:
-      # - name: MINIO_BROWSER
-      #  value: "off" # to turn-off browser
-      # - name: MINIO_STORAGE_CLASS_STANDARD
-      #   value: "EC:4"
-      ## Configure resource requests and limits for MinIO containers
-    # resources:
-    # requests:
-    # memory: 20Gi
+
+  ## Used to specify a toleration for a pod
+  # tolerations:
+    #  - effect: NoSchedule
+    #    key: dedicated
+    #    operator: Equal
+    #    value: storage
+
+  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
+  # env:
+    # - name: MINIO_BROWSER
+    #   value: "off" # to turn-off browser
+    # - name: MINIO_STORAGE_CLASS_STANDARD
+    #   value: "EC:2"
+
+  ## Configure resource requests and limits for MinIO containers
+  # resources:
+  #   requests:
+  #     cpu: 250m
+  #     memory: 16Gi
+  #   limits:
+  #     cpu: 500m
+  #      memory: 16Gi
+
   ## Liveness probe detects situations where MinIO server instance
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
@@ -114,12 +122,14 @@ spec:
     initialDelaySeconds: 10
     periodSeconds: 1
     timeoutSeconds: 1
+
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.
   ## Read more here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   # nodeSelector:
   #   disktype: ssd
+  #
   ## Affinity settings for MinIO pods. Read more about affinity
   ## here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
   # affinity:

--- a/examples/tenant-kes.yaml
+++ b/examples/tenant-kes.yaml
@@ -105,22 +105,30 @@ spec:
     commonName: ""
     organizationName: []
     dnsNames: []
-      ## Used to specify a toleration for a pod
-      # tolerations:
-      #  - effect: NoSchedule
-      #    key: dedicated
-      #    operator: Equal
-      #    value: storage
-      ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
-      # env:
-      # - name: MINIO_BROWSER
-      #  value: "off" # to turn-off browser
-      # - name: MINIO_STORAGE_CLASS_STANDARD
-      #   value: "EC:4"
-      ## Configure resource requests and limits for MinIO containers
-      # resources:
-    # requests:
-    # memory: 20Gi
+
+  ## Used to specify a toleration for a pod
+  # tolerations:
+    #  - effect: NoSchedule
+    #    key: dedicated
+    #    operator: Equal
+    #    value: storage
+
+  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
+  # env:
+    # - name: MINIO_BROWSER
+    #   value: "off" # to turn-off browser
+    # - name: MINIO_STORAGE_CLASS_STANDARD
+    #   value: "EC:2"
+
+  ## Configure resource requests and limits for MinIO containers
+  # resources:
+  #   requests:
+  #     cpu: 250m
+  #     memory: 16Gi
+  #   limits:
+  #     cpu: 500m
+  #      memory: 16Gi
+
   ## Liveness probe detects situations where MinIO server instance
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
@@ -128,12 +136,14 @@ spec:
     initialDelaySeconds: 10
     periodSeconds: 1
     timeoutSeconds: 1
+
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.
   ## Read more here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   # nodeSelector:
   #   disktype: ssd
+  #
   ## Affinity settings for MinIO pods. Read more about affinity
   ## here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
   # affinity:

--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -25,6 +25,7 @@ spec:
       prometheus.io/path: /minio/prometheus/metrics
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
+
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2020-07-27T18-37-02Z
   zones:
@@ -39,6 +40,8 @@ spec:
           resources:
             requests:
               storage: 1Ti
+        # if you have direct-csi installed https://github.com/minio/direct-csi
+        # storageClassName: direct.csi.min.io
   ## Mount path where PV will be mounted inside container(s). Defaults to "/export".
   mountPath: /export
   ## Sub path inside Mount path where MinIO starts. Defaults to "".
@@ -49,6 +52,7 @@ spec:
   ## Secret with credentials to be used by MinIO instance.
   credsSecret:
     name: minio-creds-secret
+
   ## PodManagement policy for pods created by StatefulSet. Can be "OrderedReady" or "Parallel"
   ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ## for details. Defaults to "Parallel"
@@ -60,6 +64,7 @@ spec:
   ## Enable Kubernetes based certificate generation and signing as explained in
   ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
   requestAutoCert: false
+
   ## Used when "requestAutoCert" is set to true. Set CommonName for the auto-generated certificate.
   ## Internal DNS name for the pod will be used if CommonName is not provided.
   ## DNS name format is minio-{0...3}.minio.default.svc.cluster.local
@@ -67,22 +72,30 @@ spec:
     commonName: ""
     organizationName: []
     dnsNames: []
-      ## Used to specify a toleration for a pod
-      # tolerations:
-      #  - effect: NoSchedule
-      #    key: dedicated
-      #    operator: Equal
-      #    value: storage
-      ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
-      # env:
-      # - name: MINIO_BROWSER
-      #   value: "off" # to turn-off browser
-      # - name: MINIO_STORAGE_CLASS_STANDARD
-      #   value: "EC:2"
-      ## Configure resource requests and limits for MinIO containers
-      # resources:
-      # requests:
-    # memory: 20Gi
+
+  ## Used to specify a toleration for a pod
+  # tolerations:
+    #  - effect: NoSchedule
+    #    key: dedicated
+    #    operator: Equal
+    #    value: storage
+
+  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
+  # env:
+    # - name: MINIO_BROWSER
+    #   value: "off" # to turn-off browser
+    # - name: MINIO_STORAGE_CLASS_STANDARD
+    #   value: "EC:2"
+
+  ## Configure resource requests and limits for MinIO containers
+  # resources:
+  #   requests:
+  #     cpu: 250m
+  #     memory: 16Gi
+  #   limits:
+  #     cpu: 500m
+  #      memory: 16Gi
+
   ## Liveness probe detects situations where MinIO server instance
   ## is not working properly and needs restart. Kubernetes automatically
   ## restarts the pods if liveness checks fail.
@@ -90,12 +103,14 @@ spec:
     initialDelaySeconds: 10
     periodSeconds: 1
     timeoutSeconds: 1
+
   ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
   ## eligible to run on a node, the node must have each of the
   ## indicated key-value pairs as labels.
   ## Read more here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   # nodeSelector:
   #   disktype: ssd
+  #
   ## Affinity settings for MinIO pods. Read more about affinity
   ## here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
   # affinity:

--- a/minio-operator.yaml
+++ b/minio-operator.yaml
@@ -55,7 +55,35 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                       resources:
                         type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - requests
+                          - limits
+                        properties:
+                          limits:
+                            type: object
+                            required:
+                              - cpu
+                              - memory
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                              memory:
+                                type: string
+                                pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                          requests:
+                            type: object
+                            required:
+                              - cpu
+                              - memory
+                            properties:
+                              cpu:
+                                type: string
+                                pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                              memory:
+                                type: string
+                                pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+
                       nodeSelector:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
@@ -63,8 +91,32 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       tolerations:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                        items:
+                          type: object
+                        required:
+                          - key
+                          - operator
+                          - effect
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                            enum:
+                              - Equal
+                              - Exists
+                          value:
+                            type: string
+                          effect:
+                            type: string
+                            enum:
+                              - NoExecute
+                              - NoSchedule
+                              - PreferNoSchedule
+                          tolerationSeconds:
+                            type: integer
+
                 mountPath:
                   type: string
                 podManagementPolicy:
@@ -100,8 +152,10 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 env:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 console:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -121,10 +175,40 @@ spec:
                           type: string
                     resources:
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
+                      required:
+                        - requests
+                        - limits
+                      properties:
+                        limits:
+                          type: object
+                          required:
+                            - cpu
+                            - memory
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                            memory:
+                              type: string
+                              pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
+                        requests:
+                          type: object
+                          required:
+                            - cpu
+                            - memory
+                          properties:
+                            cpu:
+                              type: string
+                              pattern: '^(\d+m|\d+(\.\d{1,3})?)$'
+                            memory:
+                              type: string
+                              pattern: '^(\d+(e\d+)?|\d+(\.\d+)?(e\d+)?[EPTGMK]i?)$'
                     env:
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
+                      type: array
+                      items:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+
                 kes:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
- env: definition should be an array
- tolerations: definition should be an array
- bonus resources: should be strictly validated
  for valid inputs

Overall advice limit usage of `x-kubernetes-preserve-unknown-fields`