### PR TITLE
Cascade Tenant Annotations and Labels to child resources

### DIFF
--- a/examples/tenant-encryption.yaml
+++ b/examples/tenant-encryption.yaml
@@ -94,21 +94,19 @@ apiVersion: minio.min.io/v1
 kind: Tenant
 metadata:
   name: minio
+  ## Optionally pass labels to be applied to the statefulset pods
+  labels:
+    app: minio
+  ## Annotations for MinIO Tenant Pods
+  annotations:
+    prometheus.io/path: /minio/prometheus/metrics
+    prometheus.io/port: "9000"
+    prometheus.io/scrape: "true"
 ## If a scheduler is specified here, Tenant pods will be dispatched by specified scheduler.
 ## If not specified, the Tenant pods will be dispatched by default scheduler.
 # scheduler:
 #  name: my-custom-scheduler
 spec:
-  ## Metadata for MinIO Tenant Pods
-  metadata:
-    labels:
-      app: minio
-    ## Annotations for MinIO Tenant Pods
-    annotations:
-      prometheus.io/path: /minio/prometheus/metrics
-      prometheus.io/port: "9000"
-      prometheus.io/scrape: "true"
-
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2020-09-10T22-02-45Z
   imagePullPolicy: IfNotPresent
@@ -218,9 +216,6 @@ spec:
     replicas: 2
     consoleSecret:
       name: console-secret
-    metadata:
-      labels:
-        app: console
 
   ## Define configuration for KES (stateless and distributed key-management system)
   ## Refer https://github.com/minio/kes

--- a/examples/tenant-pod-security-policy.yaml
+++ b/examples/tenant-pod-security-policy.yaml
@@ -63,20 +63,18 @@ apiVersion: minio.min.io/v1
 kind: Tenant
 metadata:
   name: minio
+  ## Optionally pass labels to be applied to the statefulset pods
+  labels:
+    app: minio
+  annotations:
+    prometheus.io/path: /minio/prometheus/metrics
+    prometheus.io/port: "9000"
+    prometheus.io/scrape: "true"
 ## If specified, Tenant pods will be dispatched by specified scheduler.
 ## If not specified, the pod will be dispatched by default scheduler.
 # scheduler:
 #  name: my-custom-scheduler
 spec:
-  ## Add metadata to the all pods created by the StatefulSet
-  metadata:
-    ## Optionally pass labels to be applied to the statefulset pods
-    labels:
-      app: minio
-    annotations:
-      prometheus.io/path: /minio/prometheus/metrics
-      prometheus.io/port: "9000"
-      prometheus.io/scrape: "true"
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2020-09-10T22-02-45Z
   ## Service account to be used for all the MinIO Pods

--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -33,21 +33,19 @@ apiVersion: minio.min.io/v1
 kind: Tenant
 metadata:
   name: minio
+  ## Optionally pass labels to be applied to the statefulset pods
+  labels:
+    app: minio
+  ## Annotations for MinIO Tenant Pods
+  annotations:
+    prometheus.io/path: /minio/prometheus/metrics
+    prometheus.io/port: "9000"
+    prometheus.io/scrape: "true"
 ## If a scheduler is specified here, Tenant pods will be dispatched by specified scheduler.
 ## If not specified, the Tenant pods will be dispatched by default scheduler.
 # scheduler:
 #  name: my-custom-scheduler
 spec:
-  ## Metadata for MinIO Tenant Pods
-  metadata:
-    labels:
-      app: minio
-    ## Annotations for MinIO Tenant Pods
-    annotations:
-      prometheus.io/path: /minio/prometheus/metrics
-      prometheus.io/port: "9000"
-      prometheus.io/scrape: "true"
-
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2020-09-10T22-02-45Z
   imagePullPolicy: IfNotPresent

--- a/operator-kustomize/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/crds/minio.min.io_tenants.yaml
@@ -203,8 +203,6 @@ spec:
                     This is applied to MinIO Console pods only. Refer Kubernetes documentation
                     for details https://kubernetes.io/docs/concepts/containers/images#updating-images
                   type: string
-                metadata:
-                  type: object
                 replicas:
                   description: Replicas defines number of pods for KES StatefulSet.
                   format: int32
@@ -463,10 +461,6 @@ spec:
               - initialDelaySeconds
               - periodSeconds
               - timeoutSeconds
-              type: object
-            metadata:
-              description: Metadata defines the object metadata passed to each pod
-                that is a part of this Tenant
               type: object
             mountPath:
               description: Mount path for MinIO volume (PV). Defaults to /export

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -100,12 +100,6 @@ func (t *Tenant) HasCredsSecret() bool {
 	return t.Spec.CredsSecret != nil
 }
 
