### PR TITLE
Reduce the fields of the embedded ObjectMeta fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 	@rm -rf dist/
 
 regen-crd:
-	@GO111MODULE=on go get github.com/minio/controller-tools/cmd/controller-gen@v0.4.6
+	@GO111MODULE=on go get github.com/minio/controller-tools/cmd/controller-gen@v0.4.7
 	@echo "WARNING: for the time being, you need to clone and build github.com/minio/controller-tools/cmd/controller-gen@v0.4.6"
 	@echo "Any other controller-gen will cause the generated CRD to lose the volumeClaimTemplate metadata to be lost"
 	@controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true paths="./..." output:crd:artifacts:config=$(KUSTOMIZE_CRDS)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
 	github.com/google/go-containerregistry v0.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/minio/controller-tools v0.4.6 // indirect
 	github.com/minio/minio v0.0.0-20210128013121-e79829b5b368
 	github.com/minio/minio-go/v7 v7.0.8-0.20210127003153-c40722862654
 	github.com/secure-io/sio-go v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslW
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/go-toolsmith/typep v1.0.2/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
-github.com/gobuffalo/flect v0.2.2 h1:PAVD7sp0KOdfswjAw9BpLCU9hXo7wFSzgpQ+zNeks/A=
-github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -633,10 +631,6 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/minio/cli v1.22.0/go.mod h1:bYxnK0uS629N3Bq+AOZZ+6lwF77Sodk4+UL9vNuXhOY=
-github.com/minio/controller-tools v0.4.5 h1:fuQBtPHhIu2zHEXFxAtlW+y6vdRTioy4b9HtEIHSbvM=
-github.com/minio/controller-tools v0.4.5/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
-github.com/minio/controller-tools v0.4.6 h1:vztZ5YIZRWqY+U4ZZpbZFC14BnN3r3JDx9+Xyn1j008=
-github.com/minio/controller-tools v0.4.6/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
 github.com/minio/md5-simd v1.1.0 h1:QPfiOqlZH+Cj9teu0t9b1nTBfPbyTl16Of5MeuShdK4=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=
@@ -1257,7 +1251,6 @@ golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 h1:BTs2GMGSMWpgtCpv1CE7vkJTv7XcHdcLLnAMu7UbgTY=

--- a/operator-kustomize/base/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/base/crds/minio.min.io_tenants.yaml
@@ -35,8 +35,6 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    deprecated: true
-    deprecationWarning: This version is deprecated in favor of minio.min.io/v2
     name: v1
     schema:
       openAPIV3Schema:

--- a/operator-kustomize/base/crds/minio.min.io_tenants.yaml
+++ b/operator-kustomize/base/crds/minio.min.io_tenants.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.6
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.4.7
   name: tenants.minio.min.io
 spec:
   conversion:
@@ -959,79 +958,17 @@ spec:
                                 additionalProperties:
                                   type: string
                                 type: object
-                              clusterName:
-                                type: string
-                              creationTimestamp:
-                                format: date-time
-                                type: string
-                              deletionGracePeriodSeconds:
-                                format: int64
-                                type: integer
-                              deletionTimestamp:
-                                format: date-time
-                                type: string
                               finalizers:
                                 items:
                                   type: string
                                 type: array
-                              generateName:
-                                type: string
-                              generation:
-                                format: int64
-                                type: integer
                               labels:
                                 additionalProperties:
                                   type: string
                                 type: object
-                              managedFields:
-                                items:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldsType:
-                                      type: string
-                                    fieldsV1:
-                                      type: object
-                                    manager:
-                                      type: string
-                                    operation:
-                                      type: string
-                                    time:
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 type: string
                               namespace:
-                                type: string
-                              ownerReferences:
-                                items:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    blockOwnerDeletion:
-                                      type: boolean
-                                    controller:
-                                      type: boolean
-                                    kind:
-                                      type: string
-                                    name:
-                                      type: string
-                                    uid:
-                                      type: string
-                                  required:
-                                  - apiVersion
-                                  - kind
-                                  - name
-                                  - uid
-                                  type: object
-                                type: array
-                              resourceVersion:
-                                type: string
-                              selfLink:
-                                type: string
-                              uid:
                                 type: string
                             type: object
                           spec:
@@ -1866,79 +1803,17 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                            clusterName:
-                              type: string
-                            creationTimestamp:
-                              format: date-time
-                              type: string
-                            deletionGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            deletionTimestamp:
-                              format: date-time
-                              type: string
                             finalizers:
                               items:
                                 type: string
                               type: array
-                            generateName:
-                              type: string
-                            generation:
-                              format: int64
-                              type: integer
                             labels:
                               additionalProperties:
                                 type: string
                               type: object
