### PR TITLE
fix `kubectl minio init -o`

### DIFF
--- a/kubectl-minio/cmd/resources/cluter-role-binding.go
+++ b/kubectl-minio/cmd/resources/cluter-role-binding.go
@@ -27,6 +27,10 @@ import (
 // NewCluterRoleBindingForOperator will return a new cluster-role-binding for a MinIO Operator
 func NewCluterRoleBindingForOperator(saName, ns string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      helpers.ClusterRoleBindingName,
 			Namespace: ns,

--- a/kubectl-minio/cmd/resources/deployment.go
+++ b/kubectl-minio/cmd/resources/deployment.go
@@ -68,6 +68,10 @@ func container(img, clusterDomain, nsToWatch string) corev1.Container {
 // NewDeploymentForOperator will return a new deployment for a MinIO Operator
 func NewDeploymentForOperator(opts OperatorOptions) *appsv1.Deployment {
 	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      helpers.DeploymentName,
 			Namespace: opts.NS,

--- a/kubectl-minio/cmd/resources/service-account.go
+++ b/kubectl-minio/cmd/resources/service-account.go
@@ -26,6 +26,10 @@ import (
 // NewServiceAccountForOperator will return a new service account for a MinIO Operator
 func NewServiceAccountForOperator(name, ns string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,


### PR DESCRIPTION
fix https://github.com/minio/operator/issues/358 by adding respective APIVersion/Kind to generated resources.