### PR TITLE
Download Container from private Registries using the Tenant Image Pull Secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
 	github.com/google/go-containerregistry v0.1.2
 	github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08
 	github.com/minio/minio v0.0.0-20200723003940-b9be841fd222


### PR DESCRIPTION
This introduces the capability to download container images from private registries using the private credentials specified in the Tenant's Image Pull Secret