-                            managedFields:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldsType:
-                                    type: string
-                                  fieldsV1:
-                                    type: object
-                                  manager:
-                                    type: string
-                                  operation:
-                                    type: string
-                                  time:
-                                    format: date-time
-                                    type: string
-                                type: object
-                              type: array
                             name:
                               type: string
                             namespace:
-                              type: string
-                            ownerReferences:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  blockOwnerDeletion:
-                                    type: boolean
-                                  controller:
-                                    type: boolean
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                  uid:
-                                    type: string
-                                required:
-                                - apiVersion
-                                - kind
-                                - name
-                                - uid
-                                type: object
-                              type: array
-                            resourceVersion:
-                              type: string
-                            selfLink:
-                              type: string
-                            uid:
                               type: string
                           type: object
                         spec:
@@ -2244,79 +2119,17 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                    clusterName:
-                                      type: string
-                                    creationTimestamp:
-                                      format: date-time
-                                      type: string
-                                    deletionGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    deletionTimestamp:
-                                      format: date-time
-                                      type: string
                                     finalizers:
                                       items:
                                         type: string
                                       type: array
-                                    generateName:
-                                      type: string
-                                    generation:
-                                      format: int64
-                                      type: integer
                                     labels:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                    managedFields:
-                                      items:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldsType:
-                                            type: string
-                                          fieldsV1:
-                                            type: object
-                                          manager:
-                                            type: string
-                                          operation:
-                                            type: string
-                                          time:
-                                            format: date-time
-                                            type: string
-                                        type: object
-                                      type: array
                                     name:
                                       type: string
                                     namespace:
-                                      type: string
-                                    ownerReferences:
-                                      items:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          blockOwnerDeletion:
-                                            type: boolean
-                                          controller:
-                                            type: boolean
-                                          kind:
-                                            type: string
-                                          name:
-                                            type: string
-                                          uid:
-                                            type: string
-                                        required:
-                                        - apiVersion
-                                        - kind
-                                        - name
-                                        - uid
-                                        type: object
-                                      type: array
-                                    resourceVersion:
-                                      type: string
-                                    selfLink:
-                                      type: string
-                                    uid:
                                       type: string
                                   type: object
                                 spec:
@@ -3124,79 +2937,17 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                            clusterName:
-                              type: string
-                            creationTimestamp:
-                              format: date-time
-                              type: string
-                            deletionGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            deletionTimestamp:
-                              format: date-time
-                              type: string
                             finalizers:
                               items:
                                 type: string
                               type: array
-                            generateName:
-                              type: string
-                            generation:
-                              format: int64
-                              type: integer
                             labels:
                               additionalProperties:
                                 type: string
                               type: object
-                            managedFields:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldsType:
-                                    type: string
-                                  fieldsV1:
-                                    type: object
-                                  manager:
-                                    type: string
-                                  operation:
-                                    type: string
-                                  time:
-                                    format: date-time
-                                    type: string
-                                type: object
-                              type: array
                             name:
                               type: string
                             namespace:
-                              type: string
-                            ownerReferences:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  blockOwnerDeletion:
-                                    type: boolean
-                                  controller:
-                                    type: boolean
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                  uid:
-                                    type: string
-                                required:
-                                - apiVersion
-                                - kind
-                                - name
-                                - uid
-                                type: object
-                              type: array
-                            resourceVersion:
-                              type: string
-                            selfLink:
-                              type: string
-                            uid:
                               type: string
                           type: object
                         spec:
@@ -4268,79 +4019,17 @@ spec:
                                 additionalProperties:
                                   type: string
                                 type: object
-                              clusterName:
-                                type: string
-                              creationTimestamp:
-                                format: date-time
-                                type: string
-                              deletionGracePeriodSeconds:
-                                format: int64
-                                type: integer
-                              deletionTimestamp:
-                                format: date-time
-                                type: string
                               finalizers:
                                 items:
                                   type: string
                                 type: array
-                              generateName:
-                                type: string
-                              generation:
-                                format: int64
-                                type: integer
                               labels:
                                 additionalProperties:
                                   type: string
                                 type: object
-                              managedFields:
-                                items:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldsType:
-                                      type: string
-                                    fieldsV1:
-                                      type: object
-                                    manager:
-                                      type: string
-                                    operation:
-                                      type: string
-                                    time:
-                                      format: date-time
-                                      type: string
-                                  type: object
-                                type: array
                               name:
                                 type: string
                               namespace:
-                                type: string
-                              ownerReferences:
-                                items:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    blockOwnerDeletion:
-                                      type: boolean
-                                    controller:
-                                      type: boolean
-                                    kind:
-                                      type: string
-                                    name:
-                                      type: string
-                                    uid:
-                                      type: string
-                                  required:
-                                  - apiVersion
-                                  - kind
-                                  - name
-                                  - uid
-                                  type: object
-                                type: array
-                              resourceVersion:
-                                type: string
-                              selfLink:
-                                type: string
-                              uid:
                                 type: string
                             type: object
                           spec:
@@ -4824,79 +4513,17 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                            clusterName:
-                              type: string
-                            creationTimestamp:
-                              format: date-time
-                              type: string
-                            deletionGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            deletionTimestamp:
-                              format: date-time
-                              type: string
                             finalizers:
                               items:
                                 type: string
                               type: array
-                            generateName:
-                              type: string
-                            generation:
-                              format: int64
-                              type: integer
                             labels:
                               additionalProperties:
                                 type: string
                               type: object
-                            managedFields:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldsType:
-                                    type: string
-                                  fieldsV1:
-                                    type: object
-                                  manager:
-                                    type: string
-                                  operation:
-                                    type: string
-                                  time:
-                                    format: date-time
-                                    type: string
-                                type: object
-                              type: array
                             name:
                               type: string
                             namespace:
-                              type: string
-                            ownerReferences:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  blockOwnerDeletion:
-                                    type: boolean
-                                  controller:
-                                    type: boolean
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                  uid:
-                                    type: string
-                                required:
-                                - apiVersion
-                                - kind
-                                - name
-                                - uid
-                                type: object
-                              type: array
-                            resourceVersion:
-                              type: string
-                            selfLink:
-                              type: string
-                            uid:
                               type: string
                           type: object
                         spec:
@@ -5706,79 +5333,17 @@ spec:
                               additionalProperties:
                                 type: string
                               type: object
-                            clusterName:
-                              type: string
-                            creationTimestamp:
-                              format: date-time
-                              type: string
-                            deletionGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            deletionTimestamp:
-                              format: date-time
-                              type: string
                             finalizers:
                               items:
                                 type: string
                               type: array
-                            generateName:
-                              type: string
-                            generation:
-                              format: int64
-                              type: integer
                             labels:
                               additionalProperties:
                                 type: string
                               type: object
-                            managedFields:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  fieldsType:
-                                    type: string
-                                  fieldsV1:
-                                    type: object
-                                  manager:
-                                    type: string
-                                  operation:
-                                    type: string
-                                  time:
-                                    format: date-time
-                                    type: string
-                                type: object
-                              type: array
                             name:
                               type: string
                             namespace:
-                              type: string
-                            ownerReferences:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  blockOwnerDeletion:
-                                    type: boolean
-                                  controller:
-                                    type: boolean
-                                  kind:
-                                    type: string
-                                  name:
-                                    type: string
-                                  uid:
-                                    type: string
-                                required:
-                                - apiVersion
-                                - kind
-                                - name
-                                - uid
-                                type: object
-                              type: array
-                            resourceVersion:
-                              type: string
-                            selfLink:
-                              type: string
-                            uid:
                               type: string
                           type: object
                         spec:
@@ -6084,79 +5649,17 @@ spec:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                    clusterName:
-                                      type: string
-                                    creationTimestamp:
-                                      format: date-time
-                                      type: string
-                                    deletionGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    deletionTimestamp:
-                                      format: date-time
-                                      type: string
                                     finalizers:
                                       items:
                                         type: string
                                       type: array
-                                    generateName:
-                                      type: string
-                                    generation:
-                                      format: int64
-                                      type: integer
                                     labels:
                                       additionalProperties:
                                         type: string
                                       type: object
-                                    managedFields:
-                                      items:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldsType:
-                                            type: string
-                                          fieldsV1:
-                                            type: object
-                                          manager:
-                                            type: string
-                                          operation:
-                                            type: string
-                                          time:
-                                            format: date-time
-                                            type: string
-                                        type: object
-                                      type: array
                                     name:
                                       type: string
                                     namespace:
-                                      type: string
-                                    ownerReferences:
-                                      items:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          blockOwnerDeletion:
-                                            type: boolean
-                                          controller:
-                                            type: boolean
-                                          kind:
-                                            type: string
-                                          name:
-                                            type: string
-                                          uid:
-                                            type: string
-                                        required:
-                                        - apiVersion
-                                        - kind
-                                        - name
-                                        - uid
-                                        type: object
-                                      type: array
-                                    resourceVersion:
-                                      type: string
-                                    selfLink:
-                                      type: string
-                                    uid:
                                       type: string
                                   type: object
                                 spec:

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -31,7 +31,6 @@ import (
 // +kubebuilder:resource:scope=Namespaced,shortName=tenant,singular=tenant
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.currentState"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:deprecated:warning="This version is deprecated in favor of minio.min.io/v2"
 
 // Tenant is a specification for a MinIO resource
 type Tenant struct {


### PR DESCRIPTION
Updates to `minio/controller-tools@v0.4.7` which reduces the fields specified in the CRD for embedded metadata 