### PR TITLE
kes: fix key creation failure

### DIFF
--- a/pkg/resources/jobs/kes-job.go
+++ b/pkg/resources/jobs/kes-job.go
@@ -96,7 +96,7 @@ func NewForKES(t *miniov1.Tenant) *batchv1.Job {
 
 // returns the KES job container
 func kesJobContainer(t *miniov1.Tenant) corev1.Container {
-	args := []string{"key", "create", miniov1.KESMinIOKey, "-k"}
+	args := []string{"key", "create", "-k", miniov1.KESMinIOKey} // KES CLI expects flags before command args
 
 	return corev1.Container{
 		Name:            miniov1.KESContainerName,


### PR DESCRIPTION
This commit fixes a incorrect usage of the
KES CLI. The KES CLI requires flags to be
specified before command args.

This behavior has been introduced by
6f865511cc9c1a1402d531d17f0af7298b446ec7

Fixes #396