### PR TITLE
KUBELET_DIR_PATH is required and can be changed as required

### DIFF
--- a/docs/using-direct-csi.md
+++ b/docs/using-direct-csi.md
@@ -8,10 +8,13 @@
 cat << EOF > default.env
 DIRECT_CSI_DRIVES=data{1...4}
 DIRECT_CSI_DRIVES_DIR=/mnt
+KUBELET_DIR_PATH=/var/lib/kubelet
 EOF
 
 export $(cat default.env)
 ```
+
+If you are using microk8s `KUBELET_DIR_PATH` should be changed to `/var/snap/microk8s/common/var/lib/kubelet`
 
 ### Create the namespace for the driver
 ```


### PR DESCRIPTION
Update the docs so people realise KUBELET_DIR_PATH is required and can be changed. Please see this issue https://github.com/minio/direct-csi/issues/11