### PR TITLE
add webhook server implementation for tenants

### DIFF
--- a/examples/tenant-console.yaml
+++ b/examples/tenant-console.yaml
@@ -37,7 +37,7 @@ spec:
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2020-08-05T21-34-13Z
+  image: minio/minio:RELEASE.2020-08-08T04-50-06Z
   ## Secret with credentials to be used by MinIO instance.
   credsSecret:
     name: minio-creds-secret

--- a/examples/tenant-kes.yaml
+++ b/examples/tenant-kes.yaml
@@ -37,7 +37,7 @@ spec:
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2020-08-05T21-34-13Z
+  image: minio/minio:RELEASE.2020-08-08T04-50-06Z
   ## Secret with credentials to be used by MinIO instance.
   credsSecret:
     name: minio-creds-secret

--- a/examples/tenant-pod-security-policy.yaml
+++ b/examples/tenant-pod-security-policy.yaml
@@ -78,7 +78,7 @@ spec:
       prometheus.io/port: "9000"
       prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2020-08-05T21-34-13Z
+  image: minio/minio:RELEASE.2020-08-08T04-50-06Z
   ## Service account to be used for all the MinIO Pods
   serviceAccountName: minio-pods
   zones:

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.13
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-cmp v0.4.1 // indirect
+	github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/minio/minio v0.0.0-20200723003940-b9be841fd222

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,7 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08 h1:kPna6oIGlRXWmg/jkKfxbpvsl+0DHYnw1qQwN+6+gyA=
 github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/rpc v1.2.0/go.mod h1:V4h9r+4sF5HnzqbwIez0fKSpANP0zlYd3qR7p36jkTQ=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
   - name: minio/k8s-operator
     newName: minio/k8s-operator
-    newTag: v3.0.10
+    newTag: v3.0.11
 
 namespace: minio-operator
 
@@ -15,4 +15,5 @@ resources:
   - operator-kustomize/cluster-role.yaml
   - operator-kustomize/cluster-role-binding.yaml
   - operator-kustomize/crds/minio.min.io_tenants.yaml
+  - operator-kustomize/service.yaml
   - operator-kustomize/deployment.yaml

--- a/operator-kustomize/service.yaml
+++ b/operator-kustomize/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: operator
+  labels:
+    name: minio-operator
+  namespace: minio-operator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4222
+      name: http
+    - port: 4233
+      name: https
+  selector:
+    name: minio-operator

--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -74,7 +74,7 @@ const MinIOVolumeMountPath = "/export"
 const MinIOVolumeSubPath = ""
 
 // DefaultMinIOImage specifies the default MinIO Docker hub image
-const DefaultMinIOImage = "minio/minio:RELEASE.2020-08-05T21-34-13Z"
+const DefaultMinIOImage = "minio/minio:RELEASE.2020-08-08T04-50-06Z"
 
 // DefaultMinIOUpdateURL specifies the default MinIO URL where binaries are
 // pulled from during MinIO upgrades

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -44,6 +44,21 @@ import (
 	"github.com/minio/minio/pkg/madmin"
 )
 
+// Webhook API constants
+const (
+	WebhookAPIVersion       = "/webhook/v1"
+	WebhookDefaultPort      = "4222"
+	WebhookOperatorSecret   = "operator-webhook-secret"
+	WebhookOperatorUsername = "webhookUsername"
+	WebhookOperatorPassword = "webhookPassword"
+)
+
+// List of webhook APIs
+const (
+	WebhookAPIGetenv        = WebhookAPIVersion + "/getenv"
+	WebhookAPIBucketService = WebhookAPIVersion + "/bucketsrv"
+)
+
 type hostsTemplateValues struct {
 	StatefulSet string
 	CIService   string

--- a/pkg/controller/cluster/console-csr.go
+++ b/pkg/controller/cluster/console-csr.go
@@ -86,7 +86,7 @@ func (c *Controller) createConsoleTLSCSR(ctx context.Context, mi *miniov1.Tenant
 	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})
 
 	// Create secret for Console Deployment to use
-	err = c.createSecret(ctx, mi, mi.ConsolePodLabels(), mi.ConsoleTLSSecretName(), mi.Namespace, encodedPrivKey, certbytes)
+	err = c.createSecret(ctx, mi, mi.ConsolePodLabels(), mi.ConsoleTLSSecretName(), encodedPrivKey, certbytes)
 	if err != nil {
 		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", mi.ConsoleTLSSecretName(), err)
 		return err

--- a/pkg/controller/cluster/kes-csr.go
+++ b/pkg/controller/cluster/kes-csr.go
@@ -89,7 +89,7 @@ func (c *Controller) createKESTLSCSR(ctx context.Context, mi *miniov1.Tenant) er
 	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})
 
 	// Create secret for KES Statefulset to use
-	err = c.createSecret(ctx, mi, mi.KESPodLabels(), mi.KESTLSSecretName(), mi.Namespace, encodedPrivKey, certbytes)
+	err = c.createSecret(ctx, mi, mi.KESPodLabels(), mi.KESTLSSecretName(), encodedPrivKey, certbytes)
 	if err != nil {
 		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", mi.KESTLSSecretName(), err)
 		return err
@@ -142,7 +142,7 @@ func (c *Controller) createMinIOClientTLSCSR(ctx context.Context, mi *miniov1.Te
 	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})
 
 	// Create secret for KES Statefulset to use
-	err = c.createSecret(ctx, mi, mi.MinIOPodLabels(), mi.MinIOClientTLSSecretName(), mi.Namespace, encodedPrivKey, certbytes)
+	err = c.createSecret(ctx, mi, mi.MinIOPodLabels(), mi.MinIOClientTLSSecretName(), encodedPrivKey, certbytes)
 	if err != nil {
 		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", mi.MinIOClientTLSSecretName(), err)
 		return err

--- a/pkg/controller/cluster/webhook-server.go
+++ b/pkg/controller/cluster/webhook-server.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package cluster
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	miniov1 "github.com/minio/operator/pkg/apis/minio.min.io/v1"
+)
+
+// Used for registering with rest handlers (have a look at registerStorageRESTHandlers for usage example)
+// If it is passed ["aaaa", "bbbb"], it returns ["aaaa", "{aaaa:.*}", "bbbb", "{bbbb:.*}"]
+func restQueries(keys ...string) []string {
+	var accumulator []string
+	for _, key := range keys {
+		accumulator = append(accumulator, key, "{"+key+":.*}")
+	}
+	return accumulator
+}
+
+func configureWebhookServer(c *Controller) *http.Server {
+	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
+
+	router.Methods(http.MethodGet).
+		Path(miniov1.WebhookAPIGetenv + "/{namespace}/{name:.+}").
+		HandlerFunc(c.GetenvHandler).
+		Queries(restQueries("key")...)
+
+	router.Methods(http.MethodPost).
+		Path(miniov1.WebhookAPIBucketService + "/{namespace}/{name:.+}").
+		HandlerFunc(c.BucketSrvHandler).
+		Queries(restQueries("bucket")...)
+
+	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println(r)
+	})
+
+	s := &http.Server{
+		Addr:           ":" + miniov1.WebhookDefaultPort,
+		Handler:        router,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	return s
+}


### PR DESCRIPTION
Current implementation provides a mechanism
where the tenant loads an ENV such as its
command line args remotely, this is to
facilitate faster zone addition times.
