### PR TITLE
Update goreleaser to create tar balls

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,9 +53,8 @@ builds:
 
 archives:
   -
-    format: binary
     files:
-      - "*.minisig"
+      - none*
 
 dockers:
   -


### PR DESCRIPTION
This is a pre-requisite to add kubectl-minio plugin to krew.
Ref: https://krew.sigs.k8s.io/docs/developer-guide/plugin-manifest/

This allows easy installation of the plugin via kubectl

Ref krew PR: https://github.com/kubernetes-sigs/krew-index/pull/815