### PR TITLE
Improve debug print when tar file extraction fails

### DIFF
--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -212,18 +212,19 @@ func ExtractTar(filesToExtract []string, basePath, tarFileName string) error {
 				break
 			}
 		}
+
 		if err != nil {
-			return fmt.Errorf("Tar file extraction failed: %w", err)
+			return fmt.Errorf("Tar file extraction failed to find next: %d, %w", success, err)
 		}
 		if header.Typeflag == tar.TypeReg {
 			if name := find(filesToExtract, header.Name); name != "" {
 				outFile, err := os.OpenFile(basePath+path.Base(name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
 				if err != nil {
-					return fmt.Errorf("Tar file extraction failed: %w", err)
+					return fmt.Errorf("Tar file extraction failed during open: %d, %s, %w", success, name, err)
 				}
 				if _, err := io.Copy(outFile, tr); err != nil {
 					_ = outFile.Close()
-					return fmt.Errorf("Tar file extraction failed: %w", err)
+					return fmt.Errorf("Tar file extraction failed during copy: %d, %s, %w", success, name, err)
 				}
 				_ = outFile.Close()
 				success--

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -214,7 +214,7 @@ func ExtractTar(filesToExtract []string, basePath, tarFileName string) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("Tar file extraction failed to find next: %d, %w", success, err)
+			return fmt.Errorf("Tar file extraction failed for file index: %d, with: %w", success, err)
 		}
 		if header.Typeflag == tar.TypeReg {
 			if name := find(filesToExtract, header.Name); name != "" {

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -220,7 +220,7 @@ func ExtractTar(filesToExtract []string, basePath, tarFileName string) error {
 			if name := find(filesToExtract, header.Name); name != "" {
 				outFile, err := os.OpenFile(basePath+path.Base(name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
 				if err != nil {
-					return fmt.Errorf("Tar file extraction failed during open: %d, %s, %w", success, name, err)
+					return fmt.Errorf("Tar file extraction failed while opening file: %s, at index: %d, with: %w", name, success, err)
 				}
 				if _, err := io.Copy(outFile, tr); err != nil {
 					_ = outFile.Close()

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -224,7 +224,7 @@ func ExtractTar(filesToExtract []string, basePath, tarFileName string) error {
 				}
 				if _, err := io.Copy(outFile, tr); err != nil {
 					_ = outFile.Close()
-					return fmt.Errorf("Tar file extraction failed during copy: %d, %s, %w", success, name, err)
+					return fmt.Errorf("Tar file extraction failed while copying file: %s, at index: %d, with: %w", name, success, err)
 				}
 				_ = outFile.Close()
 				success--


### PR DESCRIPTION
I tried to update the tenant image with a development build that was uploaded to docker hub and that failed during tar file extraction. Improved the debug print to help.