### PR TITLE
Make service account for KES and Console configurable

### DIFF
--- a/operator-kustomize/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/crds/minio.min.io_tenants.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: (unknown)
   creationTimestamp: null
   name: tenants.minio.min.io
 spec:
@@ -17,1241 +17,198 @@ spec:
     - tenant
     singular: tenant
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Tenant is a specification for a MinIO resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        scheduler:
-          description: TenantScheduler is the spec for a Tenant scheduler
-          properties:
-            name:
-              description: SchedulerName defines the name of scheduler to be used
-                to schedule Tenant pods
-              type: string
-          required:
-          - name
-          type: object
-        spec:
-          description: TenantSpec is the spec for a Tenant resource
-          properties:
-            certConfig:
-              description: CertConfig allows users to set entries like CommonName,
-                Organization, etc for the certificate
-              properties:
-                commonName:
-                  type: string
-                dnsNames:
-                  items:
-                    type: string
-                  type: array
-                organizationName:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            console:
-              description: ConsoleConfiguration is for setting up minio/console for
-                graphical user interface
-              properties:
-                consoleSecret:
-                  description: This secret provides all environment variables for
-                    KES This is a mandatory field
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                env:
-                  description: If provided, use these environment variables for Console
-                    resource
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, metadata.labels, metadata.annotations,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
-                                type: string
-                            required:
-                            - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                            - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-                externalCertSecret:
-                  description: ExternalCertSecret allows a user to specify custom
-                    CA certificate, and private key. This is used for enabling TLS
-                    support on Console Pods.
-                  properties:
-                    name:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                image:
-                  description: Image defines the Tenant Console Docker image.
-                  type: string
-                imagePullPolicy:
-                  description: Image pull policy. One of Always, Never, IfNotPresent.
-                    This is applied to MinIO Console pods only. Refer Kubernetes documentation
-                    for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-                  type: string
-                replicas:
-                  description: Replicas defines number of pods for KES StatefulSet.
-                  format: int32
-                  type: integer
-                resources:
-                  description: If provided, use these requests and limit for cpu/memory
-                    resource allocation
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-              required:
-              - consoleSecret
-              type: object
-            credsSecret:
-              description: If provided, use this secret as the credentials for Tenant
-                resource Otherwise MinIO server creates dynamic credentials printed
-                on MinIO server startup banner
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            env:
-              description: If provided, use these environment variables for Tenant
-                resource
-              items:
-                description: EnvVar represents an environment variable present in
-                  a Container.
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Tenant is a specification for a MinIO resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          scheduler:
+            description: TenantScheduler is the spec for a Tenant scheduler
+            properties:
+              name:
+                description: SchedulerName defines the name of scheduler to be used
+                  to schedule Tenant pods
+                type: string
+            required:
+            - name
+            type: object
+          spec:
+            description: TenantSpec is the spec for a Tenant resource
+            properties:
+              certConfig:
+                description: CertConfig allows users to set entries like CommonName,
+                  Organization, etc for the certificate
                 properties:
-                  name:
-                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                  commonName:
                     type: string
-                  value:
-                    description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
-                      and any service environment variables. If a variable cannot
-                      be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
-                    type: string
-                  valueFrom:
-                    description: Source for the environment variable's value. Cannot
-                      be used if value is not empty.
-                    properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
-                        properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name,
-                          metadata.namespace, metadata.labels, metadata.annotations,
-                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP,
-                          status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written
-                              in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified
-                              API version.
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources
-                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
-                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                          are currently supported.'
-                        properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional
-                              for env vars'
-                            type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Specifies the output format of the exposed
-                              resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          resource:
-                            description: 'Required: resource to select'
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                    type: object
-                required:
-                - name
+                  dnsNames:
+                    items:
+                      type: string
+                    type: array
+                  organizationName:
+                    items:
+                      type: string
+                    type: array
                 type: object
