### PR TITLE
Remove namespace create/delete privileges from Operator

### DIFF
--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -120,12 +120,6 @@ func (o *deleteCmd) run() error {
 	if err := deleteConsoleResources(o.operatorOpts, extclient, dynclient, consoleResources); err != nil {
 		return err
 	}
-	// if the namespace is the default, we'll delete the namespace
-	if o.operatorOpts.Namespace == helpers.DefaultNamespace {
-		if err = client.CoreV1().Namespaces().Delete(context.Background(), o.operatorOpts.Namespace, metav1.DeleteOptions{}); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/kubectl-minio/cmd/init.go
+++ b/kubectl-minio/cmd/init.go
@@ -115,14 +115,6 @@ func (o *operatorInitCmd) run() error {
 		if err != nil {
 			return err
 		}
-		// if the namespace is the default, we'll create the namespace
-		if o.operatorOpts.Namespace == helpers.DefaultNamespace {
-			ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: o.operatorOpts.Namespace}}
-			if _, err = client.CoreV1().Namespaces().Create(context.Background(), &ns, metav1.CreateOptions{}); err != nil {
-				return err
-			}
-		}
-
 		if err = createCRD(extclient, crdObj); err != nil {
 			return err
 		}

--- a/operator-kustomize/cluster-role.yaml
+++ b/operator-kustomize/cluster-role.yaml
@@ -22,6 +22,13 @@ rules:
       - ""
     resources:
       - namespaces
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ""
+    resources:
       - pods
       - services
       - events


### PR DESCRIPTION
Also do not automatically create namespaces in
Operator plugin

Fixes #441