### PR TITLE
Fix ClusterRoleBinding namespace setting on kubectl-minio

### DIFF
--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -173,9 +173,14 @@ func LoadConsoleUI(emfs http.FileSystem, decode func(data []byte, defaults *sche
 				}
 			case *rbacv1.ClusterRoleBinding:
 				if resourceObj, ok := obj.(*rbacv1.ClusterRoleBinding); ok {
+					updatedSubjects := []rbacv1.Subject{}
 					for _, sub := range resourceObj.Subjects {
 						sub.Namespace = opts.Namespace
+						// store modified subject
+						updatedSubjects = append(updatedSubjects, sub)
 					}
+					// update subjects with modified array
+					resourceObj.Subjects = updatedSubjects
 				}
 			default:
 				// fmt.Println("Unhandled kind:", obj.GetObjectKind())

--- a/kubectl-minio/go.sum
+++ b/kubectl-minio/go.sum
@@ -690,8 +690,6 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/minio/cli v1.22.0/go.mod h1:bYxnK0uS629N3Bq+AOZZ+6lwF77Sodk4+UL9vNuXhOY=
-github.com/minio/controller-tools v0.4.5/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
-github.com/minio/controller-tools v0.4.6/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
 github.com/minio/controller-tools v0.4.7/go.mod h1:xES4iNis9dGrLQuP6nquTZZNg2T0/EM8wduC4/GWfZ0=
 github.com/minio/highwayhash v1.0.0/go.mod h1:xQboMTeM9nY9v/LlAOxFctujiv5+Aq2hR5dxBpaMbdc=
 github.com/minio/md5-simd v1.1.0/go.mod h1:XpBqgZULrMYD3R+M28PcmP0CkI7PEMzB3U77ZrKZ0Gw=


### PR DESCRIPTION
Fixes issue https://github.com/minio/operator/issues/479 for clusterRoleBinding not being set correctly for defined namespaces.

Since rbacv1.ClusterRoleBinding.Subjects is not a pointer, we have to
replace the array  instead of modifying the values.

To test:
1. Build  operator locally like :
```
 make build TAG="minio/operator:test" &&  kind load docker-image minio/operator:test
```
2. Build plugin locally like
```
cd kubectl-minio && go build
```
3.and run :
```
 kubectl create ns minio-operator && ./kubectl-minio init -n minio-operator --image=minio/operator:test --output=false
```
This should create operator, console and you should be able to access operator with no 403 (forbidden) issues. 