### PR TITLE
Always delete pvc when tenant is deleted

### DIFF
--- a/operator-kustomize/cluster-role.yaml
+++ b/operator-kustomize/cluster-role.yaml
@@ -6,6 +6,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - update
+      - list
+  - apiGroups:
+      - ""
+    resources:
       - namespaces
       - secrets
       - pods

--- a/operator-kustomize/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/crds/minio.min.io_tenants.yaml
@@ -479,6 +479,12 @@ spec:
                 importance of a Pod relative to other Pods. This is applied to MinIO
                 pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
               type: string
+            purgePVCOnTenantDelete:
+              description: Delete PVCs on tenant deletion. Defaults to (false) preserving
+                PVCs if tenant is deleted. PVCs will need cleanup post tenant deletion
+                if not set to true. If set to true ALL PVs for the tenant will be
+                deleted.
+              type: boolean
             requestAutoCert:
               description: 'RequestAutoCert allows user to enable Kubernetes based
                 TLS cert generation and signing as explained here: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/'

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -39,6 +39,9 @@ const ConsoleContainerName = "console"
 // InitContainerImage name for init container.
 const InitContainerImage = "busybox:1.32"
 
+// Finalizer name used for resources operator wants to track for deletion
+const Finalizer = "finalizer.minio.min.io"
+
 // MinIO Related Names
 
 // MinIOStatefulSetNameForZone returns the name for MinIO StatefulSet

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -51,6 +51,10 @@ type TenantScheduler struct {
 type TenantSpec struct {
 	// Definition for Cluster in given MinIO cluster
 	Zones []Zone `json:"zones"`
+	// Delete PVCs on tenant deletion. Defaults to (false) preserving PVCs if tenant is deleted. PVCs will
+	// need cleanup post tenant deletion if not set to true. If set to true ALL PVs for the tenant will be deleted.
+	// +optional
+	PurgePVCOnTenantDelete bool `json:"purgePVCOnTenantDelete,omitempty"`
 	// Image defines the Tenant Docker image.
 	// +optional
 	Image string `json:"image,omitempty"`

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -702,6 +702,13 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	// Set any required default values and init Global variables
 	nsName := types.NamespacedName{Namespace: namespace, Name: name}
+
+	// Update tenant before setting defaults
+	mi, err = c.applyFinalizer(ctx, mi)
+	if err != nil {
+		return err
+	}
+
 	mi.EnsureDefaults()
 	miniov1.InitGlobals(mi)
 
@@ -717,6 +724,16 @@ func (c *Controller) syncHandler(key string) error {
 
 	secret, err := c.applyOperatorWebhookSecret(ctx, mi)
 	if err != nil {
+		return err
+	}
+
+	// Process deletion
+	if !mi.ObjectMeta.DeletionTimestamp.IsZero() {
+		klog.Infof("deleting tenant:%s/%s", mi.Namespace, mi.Name)
+		err = c.processDelete(ctx, mi)
+		if err != nil {
+			return err
+		}
 		return err
 	}
 
@@ -884,6 +901,13 @@ func (c *Controller) syncHandler(key string) error {
 					return err
 				}
 			}
+
+			// Set the PVC purge  behavior needed.
+			err = c.processPurgePVCsOnDeleteFlag(ctx, mi)
+			if err != nil {
+				return err
+			}
+
 		}
 
 		// If the StatefulSet is not controlled by this Tenant resource, we should log
@@ -1278,4 +1302,105 @@ func (c *Controller) checkAndCreateConsoleCSR(ctx context.Context, nsName types.
 		}
 	}
 	return nil