-              type: array
-            externalCertSecret:
-              description: ExternalCertSecret allows a user to specify custom CA certificate,
-                and private key. This is used for enabling TLS support on MinIO Pods.
-              properties:
-                name:
-                  type: string
-                type:
-                  type: string
-              required:
-              - name
-              type: object
-            externalClientCertSecret:
-              description: ExternalClientCertSecret allows a user to specify custom
-                CA client certificate, and private key. This is used for adding client
-                certificates on MinIO Pods --> used for KES authentication.
-              properties:
-                name:
-                  type: string
-                type:
-                  type: string
-              required:
-              - name
-              type: object
-            image:
-              description: Image defines the Tenant Docker image.
-              type: string
-            imagePullPolicy:
-              description: Image pull policy. One of Always, Never, IfNotPresent.
-                This is applied to MinIO pods only. Refer Kubernetes documentation
-                for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-              type: string
-            imagePullSecret:
-              description: ImagePullSecret defines the secret to be used for pull
-                image from a private Docker image.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            kes:
-              description: KES is for setting up minio/kes as MinIO KMS
-              properties:
-                clientCertSecret:
-                  description: ClientCertSecret allows a user to specify a custom
-                    root certificate, client certificate and client private key. This
-                    is used for adding client certificates on KES --> used for KES
-                    authentication against Vault or other KMS that supports mTLS.
-                  properties:
-                    name:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                externalCertSecret:
-                  description: ExternalCertSecret allows a user to specify custom
-                    CA certificate, and private key for group replication SSL.
-                  properties:
-                    name:
-                      type: string
-                    type:
-                      type: string
-                  required:
-                  - name
-                  type: object
-                image:
-                  description: Image defines the Tenant KES Docker image.
-                  type: string
-                imagePullPolicy:
-                  description: Image pull policy. One of Always, Never, IfNotPresent.
-                    This is applied to KES pods only. Refer Kubernetes documentation
-                    for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-                  type: string
-                kesSecret:
-                  description: This kesSecret serves as the configuration for KES
-                    This is a mandatory field
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                metadata:
-                  type: object
-                replicas:
-                  description: Replicas defines number of pods for KES StatefulSet.
-                  format: int32
-                  type: integer
-              required:
-              - kesSecret
-              type: object
-            liveness:
-              description: Liveness Probe for container liveness. Container will be
-                restarted if the probe fails.
-              properties:
-                initialDelaySeconds:
-                  format: int32
-                  type: integer
-                periodSeconds:
-                  format: int32
-                  type: integer
-                timeoutSeconds:
-                  format: int32
-                  type: integer
-              required:
-              - initialDelaySeconds
-              - periodSeconds
-              - timeoutSeconds
-              type: object
-            mountPath:
-              description: Mount path for MinIO volume (PV). Defaults to /export
-              type: string
-            podManagementPolicy:
-              description: Pod Management Policy for pod created by StatefulSet
-              type: string
-            priorityClassName:
-              description: PriorityClassName indicates the Pod priority and hence
-                importance of a Pod relative to other Pods. This is applied to MinIO
-                pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-              type: string
-            purgePVCOnTenantDelete:
-              description: Delete PVCs on tenant deletion. Defaults to (false) preserving
-                PVCs if tenant is deleted. PVCs will need cleanup post tenant deletion
-                if not set to true. If set to true ALL PVs for the tenant will be
-                deleted.
-              type: boolean
-            requestAutoCert:
-              description: 'RequestAutoCert allows user to enable Kubernetes based
-                TLS cert generation and signing as explained here: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/'
-              type: boolean
-            securityContext:
-              description: Security Context allows user to set entries like runAsUser,
-                privilege escalation etc.
-              properties:
-                fsGroup:
-                  description: "A special supplemental group that applies to all containers
-                    in a pod. Some volume types allow the Kubelet to change the ownership
-                    of that volume to be owned by the pod: \n 1. The owning GID will
-                    be the FSGroup 2. The setgid bit is set (new files created in
-                    the volume will be owned by FSGroup) 3. The permission bits are
-                    OR'd with rw-rw---- \n If unset, the Kubelet will not modify the
-                    ownership and permissions of any volume."
-                  format: int64
-                  type: integer
-                fsGroupChangePolicy:
-                  description: 'fsGroupChangePolicy defines behavior of changing ownership
-                    and permission of the volume before being exposed inside Pod.
-                    This field will only apply to volume types which support fsGroup
-                    based ownership(and permissions). It will have no effect on ephemeral
-                    volume types such as: secret, configmaps and emptydir. Valid values
-                    are "OnRootMismatch" and "Always". If not specified defaults to
-                    "Always".'
-                  type: string
-                runAsGroup:
-                  description: The GID to run the entrypoint of the container process.
-                    Uses runtime default if unset. May also be set in SecurityContext.  If
-                    set in both SecurityContext and PodSecurityContext, the value
-                    specified in SecurityContext takes precedence for that container.
-                  format: int64
-                  type: integer
-                runAsNonRoot:
-                  description: Indicates that the container must run as a non-root
-                    user. If true, the Kubelet will validate the image at runtime
-                    to ensure that it does not run as UID 0 (root) and fail to start
-                    the container if it does. If unset or false, no such validation
-                    will be performed. May also be set in SecurityContext.  If set
-                    in both SecurityContext and PodSecurityContext, the value specified
-                    in SecurityContext takes precedence.
-                  type: boolean
-                runAsUser:
-                  description: The UID to run the entrypoint of the container process.
-                    Defaults to user specified in image metadata if unspecified. May
-                    also be set in SecurityContext.  If set in both SecurityContext
-                    and PodSecurityContext, the value specified in SecurityContext
-                    takes precedence for that container.
-                  format: int64
-                  type: integer
-                seLinuxOptions:
-                  description: The SELinux context to be applied to all containers.
-                    If unspecified, the container runtime will allocate a random SELinux
-                    context for each container.  May also be set in SecurityContext.  If
-                    set in both SecurityContext and PodSecurityContext, the value
-                    specified in SecurityContext takes precedence for that container.
-                  properties:
-                    level:
-                      description: Level is SELinux level label that applies to the
-                        container.
-                      type: string
-                    role:
-                      description: Role is a SELinux role label that applies to the
-                        container.
-                      type: string
-                    type:
-                      description: Type is a SELinux type label that applies to the
-                        container.
-                      type: string
-                    user:
-                      description: User is a SELinux user label that applies to the
-                        container.
-                      type: string
-                  type: object
-                supplementalGroups:
-                  description: A list of groups applied to the first process run in
-                    each container, in addition to the container's primary GID.  If
-                    unspecified, no groups will be added to any container.
-                  items:
-                    format: int64
-                    type: integer
-                  type: array
-                sysctls:
-                  description: Sysctls hold a list of namespaced sysctls used for
-                    the pod. Pods with unsupported sysctls (by the container runtime)
-                    might fail to launch.
-                  items:
-                    description: Sysctl defines a kernel parameter to be set
+              console:
+                description: ConsoleConfiguration is for setting up minio/console
+                  for graphical user interface
+                properties:
+                  consoleSecret:
+                    description: This secret provides all environment variables for
+                      KES This is a mandatory field
                     properties:
                       name:
