### PR TITLE
Remove Cluster Domain Global

### DIFF
--- a/kubectl-minio/go.mod
+++ b/kubectl-minio/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-openapi/errors v0.19.6 // indirect
 	github.com/go-openapi/strfmt v0.19.5 // indirect
-	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.4.0 // indirect
 	github.com/imdario/mergo v0.3.10 // indirect
@@ -24,15 +23,11 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
-	github.com/secure-io/sio-go v0.3.1 // indirect
 	github.com/spf13/cobra v1.0.0
 	go.etcd.io/etcd/v3 v3.3.0-rc.0.0.20200707003333-58bb8ae09f8e // indirect
 	go.mongodb.org/mongo-driver v1.3.5 // indirect
-	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
-	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -251,3 +251,6 @@ var DefaultQueryTimeout = time.Minute * 20
 
 // TLSSecretSuffix is the suffix applied to Tenant name to create the TLS secret
 var TLSSecretSuffix = "-tls"
+
+// Cluster Domain
+const clusterDomain = "CLUSTER_DOMAIN"

--- a/pkg/apis/minio.min.io/v1/globals.go
+++ b/pkg/apis/minio.min.io/v1/globals.go
@@ -17,16 +17,6 @@
 
 package v1
 
-import "github.com/minio/minio/pkg/env"
-
-// ClusterDomain is used to store the Kubernetes cluster domain
-var ClusterDomain string
-
 // KESIdentity is the public identity generated for MinIO Server based on
 // Used only during KES Deployments
 var KESIdentity string
-
-// InitGlobals initiates the global variables while Operator starts
-func InitGlobals(t *Tenant) {
-	ClusterDomain = env.Get("CLUSTER_DOMAIN", "cluster.local")
-}

--- a/pkg/apis/minio.min.io/v1/helper_test.go
+++ b/pkg/apis/minio.min.io/v1/helper_test.go
@@ -98,7 +98,7 @@ func TestTemplateVariables(t *testing.T) {
 
 	t.Run("Domain", func(t *testing.T) {
 		hosts := mt.TemplatedMinIOHosts("{{.Domain}}")
-		assert.Contains(t, hosts, ClusterDomain)
+		assert.Contains(t, hosts, GetClusterDomain())
 	})
 }
 
@@ -110,7 +110,6 @@ func TestTenant_KESServiceEndpoint(t1 *testing.T) {
 		Spec       TenantSpec
 		Status     TenantStatus
 	}
