### PR TITLE
Fix bug when list of users is empty on an upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 
 regen-crd:
 	@GO111MODULE=on go get github.com/minio/controller-tools/cmd/controller-gen@v0.4.7
-	@echo "WARNING: for the time being, you need to clone and build github.com/minio/controller-tools/cmd/controller-gen@v0.4.6"
+	@echo "WARNING: for the time being, you need to clone and build github.com/minio/controller-tools/cmd/controller-gen@v0.4.7"
 	@echo "Any other controller-gen will cause the generated CRD to lose the volumeClaimTemplate metadata to be lost"
 	@controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true paths="./..." output:crd:artifacts:config=$(KUSTOMIZE_CRDS)
 	@kustomize build resources/patch-crd > $(TMPFILE)

--- a/kubectl-minio/cmd/resources/tenant.go
+++ b/kubectl-minio/cmd/resources/tenant.go
@@ -138,7 +138,6 @@ func NewTenant(opts *TenantOptions) (*miniov2.Tenant, error) {
 			CredsSecret: &v1.LocalObjectReference{
 				Name: opts.SecretName,
 			},
-			Users:           []v1.LocalObjectReference{},
 			Pools:           []miniov2.Pool{Pool(opts.Servers, volumesPerServer, *capacityPerVolume, opts.StorageClass)},
 			RequestAutoCert: &autoCert,
 			CertConfig: &miniov2.CertificateConfig{

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -48,7 +48,7 @@ type Tenant struct {
 type TenantSpec struct {
 	// Users defines an array of user credential secrets that will be created on MinIO during tenant provisioning.
 	// +optional
-	Users []corev1.LocalObjectReference `json:"users"`
+	Users []*corev1.LocalObjectReference `json:"users"`
 	// Definition for Cluster in given MinIO cluster
 	Zones []Zone `json:"zones"`
 	// Image defines the Tenant Docker image.

--- a/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
@@ -93,8 +93,14 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 	*out = *in
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users
-		*out = make([]corev1.LocalObjectReference, len(*in))
-		copy(*out, *in)
+		*out = make([]*corev1.LocalObjectReference, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1.LocalObjectReference)
+				**out = **in
+			}
+		}
 	}
 	if in.Zones != nil {
 		in, out := &in.Zones, &out.Zones

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -61,7 +61,7 @@ type S3Features struct {
 type TenantSpec struct {
 	// Users defines an array of user credential secrets that will be created on MinIO during tenant provisioning.
 	// +optional
-	Users []corev1.LocalObjectReference `json:"users"`
+	Users []*corev1.LocalObjectReference `json:"users,omitempty"`
 	// Definition for Cluster in given MinIO cluster
 	Pools []Pool `json:"pools"`
 	// Image defines the Tenant Docker image.

--- a/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *ConsoleConfiguration) DeepCopyInto(out *ConsoleConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -227,6 +232,11 @@ func (in *KESConfig) DeepCopyInto(out *KESConfig) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -304,6 +314,11 @@ func (in *LogConfig) DeepCopyInto(out *LogConfig) {
 		*out = new(AuditConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -359,6 +374,11 @@ func (in *LogDbConfig) DeepCopyInto(out *LogDbConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -399,6 +419,11 @@ func (in *Pool) DeepCopyInto(out *Pool) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -459,6 +484,11 @@ func (in *PrometheusConfig) DeepCopyInto(out *PrometheusConfig) {
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -652,8 +682,14 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 	*out = *in
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users
-		*out = make([]v1.LocalObjectReference, len(*in))
-		copy(*out, *in)
+		*out = make([]*v1.LocalObjectReference, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(v1.LocalObjectReference)
+				**out = **in
+			}
+		}
 	}
 	if in.Pools != nil {
 		in, out := &in.Pools, &out.Pools

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -30,7 +30,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-
+var parameterCodec = runtime.NewParameterCodec(scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
 	miniov1.AddToScheme,
 	miniov2.AddToScheme,

--- a/pkg/client/listers/minio.min.io/v1/tenant.go
+++ b/pkg/client/listers/minio.min.io/v1/tenant.go
@@ -26,10 +26,8 @@ import (
 )
 
 // TenantLister helps list Tenants.
-// All objects returned here must be treated as read-only.
 type TenantLister interface {
 	// List lists all Tenants in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Tenant, err error)
 	// Tenants returns an object that can list and get Tenants.
 	Tenants(namespace string) TenantNamespaceLister
@@ -60,13 +58,10 @@ func (s *tenantLister) Tenants(namespace string) TenantNamespaceLister {
 }
 
 // TenantNamespaceLister helps list and get Tenants.
-// All objects returned here must be treated as read-only.
 type TenantNamespaceLister interface {
 	// List lists all Tenants in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.Tenant, err error)
 	// Get retrieves the Tenant from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1.Tenant, error)
 	TenantNamespaceListerExpansion
 }

--- a/pkg/client/listers/minio.min.io/v2/tenant.go
+++ b/pkg/client/listers/minio.min.io/v2/tenant.go
@@ -26,10 +26,8 @@ import (
 )
 
 // TenantLister helps list Tenants.
-// All objects returned here must be treated as read-only.
 type TenantLister interface {
 	// List lists all Tenants in the indexer.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v2.Tenant, err error)
 	// Tenants returns an object that can list and get Tenants.
 	Tenants(namespace string) TenantNamespaceLister
@@ -60,13 +58,10 @@ func (s *tenantLister) Tenants(namespace string) TenantNamespaceLister {
 }
 
 // TenantNamespaceLister helps list and get Tenants.
-// All objects returned here must be treated as read-only.
 type TenantNamespaceLister interface {
 	// List lists all Tenants in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v2.Tenant, err error)
 	// Get retrieves the Tenant from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
 	Get(name string) (*v2.Tenant, error)
 	TenantNamespaceListerExpansion
 }


### PR DESCRIPTION
Makes the list of users optional at Struct level to avoid beaming a `null` into the k8s api

Fixed #477 