-                        description: Name of a property to set
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      value:
-                        description: Value of a property to set
+                    type: object
+                  env:
+                    description: If provided, use these environment variables for
+                      Console resource
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, metadata.labels, metadata.annotations,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  externalCertSecret:
+                    description: ExternalCertSecret allows a user to specify custom
+                      CA certificate, and private key. This is used for enabling TLS
+                      support on Console Pods.
+                    properties:
+                      name:
+                        type: string
+                      type:
                         type: string
                     required:
                     - name
-                    - value
                     type: object
-                  type: array
-                windowsOptions:
-                  description: The Windows specific settings applied to all containers.
-                    If unspecified, the options within a container's SecurityContext
-                    will be used. If set in both SecurityContext and PodSecurityContext,
-                    the value specified in SecurityContext takes precedence.
-                  properties:
-                    gmsaCredentialSpec:
-                      description: GMSACredentialSpec is where the GMSA admission
-                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                        inlines the contents of the GMSA credential spec named by
-                        the GMSACredentialSpecName field.
-                      type: string
-                    gmsaCredentialSpecName:
-                      description: GMSACredentialSpecName is the name of the GMSA
-                        credential spec to use.
-                      type: string
-                    runAsUserName:
-                      description: The UserName in Windows to run the entrypoint of
-                        the container process. Defaults to the user specified in image
-                        metadata if unspecified. May also be set in PodSecurityContext.
-                        If set in both SecurityContext and PodSecurityContext, the
-                        value specified in SecurityContext takes precedence.
-                      type: string
-                  type: object
-              type: object
-            serviceAccountName:
-              description: ServiceAccountName is the name of the ServiceAccount to
-                use to run pods of all MinIO Pods created as a part of this Tenant.
-              type: string
-            serviceName:
-              description: ServiceName defines name of the Service that will be created
-                for this instance, if none is specified, it will default to the instance
-                name
-              type: string
-            subPath:
-              description: Subpath inside mount path. This is the directory where
-                MinIO stores data. Default to "" (empty)
-              type: string
-            zones:
-              description: Definition for Cluster in given MinIO cluster
-              items:
-                description: Zone defines the spec for a MinIO Zone
-                properties:
-                  affinity:
-                    description: If specified, affinity will define the pod's scheduling
-                      constraints
-                    properties:
-                      nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node matches the corresponding matchExpressions;
-                              the node(s) with the highest sum are the most preferred.
-                            items:
-                              description: An empty preferred scheduling term matches
-                                all objects with implicit weight 0 (i.e. it's a no-op).
-                                A null preferred scheduling term matches no objects
-                                (i.e. is also a no-op).
-                              properties:
-                                preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
-                                  properties:
-                                    matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from
-                              its node.
-                            properties:
-                              nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
-                                items:
-                                  description: A null or empty node selector term
-                                    matches no objects. The requirements of them are
-                                    ANDed. The TopologySelectorTerm type implements
-                                    a subset of the NodeSelectorTerm.
-                                  properties:
-                                    matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
-                            items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
-                              properties:
-                                podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
-                                  properties:
-                                    labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to a pod label update),
-                              the system may or may not try to eventually evict the
-                              pod from its node. When there are multiple elements,
-                              the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
-                            items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the anti-affinity expressions
-                              specified by this field, but it may choose a node that
-                              violates one or more of the expressions. The node that
-                              is most preferred is the one with the greatest sum of
-                              weights, i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              anti-affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
-                            items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
-                              properties:
-                                podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
-                                  properties:
-                                    labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified
-                              by this field are not met at scheduling time, the pod
-                              will not be scheduled onto the node. If the anti-affinity
-                              requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod
-                              label update), the system may or may not try to eventually
-                              evict the pod from its node. When there are multiple
-                              elements, the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
-                            items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  name:
-                    description: Name of the zone
+                  image:
+                    description: Image defines the Tenant Console Docker image.
                     type: string
