### PR TITLE
fixes loadbalancer port for healthcheck

### DIFF
--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -494,7 +494,15 @@ func (t *Tenant) UpdateURL(lrTime time.Time, overrideURL string) (string, error)
 
 // MinIOServerHostAddress similar to MinIOServerHost but returns host with port
 func (t *Tenant) MinIOServerHostAddress() string {
-	return net.JoinHostPort(t.MinIOServerHost(), strconv.Itoa(MinIOPort))
+	var port int
+
+	if t.TLS() {
+		port = MinIOTLSPortLoadBalancerSVC
+	} else {
+		port = MinIOPortLoadBalancerSVC
+	}
+
+	return net.JoinHostPort(t.MinIOServerHost(), strconv.Itoa(port))
 }
 
 // MinIOServerEndpoint similar to MinIOServerHostAddress but a URL with current scheme


### PR DESCRIPTION
It seems like the TLS Change a couple of commits ago broke the minio health check function and with that the status update of the Tenant CRD. This prevented the console from ever being deployed. I've changed the health function to use the LB ports depending on the TLS setting.