### PR TITLE
add init container for sanity checks

### DIFF
--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -24,11 +24,20 @@ import (
 // MinIOServerName specifies the default container name for Tenant
 const MinIOServerName = "minio"
 
+// MinIODNSInitContainer Init Container for DNS
+const MinIODNSInitContainer = "minio-dns-wait"
+
+// MinIOVolumeInitContainer Init Container for DNS
+const MinIOVolumeInitContainer = "minio-vol-wait"
+
 // KESContainerName specifies the default container name for KES
 const KESContainerName = "kes"
 
 // ConsoleContainerName specifies the default container name for Console
 const ConsoleContainerName = "console"
+
+// InitContainerImage name for init container.
+const InitContainerImage = "busybox:1.32"
 
 // MinIO Related Names
 


### PR DESCRIPTION
During testing, we suspect an edge case where the volume mount might not be ready before minio starts up. Adding these init containers to ensure that volumes and DNS names are ready.