-                  nodeSelector:
-                    additionalProperties:
-                      type: string
-                    description: 'NodeSelector is a selector which must be true for
-                      the pod to fit on a node. Selector which must match a node''s
-                      labels for the pod to be scheduled on that node. More info:
-                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                    type: object
+                  imagePullPolicy:
+                    description: Image pull policy. One of Always, Never, IfNotPresent.
+                      This is applied to MinIO Console pods only. Refer Kubernetes
+                      documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  replicas:
+                    description: Replicas defines number of pods for KES StatefulSet.
+                    format: int32
+                    type: integer
                   resources:
                     description: If provided, use these requests and limit for cpu/memory
                       resource allocation
@@ -1279,300 +236,1371 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  servers:
-                    description: Number of Servers in the zone
-                    format: int32
-                    type: integer
-                  tolerations:
-                    description: Tolerations allows users to set entries like effect,
-                      key, operator, value.
-                    items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount
+                      to use to run pods of all Console Pods created as a part of
+                      this Tenant.
+                    type: string
+                required:
+                - consoleSecret
+                type: object
+              credsSecret:
+                description: If provided, use this secret as the credentials for Tenant
+                  resource Otherwise MinIO server creates dynamic credentials printed
+                  on MinIO server startup banner
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              env:
+                description: If provided, use these environment variables for Tenant
+                  resource
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
-                        effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
-                          type: string
-                        key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
-                          type: string
-                        operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
-                          type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
-                          format: int64
-                          type: integer
-                        value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
-                          type: string
-                      type: object
-                    type: array
-                  volumeClaimTemplate:
-                    description: VolumeClaimTemplate allows a user to specify how
-                      volumes inside a Tenant
-                    properties:
-                      apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                        type: string
-                      kind:
-                        description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                        type: string
-                      metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        type: object
-                      spec:
-                        description: 'Spec defines the desired characteristics of
-                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
                               type: string
