### PR TITLE
Generate CRD docs using local code path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ regen-crd:
 
 regen-crd-docs:
 	@which crd-ref-docs 1>/dev/null || (echo "Installing crd-ref-docs" && GO111MODULE=on go get github.com/elastic/crd-ref-docs)
-	@crd-ref-docs --source-path=${GOPATH}/src/github.com/minio/operator/pkg/apis --config=docs/templates/config.yaml --renderer=asciidoctor --output-path=docs/crd.adoc --templates-dir=docs/templates/asciidoctor/
+	@crd-ref-docs --source-path=./pkg/apis/minio.min.io/v2 --config=docs/templates/config.yaml --renderer=asciidoctor --output-path=docs/crd.adoc --templates-dir=docs/templates/asciidoctor/
 
 plugin: regen-crd
 	@echo "Building 'kubectl-minio' binary"


### PR DESCRIPTION
I had some issues getting my GOPATH set up and tried pointing the CRD generator right at the v2 API files. And it worked, so we might as well make this a long-term change.

Pointing at V2 only since V1 is deprecated. In the updated CRD reference I'll explicitly point users to the 3.0.29 tag for v1 CRD docs. 

Please test this locally to ensure it works - it should have no impact on non-doc operator functionality, but it's better safe than sorry.