### PR TITLE
Fix cluster role binding when operator manifests are generated

### DIFF
--- a/kubectl-minio/cmd/resources/cluter-role-binding.go
+++ b/kubectl-minio/cmd/resources/cluter-role-binding.go
@@ -29,7 +29,7 @@ func NewCluterRoleBindingForOperator(saName, ns string) *rbacv1.ClusterRoleBindi
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
-			Kind:       "RoleBinding",
+			Kind:       "ClusterRoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      helpers.ClusterRoleBindingName,


### PR DESCRIPTION
fixes https://github.com/minio/operator/issues/366

operator role binding should be cluster scoped.  My mistake during my previous PR https://github.com/minio/operator/pull/359