### PR TITLE
Remove MinIO Tenant Labels From Console Pods

### DIFF
--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -79,8 +79,6 @@ func consoleMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
 	for k, v := range t.ConsolePodLabels() {
 		meta.Labels[k] = v
 	}
-	// Mark which tenant is being used
-	meta.Labels[miniov1.TenantLabel] = t.Name
 	return meta
 }
 

--- a/pkg/resources/jobs/kes-job.go
+++ b/pkg/resources/jobs/kes-job.go
@@ -141,7 +141,6 @@ func kesMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
 	for k, v := range t.KESPodLabels() {
 		meta.Labels[k] = v
 	}
-	meta.Labels[miniov1.TenantLabel] = t.Name
 	return meta
 }
 

--- a/pkg/resources/statefulsets/kes-statefulset.go
+++ b/pkg/resources/statefulsets/kes-statefulset.go
@@ -38,7 +38,6 @@ func KESMetadata(t *miniov1.Tenant) metav1.ObjectMeta {
 	for k, v := range t.KESPodLabels() {
 		meta.Labels[k] = v
 	}
-	meta.Labels[miniov1.TenantLabel] = t.Name
 	return meta
 }
 


### PR DESCRIPTION
This PR removes the `v1.min.io/tenant` label from the Console pods, it was added so that ownership of a console pod could be determined via it's tenant label, but this had the side effect that the Tenant service started targeting the console pods, thus causing that 1 out of every X calls (where X is the number of MinIO Pods + 1) to fail.