### PR TITLE
Add support for passing annotations to Services

### DIFF
--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -148,6 +148,18 @@ spec:
   ## for details.
   podManagementPolicy: Parallel
 
+  ## serviceMetadata allows passing additional labels and annotations to MinIO and Console specific 
+  ## services created by the operator.
+  serviceMetadata:
+    minioServiceLabels:
+      label: minio-svc
+    minioServiceAnnotations:
+      v2.min.io: minio-svc
+    consoleServiceLabels:
+      label: console-svc
+    consoleServiceAnnotations:
+      v2.min.io: console-svc
+
   ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
   # env:
   # - name: MINIO_BROWSER

--- a/operator-kustomize/base/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/base/crds/minio.min.io_tenants.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.6
+  creationTimestamp: null
   name: tenants.minio.min.io
 spec:
   conversion:
@@ -5125,6 +5126,25 @@ spec:
                 type: object
               serviceAccountName:
                 type: string
+              serviceMetadata:
+                properties:
+                  consoleServiceAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  consoleServiceLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  minioServiceAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  minioServiceLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
               sideCars:
                 properties:
                   containers:

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -805,3 +805,11 @@ func GetClusterDomain() string {
 	})
 	return k8sClusterDomain
 }
+
+// MergeMaps merges two maps and returns the union
+func MergeMaps(a, b map[string]string) map[string]string {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -139,6 +139,25 @@ type TenantSpec struct {
 	// ExposeServices tells operator whether to expose the MinIO service and/or the Console Service
 	// +optional
 	ExposeServices *ExposeServices `json:"exposeServices,omitempty"`
+	// ServiceMetadata provides a way to bring your own service to be used for MinIO and / or Console
+	// +optional
+	ServiceMetadata *ServiceMetadata `json:"serviceMetadata,omitempty"`
+}
+
+// ServiceMetadata provides a way to bring your own service to be used for MinIO and / or Console
+type ServiceMetadata struct {
+	// If provided, append these labels to the MinIO service
+	// +optional
+	MinIOServiceLabels map[string]string `json:"minioServiceLabels,omitempty"`
+	// If provided, append these annotations to the MinIO service
+	// +optional
+	MinIOServiceAnnotations map[string]string `json:"minioServiceAnnotations,omitempty"`
+	// If provided, append these labels to the Console service
+	// +optional
+	ConsoleServiceLabels map[string]string `json:"consoleServiceLabels,omitempty"`
+	// If provided, append these annotations to the Console service
+	// +optional
+	ConsoleServiceAnnotations map[string]string `json:"consoleServiceAnnotations,omitempty"`
 }
 
 // LocalCertificateReference defines the spec for a local certificate


### PR DESCRIPTION
This PR adds support for annotations and labels to be
applied to minio and minio-console ClusterIP service.
This allows integration with tools like external-dns plugin
to publish the CNAME to external DNS for clients outside
of Kubernetes.