### PR TITLE
Update tls.md

### DIFF
--- a/docs/tls.md
+++ b/docs/tls.md
@@ -81,5 +81,5 @@ Finally configure MinIO to use the newly created TLS certificate:
 ```yaml
   externalCertSecret:
     - name: tls-minio
-      type: cert-manager.io/v1alpha2
+      type: kubernetes.io/tls
 ```


### PR DESCRIPTION
fixed wrong externalCertSecret type in tls.md sample from `cert-manager.io/v1alpha2` to `kubernetes.io/tls`