### PR TITLE
Console deployment should have port 9443

### DIFF
--- a/helm/minio-operator/templates/console-deployment.yaml
+++ b/helm/minio-operator/templates/console-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           ports:
           - containerPort: 9090
             name: http
-          - containerPort: 9433
+          - containerPort: 9443
             name: https
           args:
           - server

--- a/resources/console-ui.yaml
+++ b/resources/console-ui.yaml
@@ -164,6 +164,6 @@ spec:
         ports:
         - containerPort: 9090
           name: http
-        - containerPort: 9433
+        - containerPort: 9443
           name: https
       serviceAccountName: console-sa


### PR DESCRIPTION
the service definition is using 9443, a typo I guess?