### PR TITLE
Revert Tenant Finalizers

### DIFF
--- a/operator-kustomize/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/crds/minio.min.io_tenants.yaml
@@ -417,9 +417,6 @@ spec:
             priorityClassName:
               description: PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods. This is applied to MinIO pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
               type: string
-            purgePVCOnTenantDelete:
-              description: Delete PVCs on tenant deletion. Defaults to (false) preserving PVCs if tenant is deleted. PVCs will need cleanup post tenant deletion if not set to true. If set to true ALL PVs for the tenant will be deleted.
-              type: boolean
             requestAutoCert:
               description: 'RequestAutoCert allows user to enable Kubernetes based TLS cert generation and signing as explained here: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/'
               type: boolean

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -39,9 +39,6 @@ const ConsoleContainerName = "console"
 // InitContainerImage name for init container.
 const InitContainerImage = "busybox:1.32"
 
-// Finalizer name used for resources operator wants to track for deletion
-const Finalizer = "finalizer.minio.min.io"
-
 // MinIO Related Names
 
 // MinIOStatefulSetNameForZone returns the name for MinIO StatefulSet

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -51,10 +51,6 @@ type TenantScheduler struct {
 type TenantSpec struct {
 	// Definition for Cluster in given MinIO cluster
 	Zones []Zone `json:"zones"`
-	// Delete PVCs on tenant deletion. Defaults to (false) preserving PVCs if tenant is deleted. PVCs will
-	// need cleanup post tenant deletion if not set to true. If set to true ALL PVs for the tenant will be deleted.
-	// +optional
-	PurgePVCOnTenantDelete bool `json:"purgePVCOnTenantDelete,omitempty"`
 	// Image defines the Tenant Docker image.
 	// +optional
 	Image string `json:"image,omitempty"`

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -29,7 +29,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-
+var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	miniov1.AddToScheme,
 }

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -438,15 +438,6 @@ func NewForMinIOZone(t *miniov1.Tenant, wsSecret *v1.Secret, zone *miniov1.Zone,
 
 	if zone.VolumeClaimTemplate != nil {
 		pvClaim := *zone.VolumeClaimTemplate
-		if t.Spec.PurgePVCOnTenantDelete {
-			pvClaim.OwnerReferences = []metav1.OwnerReference{
-				*metav1.NewControllerRef(t, schema.GroupVersionKind{
-					Group:   miniov1.SchemeGroupVersion.Group,
-					Version: miniov1.SchemeGroupVersion.Version,
-					Kind:    miniov1.MinIOCRDResourceKind,
-				}),
-			}
-		}
 		name := pvClaim.Name
 		for i := 0; i < int(zone.VolumesPerServer); i++ {
 			pvClaim.Name = name + strconv.Itoa(i)


### PR DESCRIPTION
This PR reverts PR #268 

We need to remove the finalizers because it causes an issue where the Tenant's become un-deletable if the Operator is deleted before the tenants are deleted. If the Operator is uninstalled along with the Tenant CRD, it causes the Tenant CRD to go into terminating state, but since the Tenant has a finalizer it cannot be deleted, if the operator is reinstalled since the Tenant CRD is still in terminating state no new tenants can be created and the operator will go into an error state where it cannot process the tenant that is in terminating state either.

Fixing this deadlock requires to manually remove the finalizers from stuck tenants before attempting to reinstall the operator.

As we revert this we will rely entirely on User Experience to guide them to purge the Tenants which were deleted and left their PVCs behind.