### PR TITLE
Add support for deploying console with TLS support

### DIFF
--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -122,6 +122,12 @@ const ConsolePort = 9090
 // ConsoleServicePortName specifies the default Console Service's port name.
 const ConsoleServicePortName = "http-console"
 
+// ConsoleTLSPort specifies the default Console port number for HTTPS.
+const ConsoleTLSPort = 9443
+
+// ConsoleServiceTLSPortName specifies the default Console Service's port name.
+const ConsoleServiceTLSPortName = "https-console"
+
 // ConsoleServiceNameSuffix specifies the suffix added to Tenant service name to create a service for console
 const ConsoleServiceNameSuffix = "-ui"
 
@@ -133,6 +139,10 @@ const ConsoleAdminPolicyName = "consoleAdmin"
 
 // ConsoleRestartPolicy defines the default restart policy for Console Containers
 const ConsoleRestartPolicy = corev1.RestartPolicyAlways
+
+// ConsoleConfigMountPath specifies the path where Console config file and all secrets are mounted
+// We keep this to /tmp so it doesn't require any special permissions
+const ConsoleConfigMountPath = "/tmp/console"
 
 // DefaultConsoleReplicas specifies the default number of Console pods to be created if not specified
 const DefaultConsoleReplicas = 2

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -93,6 +93,12 @@ func (t *Tenant) KESExternalCert() bool {
 	return t.Spec.KES != nil && t.Spec.KES.ExternalCertSecret != nil
 }
 
+// ConsoleExternalCert returns true is the user has provided a secret
+// that contains CA cert, server cert and server key for Console pods
+func (t *Tenant) ConsoleExternalCert() bool {
+	return t.Spec.Console != nil && t.Spec.Console.ExternalCertSecret != nil
+}
+
 // AutoCert returns true is the user has provided a secret
 // that contains CA cert, server cert and server key for group replication
 // SSL support

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -135,3 +135,13 @@ func (t *Tenant) ConsoleCIServiceName() string {
 func (t *Tenant) ZoneStatefulsetName(zone *Zone) string {
 	return fmt.Sprintf("%s-%s", t.Name, zone.Name)
 }
+
+// ConsoleVolMountName returns the name of Secret that has TLS related Info (Cert & Private Key)
+func (t *Tenant) ConsoleVolMountName() string {
+	return t.Name + ConsoleName
+}
+
+// ConsoleTLSSecretName returns the name of Secret that has Console TLS related Info (Cert & Private Key)
+func (t *Tenant) ConsoleTLSSecretName() string {
+	return t.ConsoleDeploymentName() + TLSSecretSuffix
+}

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -183,6 +183,10 @@ type ConsoleConfiguration struct {
 	// If provided, use these requests and limit for cpu/memory resource allocation
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// ExternalCertSecret allows a user to specify custom CA certificate, and private key. This is
+	// used for enabling TLS support on Console Pods.
+	// +optional
+	ExternalCertSecret *LocalCertificateReference `json:"externalCertSecret,omitempty"`
 }
 
 // EqualImage returns true if config image and current input image are same

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -88,7 +88,8 @@ func NewHeadlessForKES(t *miniov1.Tenant) *corev1.Service {
 
 // NewClusterIPForConsole will return a new cluster IP service for Console Deployment
 func NewClusterIPForConsole(t *miniov1.Tenant) *corev1.Service {
-	minioPort := corev1.ServicePort{Port: miniov1.ConsolePort, Name: miniov1.ConsoleServicePortName}
+	consolePort := corev1.ServicePort{Port: miniov1.ConsolePort, Name: miniov1.ConsoleServicePortName}
+	consoleTLSPort := corev1.ServicePort{Port: miniov1.ConsoleTLSPort, Name: miniov1.ConsoleServiceTLSPortName}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:          t.ConsolePodLabels(),
@@ -97,7 +98,10 @@ func NewClusterIPForConsole(t *miniov1.Tenant) *corev1.Service {
 			OwnerReferences: t.OwnerRef(),
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:    []corev1.ServicePort{minioPort},
+			Ports: []corev1.ServicePort{
+				consolePort,
+				consoleTLSPort,
+			},
 			Selector: t.ConsolePodLabels(),
 			Type:     corev1.ServiceTypeClusterIP,
 		},

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -292,7 +292,7 @@ func NewForMinIOZone(t *miniov1.Tenant, zone *miniov1.Zone, serviceName string, 
 			kesCertSecret = t.Spec.KES.ExternalCertSecret.Name
 			// This covers both secrets of type "kubernetes.io/tls" and
 			// "cert-manager.io/v1alpha2" because of same keys in both.
-			if t.Spec.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" {
+			if t.Spec.KES.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.KES.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" {
 				KESCertPath = []corev1.KeyToPath{
 					{Key: "tls.crt", Path: "CAs/kes.crt"},
 				}


### PR DESCRIPTION
This PR adds support for running Console with TLS via AutoCert or with
external certificates