### PR TITLE
Rename variable and regenerate CRD with controller-gen 0.4.0

### DIFF
--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"


### PR DESCRIPTION
Renames a variable called `name` since we import a package with the same name `github.com/google/go-containerregistry/pkg/name`

Re-generates the CRD for the project using `controller-gen 0.4.0` which was the original version