### PR TITLE
Add missing kubectl in krew install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MinIO Operator brings native support for [MinIO](https://github.com/minio/minio)
 
 - Kubernetes >= v1.17.0.
 - Create PVs.
-- Install [`kubectl minio` plugin using `krew install minio`.
+- Install [`kubectl minio` plugin using `kubectl krew install minio`.
 
 ## Operator Setup
 


### PR DESCRIPTION
I noticed that the install command only works when adding `kubectl` before it. 