### PR TITLE
Delete existing tenant's pods when a new zone is being created

### DIFF
--- a/operator-kustomize/cluster-role.yaml
+++ b/operator-kustomize/cluster-role.yaml
@@ -17,6 +17,7 @@ rules:
       - create
       - list
       - delete
+      - deletecollection
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
Previous behavior was giving a large downtime since it is doing it in rolling update fashion,
hence, causing some pods to be unavailable and affecting availability for that period.
This, deletes all the pods on zone addition so that they can be recreated and synchronized faster.