### PR TITLE
[Documentation] Fix typo in volume command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ kubectl minio tenant create --name tenant1 --secret tenant1-secret --servers 4 -
 You can add capacity to the tenant using `kubectl minio` plugin, like this
 
 ```
-kubectl minio tenant volumes add --name tenant1 --servers 8 --volumes 32 --capacity 32Ti --namespace tenant1-ns
+kubectl minio tenant volume add --name tenant1 --servers 8 --volumes 32 --capacity 32Ti --namespace tenant1-ns
 ```
 
 This will add 32 drives spread uniformly over 8 servers to the tenant `tenant1`, with additional capacity of 32Ti. Read more about [tenant expansion here](https://github.com/minio/operator/blob/master/docs/expansion.md).

--- a/docs/expansion.md
+++ b/docs/expansion.md
@@ -9,7 +9,7 @@ MinIO expansion is done in terms of MinIO zones, read more about the design in [
 You can add capacity to the tenant using `kubectl minio` plugin.
 
 ```
-kubectl minio tenant volumes add --name TENANT_NAME --servers SERVERS --volumes TOTAL_VOLUMES --capacity TOTAL_RAW_CAPACITY
+kubectl minio tenant volume add --name TENANT_NAME --servers SERVERS --volumes TOTAL_VOLUMES --capacity TOTAL_RAW_CAPACITY
 ```
 
 Remember to replace `TENANT_NAME` with tenant name where you want to add volumes, `SERVERS` with new servers to be added to the tenant, `TOTAL_VOLUMES` with total new volumes to be added to tenant and `TOTAL_RAW_CAPACITY` with total new raw capacity to be added to the tenant.

--- a/kubectl-minio/README.md
+++ b/kubectl-minio/README.md
@@ -51,11 +51,11 @@ Options:
 
 #### Add Tenant Zones
 
-Command: `kubectl minio tenant volumes add --name TENANT_NAME --servers SERVERS --volumes TOTAL_VOLUMES --capacity TOTAL_RAW_CAPACITY [options]`
+Command: `kubectl minio tenant volume add --name TENANT_NAME --servers SERVERS --volumes TOTAL_VOLUMES --capacity TOTAL_RAW_CAPACITY [options]`
 
 Add new volumes (and nodes) to existing MinIO Tenant.
 
-example: `kubectl minio tenant volumes add --name cluster1 --servers 4 --volumes 16 --capacity 16Ti`
+example: `kubectl minio tenant volume add --name cluster1 --servers 4 --volumes 16 --capacity 16Ti`
 
 Options:
 
@@ -66,11 +66,11 @@ Options:
 
 #### List Tenant Zones
 
-Command: `kubectl minio tenant volumes list --name TENANT_NAME [options]`
+Command: `kubectl minio tenant volume list --name TENANT_NAME [options]`
 
 List all existing MinIO Zones in the given MinIO Tenant.
 
-example: `kubectl minio tenant volumes list --name cluster1`
+example: `kubectl minio tenant volume list --name cluster1`
 
 Options:
 


### PR DESCRIPTION
Hey everyone,

I have updated the documentation for the minio command line "volume" command, as it mistakenly was "volumes".

Let me know your thoughts 👍 

Best Regards
Robert