-// HasMetadata returns true if the user has provided a pod metadata
-// for a Tenant else false
-func (t *Tenant) HasMetadata() bool {
-	return t.Spec.Metadata != nil
-}
-
 // HasCertConfig returns true if the user has provided a certificate
 // config
 func (t *Tenant) HasCertConfig() bool {
@@ -477,12 +471,6 @@ func (t *Tenant) HasConsoleEnabled() bool {
 // for a Tenant else false
 func (t *Tenant) HasConsoleSecret() bool {
 	return t.Spec.Console != nil && t.Spec.Console.ConsoleSecret != nil
-}
-
-// HasConsoleMetadata returns true if the user has provided a console metadata
-// for a Tenant else false
-func (t *Tenant) HasConsoleMetadata() bool {
-	return t.Spec.Console != nil && t.Spec.Console.Metadata != nil
 }
 
 // HasKESMetadata returns true if the user has provided KES metadata

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -68,8 +68,6 @@ type TenantSpec struct {
 	// Pod Management Policy for pod created by StatefulSet
 	// +optional
 	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
-	// Metadata defines the object metadata passed to each pod that is a part of this Tenant
-	Metadata *metav1.ObjectMeta `json:"metadata,omitempty"`
 	// If provided, use this secret as the credentials for Tenant resource
 	// Otherwise MinIO server creates dynamic credentials printed on MinIO server startup banner
 	// +optional
@@ -193,7 +191,6 @@ type ConsoleConfiguration struct {
 	// This secret provides all environment variables for KES
 	// This is a mandatory field
 	ConsoleSecret *corev1.LocalObjectReference `json:"consoleSecret"`
-	Metadata      *metav1.ObjectMeta           `json:"metadata,omitempty"`
 	// If provided, use these environment variables for Console resource
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`

--- a/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
@@ -60,11 +60,6 @@ func (in *ConsoleConfiguration) DeepCopyInto(out *ConsoleConfiguration) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
-	if in.Metadata != nil {
-		in, out := &in.Metadata, &out.Metadata
-		*out = new(metav1.ObjectMeta)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))
@@ -248,11 +243,6 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 		}
 	}
 	out.ImagePullSecret = in.ImagePullSecret
-	if in.Metadata != nil {
-		in, out := &in.Metadata, &out.Metadata
-		*out = new(metav1.ObjectMeta)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.CredsSecret != nil {
 		in, out := &in.CredsSecret, &out.CredsSecret
 		*out = new(corev1.LocalObjectReference)

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -29,7 +29,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-
+var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	miniov1.AddToScheme,
 }

--- a/pkg/client/listers/minio.min.io/v1/tenant.go
+++ b/pkg/client/listers/minio.min.io/v1/tenant.go
@@ -26,10 +26,8 @@ import (
 )
 
 // TenantLister helps list Tenants.
-// All objects returned here must be treated as read-only.
 type TenantLister interface {
 	// List lists all Tenants in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Tenant, err error)
 	// Tenants returns an object that can list and get Tenants.
 	Tenants(namespace string) TenantNamespaceLister
@@ -60,13 +58,10 @@ func (s *tenantLister) Tenants(namespace string) TenantNamespaceLister {
 }
 
 // TenantNamespaceLister helps list and get Tenants.
-// All objects returned here must be treated as read-only.
 type TenantNamespaceLister interface {
 	// List lists all Tenants in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Tenant, err error)
 	// Get retrieves the Tenant from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Tenant, error)
 	TenantNamespaceListerExpansion
 }

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -71,6 +71,8 @@ func consoleMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
 	for k, v := range t.ConsolePodLabels() {
 		meta.Labels[k] = v
 	}
+	// Mark which tenant is being used
+	meta.Labels[miniov1.TenantLabel] = t.Name
 	return meta
 }
 

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -61,9 +61,10 @@ func consoleSecretEnvVars(t *miniov1.Tenant) []corev1.EnvFromSource {
 
 func consoleMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{}
-	if t.HasConsoleMetadata() {
-		meta = *t.Spec.Console.Metadata
-	}
+	// Copy Labels and Annotations from Tenant
+	meta.Labels = t.ObjectMeta.Labels
+	meta.Annotations = t.ObjectMeta.Annotations
+
 	if meta.Labels == nil {
 		meta.Labels = make(map[string]string)
 	}

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -135,9 +135,10 @@ func minioEnvironmentVars(t *miniov1.Tenant, wsSecret *v1.Secret, hostsTemplate 
 // metadata.
 func minioPodMetadata(t *miniov1.Tenant, zone *miniov1.Zone, opVersion string) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{}
-	if t.HasMetadata() {
-		meta = *t.Spec.Metadata
-	}
+	// Copy Labels and Annotations from Tenant
+	meta.Labels = t.ObjectMeta.Labels
+	meta.Annotations = t.ObjectMeta.Annotations
+
 	if meta.Labels == nil {
 		meta.Labels = make(map[string]string)
 	}
@@ -432,10 +433,8 @@ func NewForMinIOZone(t *miniov1.Tenant, wsSecret *v1.Secret, zone *miniov1.Zone,
 		},
 	}
 	// Copy labels and annotations from the Tenant.Spec.Metadata
-	if t.Spec.Metadata != nil {
-		ssMeta.Labels = t.Spec.Metadata.Labels
-		ssMeta.Annotations = t.Spec.Metadata.Annotations
-	}
+	ssMeta.Labels = t.ObjectMeta.Labels
+	ssMeta.Annotations = t.ObjectMeta.Annotations
 
 	if ssMeta.Labels == nil {
 		ssMeta.Labels = make(map[string]string)

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -133,7 +133,7 @@ func minioEnvironmentVars(t *miniov1.Tenant, wsSecret *v1.Secret, hostsTemplate 
 // Returns the MinIO pods metadata set in configuration.
 // If a user specifies metadata in the spec we return that
 // metadata.
-func minioMetadata(t *miniov1.Tenant, zone *miniov1.Zone, opVersion string) metav1.ObjectMeta {
+func minioPodMetadata(t *miniov1.Tenant, zone *miniov1.Zone, opVersion string) metav1.ObjectMeta {
 	meta := metav1.ObjectMeta{}
 	if t.HasMetadata() {
 		meta = *t.Spec.Metadata
@@ -420,19 +420,35 @@ func NewForMinIOZone(t *miniov1.Tenant, wsSecret *v1.Secret, zone *miniov1.Zone,
 		})
 	}
 
+	ssMeta := metav1.ObjectMeta{
+		Namespace: t.Namespace,
+		Name:      t.ZoneStatefulsetName(zone),
+		OwnerReferences: []metav1.OwnerReference{
+			*metav1.NewControllerRef(t, schema.GroupVersionKind{
+				Group:   miniov1.SchemeGroupVersion.Group,
+				Version: miniov1.SchemeGroupVersion.Version,
+				Kind:    miniov1.MinIOCRDResourceKind,
+			}),
+		},
+	}
+	// Copy labels and annotations from the Tenant.Spec.Metadata
+	if t.Spec.Metadata != nil {
+		ssMeta.Labels = t.Spec.Metadata.Labels
+		ssMeta.Annotations = t.Spec.Metadata.Annotations
+	}
+
+	if ssMeta.Labels == nil {
+		ssMeta.Labels = make(map[string]string)
+	}
+
+	// Add information labels, such as which zone we are building this pod about
+	ssMeta.Labels[miniov1.TenantLabel] = t.Name
+	ssMeta.Labels[miniov1.ZoneLabel] = zone.Name
+	ssMeta.Labels[miniov1.OperatorLabel] = operatorVersion
+
 	containers := []corev1.Container{zoneMinioServerContainer(t, wsSecret, zone, hostsTemplate, operatorVersion)}
 	ss := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: t.Namespace,
-			Name:      t.ZoneStatefulsetName(zone),
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(t, schema.GroupVersionKind{
-					Group:   miniov1.SchemeGroupVersion.Group,
-					Version: miniov1.SchemeGroupVersion.Version,
-					Kind:    miniov1.MinIOCRDResourceKind,
-				}),
-			},
-		},
+		ObjectMeta: ssMeta,
 		Spec: appsv1.StatefulSetSpec{
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: miniov1.DefaultUpdateStrategy,
@@ -442,7 +458,7 @@ func NewForMinIOZone(t *miniov1.Tenant, wsSecret *v1.Secret, zone *miniov1.Zone,
 			ServiceName:         serviceName,
 			Replicas:            &replicas,
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: minioMetadata(t, zone, operatorVersion),
+				ObjectMeta: minioPodMetadata(t, zone, operatorVersion),
 				Spec: corev1.PodSpec{
 					Containers:         containers,
 					Volumes:            podVolumes,


### PR DESCRIPTION
This PR copies the `Tenant.Metadata`'s labels and annotations into the statefulset, pods and pvcs.

The result would be:
T -> SS -> Pod -> PVC
T -> Console