### PR TITLE
fallback to default keychain if image pull secret fails

### DIFF
--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -535,8 +535,8 @@ func (c *Controller) fetchArtifacts(tenant *miniov1.Tenant) (latest time.Time, e
 
 	keychain := authn.DefaultKeychain
 
-	// if tenant has imagePullSecret use that for pulling the image, but we if we fail to extract the secret or we
-	// can't find the needed registry in that secret we will continue with the default keychain. This is because the
+	// if the tenant has imagePullSecret use that for pulling the image, but if we fail to extract the secret or we
+	// can't find the expected registry in the secret we will continue with the default keychain. This is because the
 	// needed pull secret could be attached to the service-account.
 	if tenant.Spec.ImagePullSecret.Name != "" {
 		// Get the secret

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -540,7 +540,10 @@ func (c *Controller) fetchArtifacts(tenant *miniov1.Tenant) (latest time.Time, e
 	// needed pull secret could be attached to the service-account.
 	if tenant.Spec.ImagePullSecret.Name != "" {
 		// Get the secret
-		keyc, err := c.getKeychainForTenant(ref, tenant)
+		keychain, err = c.getKeychainForTenant(ref, tenant)
+		if err != nil  {
+		      klog.Info(err)
+		}
 		if err != nil {
 			klog.Info(err)
 		} else {

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -495,7 +495,7 @@ func (c *Controller) getKeychainForTenant(ref name.Reference, tenant *miniov1.Te
 	// Get the secret
 	secret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(context.Background(), tenant.Spec.ImagePullSecret.Name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.New("can't retrieve the tenant image pull secret")
+		return authn.DefaultKeychain, errors.New("can't retrieve the tenant image pull secret")
 	}
 	// if we can't find .dockerconfigjson, error out
 	if _, ok := secret.Data[".dockerconfigjson"]; !ok {

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -518,6 +518,7 @@ func (c *Controller) getKeychainForTenant(ctx context.Context, ref name.Referenc
 		RegistryToken: cfg.RegistryToken,
 	}, nil
 }
+
 // Attempts to fetch given image and then extracts and keeps relevant files
 // (minio, minio.sha256sum & minio.minisig) at a pre-defined location (/tmp/webhook/v1/update)
 func (c *Controller) fetchArtifacts(tenant *miniov1.Tenant) (latest time.Time, err error) {
@@ -539,7 +540,7 @@ func (c *Controller) fetchArtifacts(tenant *miniov1.Tenant) (latest time.Time, e
 	// needed pull secret could be attached to the service-account.
 	if tenant.Spec.ImagePullSecret.Name != "" {
 		// Get the secret
-		keychain, err = c.getKeychainForTenant(ref, tenant)
+		keychain, err = c.getKeychainForTenant(context.Background(), ref, tenant)
 		if err != nil {
 			klog.Info(err)
 		}

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -509,7 +509,10 @@ func (c *Controller) getKeychainForTenant(ref name.Reference, tenant *miniov1.Te
 	if _, ok := config.AuthConfigs[ref.Context().RegistryStr()]; !ok {
 		return nil, errors.New("can't find target registry in auth credentials in image pull secret")
 	}
-	cfg := config.AuthConfigs[ref.Context().RegistryStr()]
+	cfg, ok := config.AuthConfigs[ref.Context().RegistryStr()]
+	if !ok {
+	     return authn.DefaultKeychain, fmt.Errorf("unable to locate auth config registry context %s", ref.Context().RegistryStr())
+	}
 	return &minioKeychain{
 		Username:      cfg.Username,
 		Password:      cfg.Password,


### PR DESCRIPTION
This changes pulling from a private registry if the image pull secret attached to the Tenant doesn't include the desired credentials. Before we would fail the upgrade endlessly, but it's possible the right credentials are still present and aquired by the default keychain implementation