-	ClusterDomain = "cluster.local"
 	autoCertEnabled := true
 	tests := []struct {
 		name   string

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -55,7 +55,7 @@ func (t *Tenant) MinIOStatefulSetNameForPool(z *Pool) string {
 
 // MinIOWildCardName returns the wild card name for all MinIO Pods in current StatefulSet
 func (t *Tenant) MinIOWildCardName() string {
-	return fmt.Sprintf("*.%s.%s.svc.%s", t.MinIOHLServiceName(), t.Namespace, ClusterDomain)
+	return fmt.Sprintf("*.%s.%s.svc.%s", t.MinIOHLServiceName(), t.Namespace, GetClusterDomain())
 }
 
 // MinIOTLSSecretName returns the name of Secret that has TLS related Info (Cert & Private Key)
@@ -84,17 +84,17 @@ func (t *Tenant) MinIOCIServiceName() string {
 
 // MinIOBucketBaseDomain returns the base domain name for buckets
 func (t *Tenant) MinIOBucketBaseDomain() string {
-	return fmt.Sprintf("%s.svc.%s", t.Namespace, ClusterDomain)
+	return fmt.Sprintf("%s.svc.%s", t.Namespace, GetClusterDomain())
 }
 
 // MinIOBucketBaseWildcardDomain returns the base domain name for buckets
 func (t *Tenant) MinIOBucketBaseWildcardDomain() string {
-	return fmt.Sprintf("*.%s.svc.%s", t.Namespace, ClusterDomain)
+	return fmt.Sprintf("*.%s.svc.%s", t.Namespace, GetClusterDomain())
 }
 
 // MinIOFQDNServiceName returns the name of the service created for the tenant.
 func (t *Tenant) MinIOFQDNServiceName() string {
-	return fmt.Sprintf("%s.%s.svc.%s", t.MinIOCIServiceName(), t.Namespace, ClusterDomain)
+	return fmt.Sprintf("%s.%s.svc.%s", t.MinIOCIServiceName(), t.Namespace, GetClusterDomain())
 }
 
 // MinIOCSRName returns the name of CSR that is generated if AutoTLS is enabled
@@ -136,7 +136,7 @@ func (t *Tenant) KESVolMountName() string {
 // KESWildCardName returns the wild card name managed by headless service created for
 // KES StatefulSet in current Tenant
 func (t *Tenant) KESWildCardName() string {
-	return fmt.Sprintf("*.%s.%s.svc.%s", t.KESHLServiceName(), t.Namespace, ClusterDomain)
+	return fmt.Sprintf("*.%s.%s.svc.%s", t.KESHLServiceName(), t.Namespace, GetClusterDomain())
 }
 
 // KESTLSSecretName returns the name of Secret that has KES TLS related Info (Cert & Private Key)
@@ -175,7 +175,7 @@ func (t *Tenant) ConsoleVolMountName() string {
 
 // ConsoleCommonName returns the CommonName to be used in the csr template
 func (t *Tenant) ConsoleCommonName() string {
-	return fmt.Sprintf("%s.%s.svc.%s", t.ConsoleCIServiceName(), t.Namespace, ClusterDomain)
+	return fmt.Sprintf("%s.%s.svc.%s", t.ConsoleCIServiceName(), t.Namespace, GetClusterDomain())
 }
 
 // ConsoleTLSSecretName returns the name of Secret that has Console TLS related Info (Cert & Private Key)

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -346,7 +346,7 @@ func (c *Controller) applyOperatorWebhookSecret(ctx context.Context, tenant *min
 						cred.SecretKey,
 						fmt.Sprintf("operator.%s.svc.%s",
 							miniov1.GetNSFromFile(),
-							miniov1.ClusterDomain),
+							miniov1.GetClusterDomain()),
 						miniov1.WebhookDefaultPort,
 						miniov1.WebhookAPIGetenv,
 						tenant.Namespace,
@@ -412,7 +412,6 @@ func (c *Controller) BucketSrvHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tenant.EnsureDefaults()
-	miniov1.InitGlobals(tenant)
 
 	// Validate the MinIO Tenant
 	if err = tenant.Validate(); err != nil {
@@ -480,7 +479,6 @@ func (c *Controller) GetenvHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tenant.EnsureDefaults()
-	miniov1.InitGlobals(tenant)
 
 	// Validate the MinIO Tenant
 	if err = tenant.Validate(); err != nil {
@@ -500,7 +498,7 @@ func (c *Controller) GetenvHandler(w http.ResponseWriter, r *http.Request) {
 			"http",
 			fmt.Sprintf("operator.%s.svc.%s",
 				miniov1.GetNSFromFile(),
-				miniov1.ClusterDomain),
+				miniov1.GetClusterDomain()),
 			miniov1.WebhookDefaultPort,
 			miniov1.WebhookAPIBucketService,
 			tenant.Namespace,
@@ -836,7 +834,6 @@ func (c *Controller) syncHandler(key string) error {
 	nsName := types.NamespacedName{Namespace: namespace, Name: tenantName}
 
 	tenant.EnsureDefaults()
-	miniov1.InitGlobals(tenant)
 
 	// Validate the MinIO Tenant
 	if err = tenant.Validate(); err != nil {
@@ -1104,7 +1101,7 @@ func (c *Controller) syncHandler(key string) error {
 
 		// FIXME: we can make operator TLS configurable here.
 		updateURL, err := tenant.UpdateURL(latest, fmt.Sprintf("http://operator.%s.svc.%s:%s%s",
-			miniov1.GetNSFromFile(), miniov1.ClusterDomain,
+			miniov1.GetNSFromFile(), miniov1.GetClusterDomain(),
 			miniov1.WebhookDefaultPort, miniov1.WebhookAPIUpdate,
 		))
 		if err != nil {

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -195,10 +195,10 @@ func NewClusterIPForLogSearchAPI(t *miniov1.Tenant) *corev1.Service {
 
 // GetLogSearchDBAddr returns the tenant's Postgres DB server address
 func GetLogSearchDBAddr(t *miniov1.Tenant) string {
-	return fmt.Sprintf("%s.%s.svc.%s:%d", t.LogHLServiceName(), t.Namespace, miniov1.ClusterDomain, miniov1.LogPgPort)
+	return fmt.Sprintf("%s.%s.svc.%s:%d", t.LogHLServiceName(), t.Namespace, miniov1.GetClusterDomain(), miniov1.LogPgPort)
 }
 
 // GetLogSearchAPIAddr returns the tenant's log-search-api server address
 func GetLogSearchAPIAddr(t *miniov1.Tenant) string {
-	return fmt.Sprintf("http://%s.%s.svc.%s:%d", t.LogSearchAPIServiceName(), t.Namespace, miniov1.ClusterDomain, miniov1.LogSearchAPIPort)
+	return fmt.Sprintf("http://%s.%s.svc.%s:%d", t.LogSearchAPIServiceName(), t.Namespace, miniov1.GetClusterDomain(), miniov1.LogSearchAPIPort)
 }


### PR DESCRIPTION
Having Cluster Domain as a global was causing the helper functions and name functions were not returning proper values when using Operator as a library