-                            type: array
-                          dataSource:
-                            description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                              - Beta) * An existing PVC (PersistentVolumeClaim) *
-                              An existing custom resource/object that implements data
-                              population (Alpha) In order to use VolumeSnapshot object
-                              types, the appropriate feature gate must be enabled
-                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
-                              the provisioner or an external controller can support
-                              the specified data source, it will create a new volume
-                              based on the contents of the specified data source.
-                              If the specified data source is not supported, the volume
-                              will not be created and the failure will be reported
-                              as an event. In the future, we plan to support more
-                              data source types and the behavior of the provisioner
-                              may change.'
-                            properties:
-                              apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified,
-                                  the specified Kind must be in the core API group.
-                                  For any other third-party types, APIGroup is required.
-                                type: string
-                              kind:
-                                description: Kind is the type of resource being referenced
-                                type: string
-                              name:
-                                description: Name is the name of resource being referenced
-                                type: string
-                            required:
-                            - kind
-                            - name
-                            type: object
-                          resources:
-                            description: 'Resources represents the minimum resources
-                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                            type: object
-                          selector:
-                            description: A label query over volumes to consider for
-                              binding.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          storageClassName:
-                            description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                            type: string
-                          volumeMode:
-                            description: volumeMode defines what type of volume is
-                              required by the claim. Value of Filesystem is implied
-                              when not included in claim spec.
-                            type: string
-                          volumeName:
-                            description: VolumeName is the binding reference to the
-                              PersistentVolume backing this claim.
-                            type: string
-                        type: object
-                      status:
-                        description: 'Status represents the current information/status
-                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          accessModes:
-                            description: 'AccessModes contains the actual access modes
-                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                            items:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
-                            type: array
-                          capacity:
-                            additionalProperties:
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, metadata.labels, metadata.annotations,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: Represents the actual resources of the underlying
-                              volume.
-                            type: object
-                          conditions:
-                            description: Current Condition of persistent volume claim.
-                              If underlying persistent volume is being resized then
-                              the Condition will be set to 'ResizeStarted'.
-                            items:
-                              description: PersistentVolumeClaimCondition contails
-                                details about state of pvc
-                              properties:
-                                lastProbeTime:
-                                  description: Last time we probed the condition.
-                                  format: date-time
-                                  type: string
-                                lastTransitionTime:
-                                  description: Last time the condition transitioned
-                                    from one status to another.
-                                  format: date-time
-                                  type: string
-                                message:
-                                  description: Human-readable message indicating details
-                                    about last transition.
-                                  type: string
-                                reason:
-                                  description: Unique, this should be a short, machine
-                                    understandable string that gives the reason for
-                                    condition's last transition. If it reports "ResizeStarted"
-                                    that means the underlying persistent volume is
-                                    being resized.
-                                  type: string
-                                status:
-                                  type: string
-                                type:
-                                  description: PersistentVolumeClaimConditionType
-                                    is a valid value of PersistentVolumeClaimCondition.Type
-                                  type: string
-                              required:
-                              - status
-                              - type
-                              type: object
-                            type: array
-                          phase:
-                            description: Phase represents the current phase of PersistentVolumeClaim.
-                            type: string
-                        type: object
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              externalCertSecret:
+                description: ExternalCertSecret allows a user to specify custom CA
+                  certificate, and private key. This is used for enabling TLS support
+                  on MinIO Pods.
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - name
+                type: object
+              externalClientCertSecret:
+                description: ExternalClientCertSecret allows a user to specify custom
+                  CA client certificate, and private key. This is used for adding
+                  client certificates on MinIO Pods --> used for KES authentication.
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - name
+                type: object
+              image:
+                description: Image defines the Tenant Docker image.
+                type: string
+              imagePullPolicy:
+                description: Image pull policy. One of Always, Never, IfNotPresent.
+                  This is applied to MinIO pods only. Refer Kubernetes documentation
+                  for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+                type: string
+              imagePullSecret:
+                description: ImagePullSecret defines the secret to be used for pull
+                  image from a private Docker image.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              kes:
+                description: KES is for setting up minio/kes as MinIO KMS
+                properties:
+                  clientCertSecret:
+                    description: ClientCertSecret allows a user to specify a custom
+                      root certificate, client certificate and client private key.
+                      This is used for adding client certificates on KES --> used
+                      for KES authentication against Vault or other KMS that supports
+                      mTLS.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
                     type: object
