### PR TITLE
Enqueue tenant only if RVs are different

### DIFF
--- a/pkg/controller/cluster/csr.go
+++ b/pkg/controller/cluster/csr.go
@@ -221,7 +221,6 @@ func (c *Controller) fetchCertificate(ctx context.Context, csrName string) ([]by
 	defer tick.Stop()
 
 	timeout := time.NewTimer(miniov1.DefaultQueryTimeout)
-	defer tick.Stop()
 
 	ch := make(chan os.Signal, 1) // should be always un-buffered SA1017
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -238,7 +238,13 @@ func NewController(
 	tenantInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueTenant,
 		UpdateFunc: func(old, new interface{}) {
-			// TODO: compare old vs new and don't enqueue if they are identical
+			oldTenant := old.(*miniov1.Tenant)
+			newTenant := new.(*miniov1.Tenant)
+			if newTenant.ResourceVersion == oldTenant.ResourceVersion {
+				// Periodic resync will send update events for all known Tenants.
+				// Two different versions of the same Tenant will always have different RVs.
+				return
+			}
 			controller.enqueueTenant(new)
 		},
 	})


### PR DESCRIPTION
- Remove superfluous tick.Stop call