### PR TITLE
Add support for --image flag in tenant create command

### DIFF
--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -173,10 +173,7 @@ func deleteConsoleResources(opts resources.OperatorOptions, clientset *apiextens
 				return err
 			}
 		}
-
 	}
-	fmt.Println("MinIO Console Deployment: Deleted")
-
 	return nil
 }
 

--- a/kubectl-minio/cmd/init.go
+++ b/kubectl-minio/cmd/init.go
@@ -147,7 +147,7 @@ func (o *operatorInitCmd) run() error {
 		// since we did an explicit deployment of resources, let's show a message telling users how to connect to console
 		fmt.Println("-----------------")
 		fmt.Println("")
-		fmt.Println("Operator UI has been deployed, to connect, start a port forward using the following command:")
+		fmt.Println("To open Operator UI, start a port forward using this command:")
 		fmt.Println("")
 		fmt.Println("kubectl minio proxy")
 		fmt.Println("")

--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -92,7 +92,7 @@ func GetFSAndDecoder() (http.FileSystem, func(data []byte, defaults *schema.Grou
 }
 
 func LoadTenantCRD(emfs http.FileSystem, decode func(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error)) *apiextensionv1.CustomResourceDefinition {
-	contents, err := fs.ReadFile(emfs, "/crds/minio.min.io_tenants.yaml")
+	contents, err := fs.ReadFile(emfs, "/base/crds/minio.min.io_tenants.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/kubectl-minio/cmd/tenant-create.go
+++ b/kubectl-minio/cmd/tenant-create.go
@@ -77,6 +77,7 @@ func newTenantCreateCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	f.StringVar(&c.tenantOpts.Capacity, "capacity", "", "total raw capacity of MinIO tenant in this pool, e.g. 16Ti")
 	f.StringVarP(&c.tenantOpts.NS, "namespace", "n", helpers.DefaultNamespace, "namespace scope for this request")
 	f.StringVarP(&c.tenantOpts.StorageClass, "storage-class", "s", helpers.DefaultStorageclass, "storage class for this MinIO tenant")
+	f.StringVarP(&c.tenantOpts.Image, "image", "i", helpers.DefaultTenantImage, "MinIO image for this tenant")
 	f.StringVar(&c.tenantOpts.KmsSecret, "kes-config", "", "name of secret with details for enabling encryption, refer example https://github.com/minio/operator/blob/master/examples/kes-secret.yaml")
 	f.BoolVarP(&c.output, "output", "o", false, "dry run this command and generate requisite yaml")
 
@@ -90,7 +91,6 @@ func (c *createCmd) validate(args []string) error {
 	c.tenantOpts.Name = args[0]
 	c.tenantOpts.SecretName = c.tenantOpts.Name + tenantSecretSuffix
 	c.tenantOpts.ConsoleSecret = c.tenantOpts.Name + consoleSecretSuffix
-	c.tenantOpts.Image = helpers.DefaultTenantImage
 	if args == nil {
 		return errors.New("create command requires specifying the tenant name as an argument, e.g. 'kubectl minio tenant create tenant1'")
 	}

--- a/kubectl-minio/go.sum
+++ b/kubectl-minio/go.sum
@@ -691,6 +691,7 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/minio/cli v1.22.0/go.mod h1:bYxnK0uS629N3Bq+AOZZ+6lwF77Sodk4+UL9vNuXhOY=
 github.com/minio/controller-tools v0.4.5/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
+github.com/minio/controller-tools v0.4.6/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
 github.com/minio/minio v0.0.0-20210128013121-e79829b5b368 h1:oRvZaqSesXt/SVTqkfJ9UhmXpkDiBUITpmSJU1hwmSA=

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -31,15 +31,16 @@ import (
 func NewClusterIPForMinIO(t *miniov2.Tenant) *corev1.Service {
 	var port int32 = miniov2.MinIOPortLoadBalancerSVC
 	var name string = miniov2.MinIOServiceHTTPPortName
-	var internalLabels, labels map[string]string
+	var internalLabels, labels, annotations map[string]string
 
 	internalLabels = t.MinIOPodLabels()
 	if t.TLS() {
 		port = miniov2.MinIOTLSPortLoadBalancerSVC
 		name = miniov2.MinIOServiceHTTPSPortName
 	}
-	if t.Spec.ServiceMetadata.MinIOServiceLabels != nil {
+	if t.Spec.ServiceMetadata != nil && t.Spec.ServiceMetadata.MinIOServiceLabels != nil {
 		labels = miniov2.MergeMaps(internalLabels, t.Spec.ServiceMetadata.MinIOServiceLabels)
+		annotations = t.Spec.ServiceMetadata.MinIOServiceAnnotations
 	}
 	minioPort := corev1.ServicePort{
 		Port:       port,
@@ -52,7 +53,7 @@ func NewClusterIPForMinIO(t *miniov2.Tenant) *corev1.Service {
 			Name:            t.MinIOCIServiceName(),
 			Namespace:       t.Namespace,
 			OwnerReferences: t.OwnerRef(),
-			Annotations:     t.Spec.ServiceMetadata.MinIOServiceAnnotations,
+			Annotations:     annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:    []corev1.ServicePort{minioPort},
@@ -182,15 +183,16 @@ func NewHeadlessForPrometheus(t *miniov2.Tenant) *corev1.Service {
 
 // NewClusterIPForConsole will return a new cluster IP service for Console Deployment
 func NewClusterIPForConsole(t *miniov2.Tenant) *corev1.Service {
-	var internalLabels, labels map[string]string
+	var internalLabels, labels, annotations map[string]string
 	internalLabels = t.ConsolePodLabels()
 
 	consolePort := corev1.ServicePort{Port: miniov2.ConsolePort, Name: miniov2.ConsoleServicePortName}
 	if t.TLS() || t.ConsoleExternalCert() {
 		consolePort = corev1.ServicePort{Port: miniov2.ConsoleTLSPort, Name: miniov2.ConsoleServiceTLSPortName}
 	}
-	if t.Spec.ServiceMetadata.ConsoleServiceLabels != nil {
+	if t.Spec.ServiceMetadata != nil && t.Spec.ServiceMetadata.ConsoleServiceLabels != nil {
 		labels = miniov2.MergeMaps(internalLabels, t.Spec.ServiceMetadata.ConsoleServiceLabels)
+		annotations = t.Spec.ServiceMetadata.ConsoleServiceAnnotations
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -198,7 +200,7 @@ func NewClusterIPForConsole(t *miniov2.Tenant) *corev1.Service {
 			Name:            t.ConsoleCIServiceName(),
 			Namespace:       t.Namespace,
 			OwnerReferences: t.OwnerRef(),
-			Annotations:     t.Spec.ServiceMetadata.ConsoleServiceAnnotations,
+			Annotations:     annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{


### PR DESCRIPTION
Fixes #442

Also fix plugin output and nil pointer when creating
a tenant without service spec fields.