-                  volumesPerServer:
-                    description: Number of persistent volumes that will be attached
-                      per server
+                  externalCertSecret:
+                    description: ExternalCertSecret allows a user to specify custom
+                      CA certificate, and private key for group replication SSL.
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  image:
+                    description: Image defines the Tenant KES Docker image.
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy. One of Always, Never, IfNotPresent.
+                      This is applied to KES pods only. Refer Kubernetes documentation
+                      for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+                    type: string
+                  kesSecret:
+                    description: This kesSecret serves as the configuration for KES
+                      This is a mandatory field
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  metadata:
+                    type: object
+                  replicas:
+                    description: Replicas defines number of pods for KES StatefulSet.
+                    format: int32
+                    type: integer
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount
+                      to use to run pods of all KES Pods created as a part of this
+                      Tenant.
+                    type: string
+                required:
+                - kesSecret
+                type: object
+              liveness:
+                description: Liveness Probe for container liveness. Container will
+                  be restarted if the probe fails.
+                properties:
+                  initialDelaySeconds:
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    format: int32
+                    type: integer
+                  timeoutSeconds:
                     format: int32
                     type: integer
                 required:
-                - servers
-                - volumeClaimTemplate
-                - volumesPerServer
+                - initialDelaySeconds
+                - periodSeconds
+                - timeoutSeconds
                 type: object
