### PR TITLE
Delete operator service on plugin delete and skip existing items on c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ kubectl-minio/kubectl-minio
 *.zip
 kubectl-minio/crds
 logsearchapi/logsearchapi
+*.log

--- a/kubectl-minio/cmd/helpers/constants.go
+++ b/kubectl-minio/cmd/helpers/constants.go
@@ -81,6 +81,9 @@ const (
 
 	// DefaultConsoleImage is the default console image used while creating tenant
 	DefaultConsoleImage = "minio/console:v0.6.0"
+
+	// DefaultOperatorServiceName is the default service name for operator
+	DefaultOperatorServiceName = "operator"
 )
 
 var (

--- a/kubectl-minio/cmd/proxy.go
+++ b/kubectl-minio/cmd/proxy.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	"github.com/fatih/color"
 
@@ -64,7 +65,13 @@ func newProxyCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			if len(args) != 0 {
 				return errors.New("this command does not accept arguments")
 			}
-			return o.run()
+			klog.Info("proxy command started")
+			err := o.run()
+			if err != nil {
+				klog.Warning(err)
+				return err
+			}
+			return nil
 		},
 	}
 	cmd = helpers.DisableHelp(cmd)

--- a/kubectl-minio/cmd/resources/service.go
+++ b/kubectl-minio/cmd/resources/service.go
@@ -19,6 +19,7 @@
 package resources
 
 import (
+	"github.com/minio/kubectl-minio/cmd/helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,7 +31,7 @@ func NewServiceForOperator(opts OperatorOptions) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    operatorLabels(),
-			Name:      "operator",
+			Name:      helpers.DefaultOperatorServiceName,
 			Namespace: opts.Namespace,
 		},
 		Spec: corev1.ServiceSpec{

--- a/kubectl-minio/cmd/tenant-create.go
+++ b/kubectl-minio/cmd/tenant-create.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -67,7 +68,13 @@ func newTenantCreateCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			if err := c.validate(args); err != nil {
 				return err
 			}
-			return c.run(args)
+			klog.Info("create tenant command started")
+			err := c.run(args)
+			if err != nil {
+				klog.Warning(err)
+				return err
+			}
+			return nil
 		},
 	}
 	cmd = helpers.DisableHelp(cmd)

--- a/kubectl-minio/cmd/tenant-delete.go
+++ b/kubectl-minio/cmd/tenant-delete.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 
 	operatorv1 "github.com/minio/operator/pkg/client/clientset/versioned"
 	"github.com/spf13/cobra"
@@ -64,7 +65,13 @@ func newTenantDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.run(args)
+			klog.Info("delete tenant command started")
+			err := c.run(args)
+			if err != nil {
+				klog.Warning(err)
+				return err
+			}
+			return nil
 		},
 	}
 	cmd = helpers.DisableHelp(cmd)

--- a/kubectl-minio/cmd/tenant-expand.go
+++ b/kubectl-minio/cmd/tenant-expand.go
@@ -30,6 +30,7 @@ import (
 	"github.com/minio/minio/pkg/color"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
@@ -62,7 +63,13 @@ func newTenantExpandCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			if err := v.validate(args); err != nil {
 				return err
 			}
-			return v.run()
+			klog.Info("expand tenant command started")
+			err := v.run()
+			if err != nil {
+				klog.Warning(err)
+				return err
+			}
+			return nil
 		},
 	}
 	cmd = helpers.DisableHelp(cmd)

--- a/kubectl-minio/cmd/tenant-info.go
+++ b/kubectl-minio/cmd/tenant-info.go
@@ -29,6 +29,7 @@ import (
 	"github.com/minio/kubectl-minio/cmd/helpers"
 	"github.com/minio/minio/pkg/color"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/minio/operator/pkg/resources/services"
@@ -58,7 +59,13 @@ func newTenantInfoCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			if err := c.validate(args); err != nil {
 				return err
 			}
-			return c.run(args)
+			klog.Info("info tenant command started")
+			err := c.run(args)
+			if err != nil {
+				klog.Warning(err)
+				return err
+			}
+			return nil
 		},
 	}
 	cmd = helpers.DisableHelp(cmd)

--- a/kubectl-minio/cmd/tenant-upgrade.go
+++ b/kubectl-minio/cmd/tenant-upgrade.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -60,7 +61,13 @@ func newTenantUpgradeCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			if err := c.validate(args); err != nil {
 				return err
 			}
-			return c.run()
+			klog.Info("upgrade tenant command started")
+			err := c.run()
+			if err != nil {
+				klog.Warning(err)
+				return err
+			}
+			return nil
 		},
 	}
 	cmd = helpers.DisableHelp(cmd)

--- a/kubectl-minio/go.mod
+++ b/kubectl-minio/go.mod
@@ -22,5 +22,6 @@ require (
 	k8s.io/apimachinery v0.20.2
 	k8s.io/cli-runtime v0.20.2
 	k8s.io/client-go v0.20.2
+	k8s.io/klog/v2 v2.4.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/kubectl-minio/main.go
+++ b/kubectl-minio/main.go
@@ -21,12 +21,25 @@ package main
 import (
 	"os"
 
+	"flag"
+
 	"github.com/minio/kubectl-minio/cmd"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
 )
 
 func main() {
+	// klog init
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "false")
+	flag.Set("log_file", "logs.log")
+	flag.Parse()
+
 	if err := cmd.NewCmdMinIO(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}).Execute(); err != nil {
+		// make sure we flush before exiting
+		klog.Flush()
 		os.Exit(1)
 	}
+	// make sure we flush before exiting
+	klog.Flush()
 }


### PR DESCRIPTION
…reation

Fixes https://github.com/minio/operator/issues/473

Operator service was not being deleted on `kubectl-minio delete` also change to not returning the error
when resource already exist on `init` command.

Also on deletion, skip if item was not found since it is not there already.


**Note**:
This also brings the discussion if whether we should just logg instead of returning any other type of errors on deletion
as well as if we should have a defer function during creation to delete items created if something failed during `init` command.

Test:
To test:
1. Build  operator locally like :
```
 make build TAG="minio/operator:test" &&  kind load docker-image minio/operator:test
```
2. Build plugin locally like
```
cd kubectl-minio && go build
```
3.and run :
```
 kubectl create ns minio-operator && ./kubectl-minio init -n minio-operator --image=minio/operator:test
```
4. delete plugin:
```
./kubectl-minio delete
```
By then all resources including `Service` operator should be deleted.
5. Create again:
```
./kubectl-minio init -n minio-operator --image=minio/operator:test
```
Plugin should be generated with no errors
6. Create again2:
```
./kubectl-minio init -n minio-operator --image=minio/operator:test
```
plugin should just return skipped items during creation:
```
MinIO Operator Namespace minio-operator: created
CustomResourceDefinition tenants.minio.min.io: already present, skipped
ClusterRole minio-operator-role: already present, skipped
ServiceAccount minio-operator: already present, skipped
ClusterRoleBinding minio-operator-binding: already present, skipped
MinIO Operator Service operator: already present, skipped
MinIO Operator Deployment minio-operator: already present, skipped
serviceaccounts "console-sa" already exists, skipped
clusterroles.rbac.authorization.k8s.io "console-sa-role" already exists, skipped
clusterrolebindings.rbac.authorization.k8s.io "console-sa-binding" already exists, skipped
configmaps "console-env" already exists, skipped
services "console" already exists, skipped
deployments.apps "console" already exists, skipped
MinIO Console Deployment: created
-----------------

To open Operator UI, start a port forward using this command:

kubectl minio proxy

-----------------
```