### PR TITLE
Mount certificates to Console container under /tmp/certs

### DIFF
--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -140,6 +140,9 @@ const ConsoleConfigMountPath = "/tmp/console"
 // DefaultConsoleReplicas specifies the default number of Console pods to be created if not specified
 const DefaultConsoleReplicas = 2
 
+// ConsoleCertPath is the path where all Console certs are mounted
+const ConsoleCertPath = "/tmp/certs"
+
 // KES Related Constants
 
 // DefaultKESImage specifies the latest KES Docker hub image


### PR DESCRIPTION
- removed --tls-cert and --tls-key flags from console because they are
  not need it anymore
- added --certs-dir flag to console server so we take advantage of the
  sni feature