-              type: array
-          required:
-          - zones
-          type: object
-        status:
-          description: Status provides details of the state of the Tenant
-          properties:
-            availableReplicas:
-              format: int32
-              type: integer
-            currentState:
-              type: string
-          required:
-          - availableReplicas
-          - currentState
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
+              mountPath:
+                description: Mount path for MinIO volume (PV). Defaults to /export
+                type: string
+              podManagementPolicy:
+                description: Pod Management Policy for pod created by StatefulSet
+                type: string
+              priorityClassName:
+                description: PriorityClassName indicates the Pod priority and hence
+                  importance of a Pod relative to other Pods. This is applied to MinIO
+                  pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+                type: string
+              purgePVCOnTenantDelete:
+                description: Delete PVCs on tenant deletion. Defaults to (false) preserving
+                  PVCs if tenant is deleted. PVCs will need cleanup post tenant deletion
+                  if not set to true. If set to true ALL PVs for the tenant will be
+                  deleted.
+                type: boolean
+              requestAutoCert:
+                description: 'RequestAutoCert allows user to enable Kubernetes based
+                  TLS cert generation and signing as explained here: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/'
+                type: boolean
+              securityContext:
+                description: Security Context allows user to set entries like runAsUser,
+                  privilege escalation etc.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified defaults to "Always".'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
+              serviceAccountName:
+                description: ServiceAccountName is the name of the ServiceAccount
+                  to use to run pods of all MinIO Pods created as a part of this Tenant.
+                type: string
+              serviceName:
+                description: ServiceName defines name of the Service that will be
+                  created for this instance, if none is specified, it will default
+                  to the instance name
+                type: string
+              subPath:
+                description: Subpath inside mount path. This is the directory where
+                  MinIO stores data. Default to "" (empty)
+                type: string
+              zones:
+                description: Definition for Cluster in given MinIO cluster
+                items:
+                  description: Zone defines the spec for a MinIO Zone
+                  properties:
+                    affinity:
+                      description: If specified, affinity will define the pod's scheduling
+                        constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    name:
+                      description: Name of the zone
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'NodeSelector is a selector which must be true
+                        for the pod to fit on a node. Selector which must match a
+                        node''s labels for the pod to be scheduled on that node. More
+                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    resources:
+                      description: If provided, use these requests and limit for cpu/memory
+                        resource allocation
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    servers:
+                      description: Number of Servers in the zone
+                      format: int32
+                      type: integer
+                    tolerations:
+                      description: Tolerations allows users to set entries like effect,
+                        key, operator, value.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    volumeClaimTemplate:
+                      description: VolumeClaimTemplate allows a user to specify how
+                        volumes inside a Tenant
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                        spec:
+                          description: 'Spec defines the desired characteristics of
+                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                - Beta) * An existing PVC (PersistentVolumeClaim)
+                                * An existing custom resource/object that implements
+                                data population (Alpha) In order to use VolumeSnapshot
+                                object types, the appropriate feature gate must be
+                                enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                If the provisioner or an external controller can support
+                                the specified data source, it will create a new volume
+                                based on the contents of the specified data source.
+                                If the specified data source is not supported, the
+                                volume will not be created and the failure will be
+                                reported as an event. In the future, we plan to support
+                                more data source types and the behavior of the provisioner
+                                may change.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        status:
+                          description: 'Status represents the current information/status
+                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the actual access
+                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            capacity:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Represents the actual resources of the
+                                underlying volume.
+                              type: object
+                            conditions:
+                              description: Current Condition of persistent volume
+                                claim. If underlying persistent volume is being resized
+                                then the Condition will be set to 'ResizeStarted'.
+                              items:
+                                description: PersistentVolumeClaimCondition contails
+                                  details about state of pvc
+                                properties:
+                                  lastProbeTime:
+                                    description: Last time we probed the condition.
+                                    format: date-time
+                                    type: string
+                                  lastTransitionTime:
+                                    description: Last time the condition transitioned
+                                      from one status to another.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: Human-readable message indicating
+                                      details about last transition.
+                                    type: string
+                                  reason:
+                                    description: Unique, this should be a short, machine
+                                      understandable string that gives the reason
+                                      for condition's last transition. If it reports
+                                      "ResizeStarted" that means the underlying persistent
+                                      volume is being resized.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: PersistentVolumeClaimConditionType
+                                      is a valid value of PersistentVolumeClaimCondition.Type
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                            phase:
+                              description: Phase represents the current phase of PersistentVolumeClaim.
+                              type: string
+                          type: object
+                      type: object
+                    volumesPerServer:
+                      description: Number of persistent volumes that will be attached
+                        per server
+                      format: int32
+                      type: integer
+                  required:
+                  - servers
+                  - volumeClaimTemplate
+                  - volumesPerServer
+                  type: object
+                type: array
+            required:
+            - zones
+            type: object
+          status:
+            description: Status provides details of the state of the Tenant
+            properties:
+              availableReplicas:
+                format: int32
+                type: integer
+              currentState:
+                type: string
+            required:
+            - availableReplicas
+            - currentState
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -191,6 +191,10 @@ type ConsoleConfiguration struct {
 	// This secret provides all environment variables for KES
 	// This is a mandatory field
 	ConsoleSecret *corev1.LocalObjectReference `json:"consoleSecret"`
+	// ServiceAccountName is the name of the ServiceAccount to use to run pods of all Console
+	// Pods created as a part of this Tenant.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 	// If provided, use these environment variables for Console resource
 	// +optional
 	Env []corev1.EnvVar `json:"env,omitempty"`
@@ -220,6 +224,10 @@ type KESConfig struct {
 	// This is applied to KES pods only.
 	// Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// ServiceAccountName is the name of the ServiceAccount to use to run pods of all KES
+	// Pods created as a part of this Tenant.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 	// This kesSecret serves as the configuration for KES
 	// This is a mandatory field
 	Configuration *corev1.LocalObjectReference `json:"kesSecret"`

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -215,9 +215,10 @@ func NewConsole(t *miniov1.Tenant) *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: consoleMetadata(t),
 				Spec: corev1.PodSpec{
-					Containers:    []corev1.Container{consoleContainer(t)},
-					RestartPolicy: miniov1.ConsoleRestartPolicy,
-					Volumes:       podVolumes,
+					ServiceAccountName: t.Spec.Console.ServiceAccountName,
+					Containers:         []corev1.Container{consoleContainer(t)},
+					RestartPolicy:      miniov1.ConsoleRestartPolicy,
+					Volumes:            podVolumes,
 				},
 			},
 		},

--- a/pkg/resources/statefulsets/kes-statefulset.go
+++ b/pkg/resources/statefulsets/kes-statefulset.go
@@ -193,10 +193,11 @@ func NewForKES(t *miniov1.Tenant, serviceName string) *appsv1.StatefulSet {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: KESMetadata(t),
 				Spec: corev1.PodSpec{
-					Containers:    containers,
-					Volumes:       podVolumes,
-					RestartPolicy: corev1.RestartPolicyAlways,
-					SchedulerName: t.Scheduler.Name,
+					ServiceAccountName: t.Spec.KES.ServiceAccountName,
+					Containers:         containers,
+					Volumes:            podVolumes,
+					RestartPolicy:      corev1.RestartPolicyAlways,
+					SchedulerName:      t.Scheduler.Name,
 				},
 			},
 		},


### PR DESCRIPTION
Makes the service account for KES and Console configurable. We need this because we have the requirement of using a dedicated service account for each workload.