+}
+
+// getPodsForTenant returns a list of pods running on a given tenant
+func (c *Controller) getPodsForTenant(tenant *miniov1.Tenant) ([]corev1.Pod, error) {
+	pods, err := c.kubeClientSet.CoreV1().Pods(tenant.Namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", miniov1.TenantLabel, tenant.Name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
+// processPurgePVCsOnDelete sets the owner reference for PVC to the tenant. This allows automatic deletion
+// of the PVCs when the tenant is deleted.
+func (c *Controller) processPurgePVCsOnDeleteFlag(ctx context.Context, mi *miniov1.Tenant) error {
+
+	pods, err := c.getPodsForTenant(mi)
+	if err != nil {
+		// No pods created for tenant
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	for _, pod := range pods {
+		for _, pvc := range pod.Spec.Volumes {
+			if pvc.PersistentVolumeClaim != nil {
+				p, err := c.kubeClientSet.CoreV1().PersistentVolumeClaims(mi.Namespace).Get(ctx, pvc.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+				if err != nil {
+					// No claims found
+					if k8serrors.IsNotFound(err) {
+						return nil
+					}
+					return err
+				}
+				update := true
+				if mi.Spec.PurgePVCOnTenantDelete {
+					// No need to add if already present
+					for _, o := range p.OwnerReferences {
+						if o.UID == mi.OwnerRef()[0].UID {
+							update = false
+							break
+						}
+					}
+					if update {
+						p.OwnerReferences = append(p.OwnerReferences, mi.OwnerRef()...)
+					}
+				} else {
+					update = false
+					// If UID is set remove and update
+					for i, o := range mi.OwnerReferences {
+						// Loop through ALL to remove the UID reference to tenant.
+						if o.UID == mi.OwnerRef()[0].UID {
+							p.OwnerReferences = append(p.OwnerReferences[:i], p.OwnerReferences[i+1:]...)
+							update = true
+						}
+					}
+				}
+				if update {
+					_, err = c.kubeClientSet.CoreV1().PersistentVolumeClaims(mi.Namespace).Update(ctx, p, metav1.UpdateOptions{})
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Controller) applyFinalizer(ctx context.Context, mi *miniov1.Tenant) (*miniov1.Tenant, error) {
+	found := false
+	for _, f := range mi.Finalizers {
+		if f == miniov1.Finalizer {
+			found = true
+			break
+		}
+	}
+	var err error
+	if !found {
+		mi.ObjectMeta.Finalizers = append(mi.ObjectMeta.Finalizers, miniov1.Finalizer)
+		mi, err = c.minioClientSet.MinioV1().Tenants(mi.Namespace).Update(ctx, mi, metav1.UpdateOptions{})
+	}
+	return mi, err
+}
+
+func (c *Controller) processDelete(ctx context.Context, mi *miniov1.Tenant) error {
+	// Set the PVC purge behavior needed. This will ensure that k8s correctly deletes all PVCs.
+	err := c.processPurgePVCsOnDeleteFlag(ctx, mi)
+	if err != nil {
+		return err
+	}
+	// Remove finalizer
+	for i, f := range mi.ObjectMeta.Finalizers {
+		if f == miniov1.Finalizer {
+			mi.ObjectMeta.Finalizers = append(mi.Finalizers[:i], mi.ObjectMeta.Finalizers[i+1:]...)
+		}
+	}
+	_, err = c.minioClientSet.MinioV1().Tenants(mi.Namespace).Update(ctx, mi, metav1.UpdateOptions{})
+	return err
 }

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -447,6 +447,15 @@ func NewForMinIOZone(t *miniov1.Tenant, wsSecret *v1.Secret, zone *miniov1.Zone,
 
 	if zone.VolumeClaimTemplate != nil {
 		pvClaim := *zone.VolumeClaimTemplate
+		if t.Spec.PurgePVCOnTenantDelete {
+			pvClaim.OwnerReferences = []metav1.OwnerReference{
+				*metav1.NewControllerRef(t, schema.GroupVersionKind{
+					Group:   miniov1.SchemeGroupVersion.Group,
+					Version: miniov1.SchemeGroupVersion.Version,
+					Kind:    miniov1.MinIOCRDResourceKind,
+				}),
+			}
+		}
 		name := pvClaim.Name
 		for i := 0; i < int(zone.VolumesPerServer); i++ {
 			pvClaim.Name = name + strconv.Itoa(i)


### PR DESCRIPTION
If we want to make this optional, we can add a new field in the CRD.
```
> kubectl get pvc                                   
NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data0-minio-zone-0-0   Bound    pvc-cf812963-bed1-4487-a260-4cb8bec6921a   1Ti        RWO            standard       3m19s
data0-minio-zone-0-1   Bound    pvc-a2b768ef-af27-452a-b7b7-f91e1311ac1a   1Ti        RWO            standard       3m19s
data0-minio-zone-0-2   Bound    pvc-b5a6652e-99db-4e46-96c5-52e906ecb5f2   1Ti        RWO            standard       3m19s
data0-minio-zone-0-3   Bound    pvc-e7fdefae-4143-4cd3-b7f3-084efaf64edd   1Ti        RWO            standard       3m19s
data1-minio-zone-0-0   Bound    pvc-94c90bbc-861d-4e99-9f40-e1a408e3ff5d   1Ti        RWO            standard       3m19s
data1-minio-zone-0-1   Bound    pvc-09569871-2613-451e-aa01-9fa5299e13bf   1Ti        RWO            standard       3m19s
data1-minio-zone-0-2   Bound    pvc-ce6a1890-8c4a-4dcf-a39d-1eb81b67509b   1Ti        RWO            standard       3m19s
data1-minio-zone-0-3   Bound    pvc-78982b3e-4c19-451e-950c-6569d9a96e52   1Ti        RWO            standard       3m19s
data2-minio-zone-0-0   Bound    pvc-0697ab06-de65-4beb-886f-cbaac11bcab4   1Ti        RWO            standard       3m19s
data2-minio-zone-0-1   Bound    pvc-2db7d109-b678-4ba3-a093-92615e87381f   1Ti        RWO            standard       3m19s
data2-minio-zone-0-2   Bound    pvc-4ee2510a-0591-497a-86ae-4da6d42191f7   1Ti        RWO            standard       3m19s
data2-minio-zone-0-3   Bound    pvc-bb946db4-0bf9-4306-9ba5-3cae4508f93d   1Ti        RWO            standard       3m19s
data3-minio-zone-0-0   Bound    pvc-d3c13b68-258d-4061-b6cd-7a9a0f2ef167   1Ti        RWO            standard       3m19s
data3-minio-zone-0-1   Bound    pvc-c242cfdf-f16d-4173-8b5e-0658067433d8   1Ti        RWO            standard       3m19s
data3-minio-zone-0-2   Bound    pvc-c52551ed-2469-454a-abd3-df1766b16f1f   1Ti        RWO            standard       3m19s
data3-minio-zone-0-3   Bound    pvc-a88b0298-40dd-41db-97f6-63a17921de57   1Ti        RWO            standard       3m19s
 ~/go/src/github.com/minio/minio-operator  master >1 *8 !2 ?5 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 05:20:39 PM 
> kubectl delete -f examples/tenant-console.yaml          
secret "minio-creds-secret" deleted
secret "console-secret" deleted
tenant.minio.min.io "minio" deleted
 ~/go/src/github.com/minio/minio-operator  master >1 *8 !2 ?5 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- kind-kind kube  05:20:48 PM 
> kubectl get pvc                               
NAME                   STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
data0-minio-zone-0-0   Terminating   pvc-cf812963-bed1-4487-a260-4cb8bec6921a   1Ti        RWO            standard       3m31s
data0-minio-zone-0-1   Terminating   pvc-a2b768ef-af27-452a-b7b7-f91e1311ac1a   1Ti        RWO            standard       3m31s
data0-minio-zone-0-2   Terminating   pvc-b5a6652e-99db-4e46-96c5-52e906ecb5f2   1Ti        RWO            standard       3m31s
data0-minio-zone-0-3   Terminating   pvc-e7fdefae-4143-4cd3-b7f3-084efaf64edd   1Ti        RWO            standard       3m31s
data1-minio-zone-0-0   Terminating   pvc-94c90bbc-861d-4e99-9f40-e1a408e3ff5d   1Ti        RWO            standard       3m31s
data1-minio-zone-0-1   Terminating   pvc-09569871-2613-451e-aa01-9fa5299e13bf   1Ti        RWO            standard       3m31s
data1-minio-zone-0-2   Terminating   pvc-ce6a1890-8c4a-4dcf-a39d-1eb81b67509b   1Ti        RWO            standard       3m31s
data1-minio-zone-0-3   Terminating   pvc-78982b3e-4c19-451e-950c-6569d9a96e52   1Ti        RWO            standard       3m31s
data2-minio-zone-0-0   Terminating   pvc-0697ab06-de65-4beb-886f-cbaac11bcab4   1Ti        RWO            standard       3m31s
data2-minio-zone-0-1   Terminating   pvc-2db7d109-b678-4ba3-a093-92615e87381f   1Ti        RWO            standard       3m31s
data2-minio-zone-0-2   Terminating   pvc-4ee2510a-0591-497a-86ae-4da6d42191f7   1Ti        RWO            standard       3m31s
data2-minio-zone-0-3   Terminating   pvc-bb946db4-0bf9-4306-9ba5-3cae4508f93d   1Ti        RWO            standard       3m31s
data3-minio-zone-0-0   Terminating   pvc-d3c13b68-258d-4061-b6cd-7a9a0f2ef167   1Ti        RWO            standard       3m31s
data3-minio-zone-0-1   Terminating   pvc-c242cfdf-f16d-4173-8b5e-0658067433d8   1Ti        RWO            standard       3m31s
data3-minio-zone-0-2   Terminating   pvc-c52551ed-2469-454a-abd3-df1766b16f1f   1Ti        RWO            standard       3m31s
data3-minio-zone-0-3   Terminating   pvc-a88b0298-40dd-41db-97f6-63a17921de57   1Ti        RWO            standard       3m31s
```