### PR TITLE
Update CRD Autogenerated Documentation Reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ kubectl-minio/kubectl-minio
 kubectl-minio/crds
 logsearchapi/logsearchapi
 *.log
+.vscode

--- a/docs/crd.adoc
+++ b/docs/crd.adoc
@@ -4,109 +4,23 @@
 [id="{p}-api-reference"]
 == API Reference
 
-.Packages
-- xref:{anchor_prefix}-minio-min-io-v1[$$minio.min.io/v1$$]
-- xref:{anchor_prefix}-minio-min-io-v2[$$minio.min.io/v2$$]
-
-
-[id="{anchor_prefix}-minio-min-io-v1"]
-=== minio.min.io/v1
-
-Package v1 is the v1beta1 version of the API.
-
-
-
-[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenant"]
-==== Tenant 
-
-Tenant is a specification for a MinIO resource
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantlist[$$TenantList$$]
-****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
-
-| *`scheduler`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler[$$TenantScheduler$$]__ | 
-| *`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]__ | 
-|===
-
-
-
-
-[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec"]
-==== TenantSpec 
-
-TenantSpec is the spec for a Tenant resource
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenant[$$Tenant$$]
-****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`zones`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-zone[$$Zone$$] array__ | Definition for Cluster in given MinIO cluster
-| *`image`* __string__ | Image defines the Tenant Docker image.
-| *`imagePullSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | ImagePullSecret defines the secret to be used for pull image from a private Docker image.
-| *`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ | Pod Management Policy for pod created by StatefulSet
-| *`credsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | If provided, use this secret as the credentials for Tenant resource Otherwise MinIO server creates dynamic credentials printed on MinIO server startup banner
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvar-v1-core[$$EnvVar$$]__ | If provided, use these environment variables for Tenant resource
-| *`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalCertSecret allows a user to specify one or more custom TLS certificates, and private keys. This is used for enabling TLS with SNI support on MinIO Pods.
-| *`externalClientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalClientCertSecret allows a user to specify custom CA client certificate, and private key. This is used for adding client certificates on MinIO Pods --> used for KES authentication.
-| *`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalCaCertSecret allows a user to provide additional CA certificates. This is used for Console to verify TLS connections with other applications.
-| *`mountPath`* __string__ | Mount path for MinIO volume (PV). Defaults to /export
-| *`subPath`* __string__ | Subpath inside mount path. This is the directory where MinIO stores data. Default to "" (empty)
-| *`requestAutoCert`* __boolean__ | RequestAutoCert allows user to enable Kubernetes based TLS cert generation and signing as explained here: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
-| *`s3`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features[$$S3Features$$]__ | S3 related features can be disabled or enabled such as `bucketDNS` etc.
-| *`certConfig`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig[$$CertificateConfig$$]__ | CertConfig allows users to set entries like CommonName, Organization, etc for the certificate
-| *`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ | Security Context allows user to set entries like runAsUser, privilege escalation etc.
-| *`console`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-consoleconfiguration[$$ConsoleConfiguration$$]__ | ConsoleConfiguration is for setting up minio/console for graphical user interface
-| *`kes`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]__ | KES is for setting up minio/kes as MinIO KMS
-| *`log`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig[$$LogConfig$$]__ | Log is for setting up log search
-| *`prometheus`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig[$$PrometheusConfig$$]__ | Prometheus is for setting up Prometheus metrics.
-| *`serviceAccountName`* __string__ | ServiceAccountName is the name of the ServiceAccount to use to run pods of all MinIO Pods created as a part of this Tenant.
-| *`priorityClassName`* __string__ | PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods. This is applied to MinIO pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-| *`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#pullpolicy-v1-core[$$PullPolicy$$]__ | Image pull policy. One of Always, Never, IfNotPresent. This is applied to MinIO pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-| *`sideCars`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars[$$SideCars$$]__ | SideCars a list of containers to run as sidecars along every MinIO Pod on every pool
-| *`exposeServices`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices[$$ExposeServices$$]__ | ExposeServices tells operator whether to expose the MinIO service and/or the Console Service
-|===
-
-
-[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-zone"]
-==== Zone 
-
-Zone defines the spec for a MinIO Zone
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
-****
-
-[cols="25a,75a", options="header"]
-|===
-| Field | Description
-| *`name`* __string__ | Name of the zone
-| *`servers`* __integer__ | Number of Servers in the zone
-| *`volumesPerServer`* __integer__ | Number of persistent volumes that will be attached per server
-| *`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ | VolumeClaimTemplate allows a user to specify how volumes inside a Tenant
-| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | If provided, use these requests and limit for cpu/memory resource allocation
-| *`nodeSelector`* __object (keys:string, values:string)__ | NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-| *`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core[$$Affinity$$]__ | If specified, affinity will define the pod's scheduling constraints
-| *`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core[$$Toleration$$]__ | Tolerations allows users to set entries like effect, key, operator, value.
-|===
-
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2021-03-01T04-20-55Z]
+:console-image: https://hub.docker.com/r/minio/console/tags[minio/console:v0.6.3]
+:kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.13.4]
+:prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
+:logsearch-image: https://hub.docker.com/r/minio/logsearchapi/tags[minio/logsearchapi:v4.0.2]
+:postgres-image: https://github.com/docker-library/postgres[library/postgres]
 
 
 [id="{anchor_prefix}-minio-min-io-v2"]
 === minio.min.io/v2
 
-Package v2 is the v2 version of the API.
+Package v2 - This page provides a quick automatically generated reference for the MinIO Operator `minio.min.io/v2` CRD. For more complete documentation on the MinIO Operator CRD, see https://docs.min.io/minio/k8s/reference/minio-operator-reference[MinIO Kubernetes Documentation]. +
+
+The `minio.min.io/v2` API was released with the v4.0.0 MinIO Operator. The MinIO Operator automatically converts existing tenants using the `/v1` API to `/v2`. +
+
+The `minio.min.io/v1` API is deprecated and will be removed in a future release. Update your existing MinIO Tenant object specifications to the `/v2` API. For documentation on the `v1` API, see the https://github.com/minio/operator/blob/v4.0.0/docs/crd.adoc#k8s-api-minio-min-io-v1[MinIO Operator CRD v1 reference]. +
+
 
 
 
@@ -123,156 +37,368 @@ AuditConfig defines configuration parameters for Audit (type) logs
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`diskCapacityGB`* __integer__ | DiskCapacityGB defines the disk capacity in GB available to store audit logs
+
+|*`diskCapacityGB`* __integer__ 
+|*Required* + 
+ Specify the amount of storage to request in Gigabytes (GB) for storing audit logs.
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig"]
 ==== CertificateConfig 
 
-CertificateConfig is a specification for certificate contents
+CertificateConfig (`certConfig`) defines controlling attributes associated to any TLS certificate automatically generated by the Operator as part of tenant creation. These fields have no effect if `spec.autoCert: false`.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`commonName`* __string__ | 
-| *`organizationName`* __string array__ | 
-| *`dnsNames`* __string array__ | 
+
+|*`commonName`* __string__ 
+|*Optional* + 
+ The `CommonName` or `CN` attribute to associate to automatically generated TLS certificates. +
+
+|*`organizationName`* __string array__ 
+|*Optional* + 
+ Specify one or more `OrganizationName` or `O` attributes to associate to automatically generated TLS certificates. +
+
+|*`dnsNames`* __string array__ 
+|*Optional* + 
+ Specify one or more x.509 Subject Alternative Names (SAN) to associate to automatically generated TLS certificates. MinIO Server pods use SNI to determine which certificate to respond with based on the requested hostname.
+
+|===
+
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificatestatus"]
+==== CertificateStatus 
+
+CertificateStatus keeps track of all the certificates managed by the operator
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantstatus[$$TenantStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`autoCertEnabled`* __boolean__ 
+|AutoCertEnabled registers whether we know if the tenant has autocert enabled
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-consoleconfiguration"]
 ==== ConsoleConfiguration 
 
-ConsoleConfiguration defines the specifications for Console Deployment
+ConsoleConfiguration (`console`) defines configuration of the https://github.com/minio/console[MinIO Console] deployed as part of the MinIO Tenant. The Operator automatically configures the Console for connectivity to MinIO server pods in the tenant. + 
+ For more complete documentation on this object, see the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#minio-operator-yaml-reference[MinIO Kubernetes Documentation].
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`replicas`* __integer__ | Replicas defines number of pods for KES StatefulSet.
-| *`image`* __string__ | Image defines the Tenant Console Docker image.
-| *`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#pullpolicy-v1-core[$$PullPolicy$$]__ | Image pull policy. One of Always, Never, IfNotPresent. This is applied to MinIO Console pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-| *`consoleSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | This secret provides all environment variables for KES This is a mandatory field
-| *`serviceAccountName`* __string__ | ServiceAccountName is the name of the ServiceAccount to use to run pods of all Console Pods created as a part of this Tenant.
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvar-v1-core[$$EnvVar$$]__ | If provided, use these environment variables for Console resource
-| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | If provided, use these requests and limit for cpu/memory resource allocation
-| *`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalCertSecret allows a user to provide an external certificate and private key. This is used for enabling TLS on Console and has priority over AutoCert.
-| *`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalCaCertSecret allows a user to provide additional CA certificates. This is used for Console to verify TLS connections with other applications.
-| *`annotations`* __object (keys:string, values:string)__ | If provided, use these annotations for Console Object Meta annotations
-| *`labels`* __object (keys:string, values:string)__ | If provided, use these labels for Console Object Meta labels
-| *`nodeSelector`* __object (keys:string, values:string)__ | If provided, use these nodeSelector for Console Object Meta nodeSelector
+
+|*`replicas`* __integer__ 
+|*Optional* + 
+ Specify the number of replica Console pods to deploy in the tenant. Defaults to `2`.
+
+|*`image`* __string__ 
+|*Optional* + 
+ The Docker image to use for deploying the MinIO Console. Defaults to {console-image}.+
+
+|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__ 
+|*Optional* + 
+ The pull policy for the MinIO Console Docker image. Specify one of the following: + 
+ * `Always` + 
+ * `Never` + 
+ * `IfNotPresent` (Default) + 
+ Refer to the Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+|*`consoleSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
+|*Required* + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] which contains environment variables to use for setting up the MinIO Console service. + 
+ See the https://github.com/minio/operator/blob/master/examples/console-secret.yaml[MinIO Operator `console-secret.yaml`] for an example.
+
+|*`serviceAccountName`* __string__ 
+|*Optional* + 
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO Console pods created as part of the Tenant. +
+
+|*`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core[$$EnvVar$$]__ 
+|*Optional* + 
+ Specify one or more https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core[Environment Variables] for use by the MinIO Console.
+
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
+|*Optional* + 
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+
+|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
+|*Optional* + 
+ Enables TLS with SNI support on each MinIO Console pod in the tenant. If `externalCertSecret` is omitted *and* `spec.requestAutoCert` is set to `false`, MinIO Console pods deploy *without* TLS enabled. + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret]. The MinIO Operator copies the specified certificate to every MinIO Console pod in the tenant. When the MinIO Console pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
+ Specify an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
+|*Optional* + 
+ Allows MinIO Console pods to verify client TLS certificates signed by a Certificate Authority not in the pod's trust store. + 
+ Specify one or more https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified CA files to every MinIO Console pod in the tenant. + 
+ Each element in the `externalCertSecret` array is an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the Certificate Authority files. + 
+ * - `type` - Specify `kubernetes.io/tls`. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`annotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these annotations for Console Object Meta annotations
+
+|*`labels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these labels for Console Object Meta labels
+
+|*`nodeSelector`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ The filter for the Operator to apply when selecting which nodes on which to deploy MinIO Console pods. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__ 
+|*Optional* + 
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO Console pods.
+
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
+|*Optional* + 
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of MinIO Console pods. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices"]
 ==== ExposeServices 
 
-ExposeServices tells operator whether to expose the services for MinIO and Console
+ExposeServices (`exposeServices`) defines the exposure of the MinIO object storage and Console services. +
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`minio`* __boolean__ | MinIO tells operator whether to expose the MinIO service
-| *`console`* __boolean__ | Console tells operator whether to expose the Console Service
+
+|*`minio`* __boolean__ 
+|*Optional* + 
+ Directs the Operator to expose the MinIO service. Defaults to `true`. +
+
+|*`console`* __boolean__ 
+|*Optional* + 
+ Directs the Operator to expose the MinIO Console service. Defaults to `true`. +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig"]
 ==== KESConfig 
 
-KESConfig defines the specifications for KES StatefulSet
+KESConfig (`kes`) defines the configuration of the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) StatefulSet deployed as part of the MinIO Tenant. KES supports Server-Side Encryption of objects using an external Key Management Service (KMS). +
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`replicas`* __integer__ | Replicas defines number of pods for KES StatefulSet.
-| *`image`* __string__ | Image defines the Tenant KES Docker image.
-| *`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#pullpolicy-v1-core[$$PullPolicy$$]__ | Image pull policy. One of Always, Never, IfNotPresent. This is applied to KES pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-| *`serviceAccountName`* __string__ | ServiceAccountName is the name of the ServiceAccount to use to run pods of all KES Pods created as a part of this Tenant.
-| *`kesSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | This kesSecret serves as the configuration for KES This is a mandatory field
-| *`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalCertSecret allows a user to specify custom CA certificate, and private key for group replication SSL.
-| *`clientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ClientCertSecret allows a user to specify a custom root certificate, client certificate and client private key. This is used for adding client certificates on KES --> used for KES authentication against Vault or other KMS that supports mTLS.
-| *`annotations`* __object (keys:string, values:string)__ | If provided, use these annotations for KES Object Meta annotations
-| *`labels`* __object (keys:string, values:string)__ | If provided, use these labels for KES Object Meta labels
-| *`nodeSelector`* __object (keys:string, values:string)__ | If provided, use these nodeSelector for KES Object Meta nodeSelector
+
+|*`replicas`* __integer__ 
+|*Optional* + 
+ Specify the number of replica KES pods to deploy in the tenant. Defaults to `2`.
+
+|*`image`* __string__ 
+|*Optional* + 
+ The Docker image to use for deploying MinIO KES. Defaults to {kes-image}. +
+
+|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__ 
+|*Optional* + 
+ The pull policy for the MinIO Console Docker image. Specify one of the following: + 
+ * `Always` + 
+ * `Never` + 
+ * `IfNotPresent` (Default) + 
+ Refer to the Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+|*`serviceAccountName`* __string__ 
+|*Optional* + 
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
+
+|*`kesSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
+|*Required* + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] which contains environment variables to use for setting up the MinIO KES service. + 
+ See the https://github.com/minio/operator/blob/master/examples/kes-secret.yaml[MinIO Operator `console-secret.yaml`] for an example.
+
+|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
+|*Optional* + 
+ Enables TLS with SNI support on each MinIO KES pod in the tenant. If `externalCertSecret` is omitted *and* `spec.requestAutoCert` is set to `false`, MinIO KES pods deploy *without* TLS enabled. + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret]. The MinIO Operator copies the specified certificate to every MinIO Console pod in the tenant. When the MinIO Console pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
+ Specify an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`clientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
+|*Optional* + 
+ Specify a a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret] containing a custom root Certificate Authority and x.509 certificate to use for performing mTLS authentication with an external Key Management Service, such as Hashicorp Vault. + 
+ Specify an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the Certificate Authority and x.509 Certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` +
+
+|*`annotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these annotations for KES Object Meta annotations
+
+|*`labels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these labels for KES Object Meta labels
+
+|*`nodeSelector`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ The filter for the Operator to apply when selecting which nodes on which to deploy MinIO KES pods. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__ 
+|*Optional* + 
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO KES pods.
+
+|*`keyName`* __string__ 
+|*Optional* + 
+ If provided, use this as the name of the key that KES creates on the KMS backend
+
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
+|Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of MinIO KES pods. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference"]
 ==== LocalCertificateReference 
 
-LocalCertificateReference defines the spec for a local certificate
+LocalCertificateReference (`externalCertSecret`, `externalCaCertSecret`,`clientCertSecret`) contains a Kubernetes secret containing TLS certificates or Certificate Authority files for use with enabling TLS in the MinIO Tenant. +
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-consoleconfiguration[$$ConsoleConfiguration$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | 
-| *`type`* __string__ | 
+
+|*`name`* __string__ 
+|*Required* + 
+ The name of the Kubernetes secret containing the TLS certificate or Certificate Authority file. +
+
+|*`type`* __string__ 
+|*Required* + 
+ The type of Kubernetes secret. Specify `kubernetes.io/tls` +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig"]
 ==== LogConfig 
 
-LogConfig defines configuration parameters for Log feature
+LogConfig (`log`) defines the configuration of the MinIO Log Search API deployed as part of the MinIO Tenant. The Operator deploys a PostgreSQL instance as part of the tenant to support storing and querying MinIO logs. + 
+ If the tenant specification includes the `console` object, the Operator automatically configures and enables MinIO Log Search via the Console UI.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`image`* __string__ | Image defines the tenant's LogSearchAPI container image.
-| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | If provided, use these requests and limit for cpu/memory resource allocation
-| *`nodeSelector`* __object (keys:string, values:string)__ | NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-| *`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core[$$Affinity$$]__ | If specified, affinity will define the pod's scheduling constraints
-| *`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core[$$Toleration$$]__ | Tolerations allows users to set entries like effect, key, operator, value.
-| *`annotations`* __object (keys:string, values:string)__ | If provided, use these annotations for Console Object Meta annotations
-| *`labels`* __object (keys:string, values:string)__ | If provided, use these labels for Console Object Meta labels
-| *`db`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logdbconfig[$$LogDbConfig$$]__ | Db holds configuration for audit logs DB
-| *`audit`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-auditconfig[$$AuditConfig$$]__ | AuditConfig holds configuration for audit logs from MinIO
+
+|*`image`* __string__ 
+|*Optional* + 
+ The Docker image to use for deploying the MinIO Log Search API. Defaults to {logsearch-image}. +
+
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
+|*Optional* + 
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+
+|*`nodeSelector`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ The filter for the Operator to apply when selecting which nodes on which to deploy MinIO Log Search API pods. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
+|*Optional* + 
+ Specify node affinity, pod affinity, and pod anti-affinity for LogSearch API pods. +
+
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__ 
+|*Optional* + 
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO Log Search API pods.
+
+|*`annotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these annotations for Log Search Object Meta annotations
+
+|*`labels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these labels for Log Search Object Meta labels
+
+|*`db`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logdbconfig[$$LogDbConfig$$]__ 
+|*Optional* + 
+ Object specification for configuring the backing PostgreSQL database for the LogSearch API. +
+
+|*`audit`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-auditconfig[$$AuditConfig$$]__ 
+|*Required* + 
+ Object specification for configuring LogSearch API.
+
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
+|*Optional* + 
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods deployed as part of the Log Search API. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logdbconfig"]
 ==== LogDbConfig 
 
-LogDbConfig Holds all the configurations regarding the Log DB (Postgres) StatefulSet
+LogDbConfig (`db`) defines the configuration of the PostgreSQL StatefulSet deployed to support the MinIO LogSearch API. +
 
 .Appears In:
 ****
@@ -282,21 +408,58 @@ LogDbConfig Holds all the configurations regarding the Log DB (Postgres) Statefu
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`image`* __string__ | Image defines postgres DB container image.
-| *`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ | VolumeClaimTemplate allows a user to specify how volumes inside a Tenant
-| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | If provided, use these requests and limit for cpu/memory resource allocation
-| *`nodeSelector`* __object (keys:string, values:string)__ | NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-| *`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core[$$Affinity$$]__ | If specified, affinity will define the pod's scheduling constraints
-| *`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core[$$Toleration$$]__ | Tolerations allows users to set entries like effect, key, operator, value.
-| *`annotations`* __object (keys:string, values:string)__ | If provided, use these annotations for Console Object Meta annotations
-| *`labels`* __object (keys:string, values:string)__ | If provided, use these labels for Console Object Meta labels
+
+|*`image`* __string__ 
+|*Optional* + 
+ The Docker image to use for deploying PostgreSQL. Defaults to {postgres-image}. +
+
+|*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
+|*Optional* + 
+ Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the PostgreSQL pod. +
+
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
+|*Optional* + 
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits for the PostgreSQL pod.
+
+|*`nodeSelector`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ The filter for the Operator to apply when selecting which nodes on which to deploy the PostgreSQL pod. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
+|*Optional* + 
+ Specify node affinity, pod affinity, and pod anti-affinity for the PostgreSQL pods. +
+
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__ 
+|*Optional* + 
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to the PostgreSQL pods.
+
+|*`annotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these annotations for PostgreSQL Object Meta annotations
+
+|*`labels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these labels for PostgreSQL Object Meta labels
+
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
+|*Optional* + 
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of the PostgreSQL pods. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool"]
 ==== Pool 
 
-Pool defines the spec for a MinIO Pool
+Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
 
 .Appears In:
 ****
@@ -306,81 +469,243 @@ Pool defines the spec for a MinIO Pool
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | Name of the pool
-| *`servers`* __integer__ | Number of Servers in the pool
-| *`volumesPerServer`* __integer__ | Number of persistent volumes that will be attached per server
-| *`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ | VolumeClaimTemplate allows a user to specify how volumes are configured for the Pool
-| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | If provided, use these requests and limit for cpu/memory resource allocation
-| *`nodeSelector`* __object (keys:string, values:string)__ | NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-| *`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#affinity-v1-core[$$Affinity$$]__ | If specified, affinity will define the pod's scheduling constraints
-| *`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core[$$Toleration$$] array__ | Tolerations allows users to set entries like effect, key, operator, value.
+
+|*`name`* __string__ 
+|*Optional* + 
+ Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
+
+|*`servers`* __integer__ 
+|*Required* 
+ The number of MinIO server pods to deploy in the pool. The minimum value is `2`. 
+ The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+
+|*`volumesPerServer`* __integer__ 
+|*Required* + 
+ The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. + 
+ The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+
+|*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
+|*Required* + 
+ Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the MinIO tenant. +
+
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
+|*Optional* + 
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+
+|*`nodeSelector`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ The filter for the Operator to apply when selecting which nodes on which to deploy pods in the pool. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
+|*Optional* + 
+ Specify node affinity, pod affinity, and pod anti-affinity for pods in the MinIO pool. +
+
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$] array__ 
+|*Optional* + 
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to pods deployed in the MinIO pool.
+
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
+|*Optional* + 
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods in the pool. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
+
+|===
+
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstate"]
+==== PoolState (string) 
+
+PoolState represents the state of a pool
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstatus[$$PoolStatus$$]
+****
+
+
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstatus"]
+==== PoolStatus 
+
+PoolStatus keeps track of all the pools and their current state
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantstatus[$$TenantStatus$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`ssName`* __string__ 
+|
+
+|*`state`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstate[$$PoolState$$]__ 
+|
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig"]
 ==== PrometheusConfig 
 
-PrometheusConfig defines configuration for Prometheus metrics server
+PrometheusConfig (`prometheus`) defines the configuration of a Prometheus instance as part of the MinIO tenant. The Operator automatically configures the Prometheus instance to scrape and store metrics from the MinIO tenant. + 
+ The Operator deploys each Prometheus pod using the {prometheus-image} Docker image.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`diskCapacityGB`* __integer__ | DiskCapacityGB defines the disk capacity in GB available to the Prometheus server
-| *`annotations`* __object (keys:string, values:string)__ | If provided, use these annotations for Prometheus Object Meta annotations
-| *`labels`* __object (keys:string, values:string)__ | If provided, use these labels for Prometheus Object Meta labels
-| *`nodeSelector`* __object (keys:string, values:string)__ | If provided, use these nodeSelector for Prometheus Object Meta nodeSelector
-| *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | If provided, use these requests and limit for cpu/memory resource allocation
+
+|*`image`* __string__ 
+|*Optional* + 
+ Defines the Docker image to use for deploying Prometheus pods. Defaults to {prometheus-image}. +
+
+|*`sidecarimage`* __string__ 
+|*Optional* + 
+ *Deprecated in Operator v4.0.1* + 
+ Defines the Docker image to use as a sidecar for the Prometheus server. Defaults to `alpine`. + 
+ The specified Docker image *must* be the https://hub.docker.com/_/alpine[`alpine`] package. +
+
+|*`initimage`* __string__ 
+|*Optional* + 
+ *Deprecated in Operator v4.0.1* + 
+ Defines the Docker image to use as the init container for running the Prometheus server. Defaults to `busybox`. + 
+ The specified Docker image *must* be the https://hub.docker.com/_/busybox[`busybox`] package. +
+
+|*`diskCapacityGB`* __integer__ 
+|*Optional* + 
+ Specify the amount of storage to request in Gigabytes (GB) for supporting the Prometheus pod.
+
+|*`annotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these annotations for Prometheus Object Meta annotations
+
+|*`labels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, use these labels for Prometheus Object Meta labels
+
+|*`nodeSelector`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ The filter for the Operator to apply when selecting which nodes on which to deploy the Prometheus pod. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
+|*Optional* + 
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits of the Prometheus pod. +
+
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
+|*Optional* + 
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of the Prometheus pod. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features"]
 ==== S3Features 
 
-S3Features list of S3 features to enable/disable. Currently only supports BucketDNS
+S3Features (`s3`) - Object describing which S3 features to enable/disable in the MinIO Tenant. + 
+ Currently only supports `BucketDNS`
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`bucketDNS`* __boolean__ | BucketDNS if 'true' means Buckets can be accessed using `<bucket>.minio.default.svc.cluster.local`
+
+|*`bucketDNS`* __boolean__ 
+|*Optional* + 
+ Specify `true` to allow clients to access buckets using the DNS path `<bucket>.minio.default.svc.cluster.local`. Defaults to `false`.
+
+|===
+
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-servicemetadata"]
+==== ServiceMetadata 
+
+ServiceMetadata (`serviceMetadata`) defines custom labels and annotations for the MinIO Object Storage service and/or MinIO Console service. +
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`minioServiceLabels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, append these labels to the MinIO service
+
+|*`minioServiceAnnotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, append these annotations to the MinIO service
+
+|*`consoleServiceLabels`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, append these labels to the Console service
+
+|*`consoleServiceAnnotations`* __object (keys:string, values:string)__ 
+|*Optional* + 
+ If provided, append these annotations to the Console service
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars"]
 ==== SideCars 
 
-SideCars represents a list of containers that will be attached to the MinIO pods on each pool
+SideCars (`sidecars`) defines a list of containers that the Operator attaches to each MinIO server pods in the `pool`.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenantspec[$$TenantSpec$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`containers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#container-v1-core[$$Container$$] array__ | List of containers to run inside the Pod
-| *`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ | volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name. TODO: Define the behavior if a claim already exists with the same name.
-| *`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#volume-v1-core[$$Volume$$] array__ | List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+
+|*`containers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core[$$Container$$] array__ 
+|*Optional* + 
+ List of containers to run inside the Pod
+
+|*`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
+|*Optional* + 
+ volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+
+|*`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core[$$Volume$$] array__ 
+|*Optional* + 
+ List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenant"]
 ==== Tenant 
 
-Tenant is a specification for a MinIO resource
+Tenant is a https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/[Kubernetes object] describing a MinIO Tenant. +
 
 .Appears In:
 ****
@@ -390,10 +715,18 @@ Tenant is a specification for a MinIO resource
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`scheduler`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler[$$TenantScheduler$$]__ | 
-| *`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]__ | 
+|*`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta[$$ObjectMeta$$]__ 
+|Refer to Kubernetes API documentation for fields of `metadata`.
+
+
+|*`scheduler`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler[$$TenantScheduler$$]__ 
+|
+
+|*`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]__ 
+|*Required* + 
+ The root field for the MinIO Tenant object.
+
 |===
 
 
@@ -402,25 +735,30 @@ Tenant is a specification for a MinIO resource
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler"]
 ==== TenantScheduler 
 
-TenantScheduler is the spec for a Tenant scheduler
+TenantScheduler (`scheduler`) - Object describing Kubernetes Scheduler to use for deploying the MinIO Tenant.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v1-tenant[$$Tenant$$]
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenant[$$Tenant$$]
 ****
 
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`name`* __string__ | SchedulerName defines the name of scheduler to be used to schedule Tenant pods
+
+|*`name`* __string__ 
+|*Optional* + 
+ Specify the name of the https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/[Kubernetes scheduler] to be used to schedule Tenant pods
+
 |===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec"]
 ==== TenantSpec 
 
-TenantSpec is the spec for a Tenant resource
+TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. + 
+ The following parameters are specific to the `minio.min.io/v2` MinIO CRD API `spec` definition added as part of the MinIO Operator v4.0.0. + 
+ For more complete documentation on this object, see the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#minio-operator-yaml-reference[MinIO Kubernetes Documentation]. +
 
 .Appears In:
 ****
@@ -430,32 +768,145 @@ TenantSpec is the spec for a Tenant resource
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
-| *`pools`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool[$$Pool$$] array__ | Definition for Cluster in given MinIO cluster
-| *`image`* __string__ | Image defines the Tenant Docker image.
-| *`imagePullSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | ImagePullSecret defines the secret to be used for pull image from a private Docker image.
-| *`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ | Pod Management Policy for pod created by StatefulSet
-| *`credsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#localobjectreference-v1-core[$$LocalObjectReference$$]__ | If provided, use this secret as the credentials for Tenant resource Otherwise MinIO server creates dynamic credentials printed on MinIO server startup banner
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#envvar-v1-core[$$EnvVar$$] array__ | If provided, use these environment variables for Tenant resource
-| *`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ | ExternalCertSecret allows a user to provide one or more TLS certificates and private keys. This is used for enabling TLS with SNI support on MinIO server.
-| *`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalCaCertSecret allows a user to provide additional CA certificates. This is used for MinIO to verify TLS connections with other applications.
-| *`externalClientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ | ExternalClientCertSecret allows a user to specify custom CA client certificate, and private key. This is used for adding client certificates on MinIO Pods --> used for KES authentication.
-| *`mountPath`* __string__ | Mount path for MinIO volume (PV). Defaults to /export
-| *`subPath`* __string__ | Subpath inside mount path. This is the directory where MinIO stores data. Default to "" (empty)
-| *`requestAutoCert`* __boolean__ | RequestAutoCert allows user to enable Kubernetes based TLS cert generation and signing as explained here: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
-| *`s3`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features[$$S3Features$$]__ | S3 related features can be disabled or enabled such as `bucketDNS` etc.
-| *`certConfig`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig[$$CertificateConfig$$]__ | CertConfig allows users to set entries like CommonName, Organization, etc for the certificate
-| *`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ | Security Context allows user to set entries like runAsUser, privilege escalation etc.
-| *`console`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-consoleconfiguration[$$ConsoleConfiguration$$]__ | ConsoleConfiguration is for setting up minio/console for graphical user interface
-| *`kes`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]__ | KES is for setting up minio/kes as MinIO KMS
-| *`log`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig[$$LogConfig$$]__ | Log is for setting up log search
-| *`prometheus`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig[$$PrometheusConfig$$]__ | Prometheus is for setting up Prometheus metrics.
-| *`serviceAccountName`* __string__ | ServiceAccountName is the name of the ServiceAccount to use to run pods of all MinIO Pods created as a part of this Tenant.
-| *`priorityClassName`* __string__ | PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods. This is applied to MinIO pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-| *`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#pullpolicy-v1-core[$$PullPolicy$$]__ | Image pull policy. One of Always, Never, IfNotPresent. This is applied to MinIO pods only. Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
-| *`sideCars`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars[$$SideCars$$]__ | SideCars a list of containers to run as sidecars along every MinIO Pod on every pool
-| *`exposeServices`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices[$$ExposeServices$$]__ | ExposeServices tells operator whether to expose the MinIO service and/or the Console Service
-|===
 
+|*`users`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$] array__ 
+|*Optional* + 
+ An array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secrets] to use for generating MinIO users during tenant provisioning. + 
+ Each element in the array is an object consisting of a key-value pair `name: <string>`, where the `<string>` references an opaque Kubernetes secret. + 
+ Each referenced Kubernetes secret must include the following fields: + 
+ * `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user + 
+ * `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user + 
+ The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
+
+|*`pools`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool[$$Pool$$] array__ 
+|*Required* + 
+ An array of objects describing each MinIO server pool deployed in the MinIO Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. + 
+ The MinIO Tenant `spec` *must have* at least *one* element in the `pools` array. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
+
+|*`image`* __string__ 
+|*Optional* + 
+ The Docker image to use when deploying `minio` server pods. Defaults to {minio-image}. +
+
+|*`imagePullSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
+|*Optional* + 
+ Specify the secret key to use for pulling images from a private Docker repository. +
+
+|*`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ 
+|*Optional* + 
+ Pod Management Policy for pod created by StatefulSet
+
+|*`credsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
+|*Optional* + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] to use for setting the MinIO root access key and secret key. Specify the secret as `name: <secret>`. The Kubernetes secret must contain the following fields: + 
+ * `data.accesskey` - The access key for the root credentials + 
+ * `data.secretkey` - The secret key for the root credentials + 
+ The MinIO Operator automatically generates the secret along with appropriate values for the access key and secret key if this field is omitted. +
+
+|*`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core[$$EnvVar$$] array__ 
+|*Optional* + 
+ If provided, the MinIO Operator the specified environment variables when deploying the Tenant resource.
+
+|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ 
+|*Optional* + 
+ Enables TLS with SNI support on each MinIO pod in the tenant. If `externalCertSecret` is omitted *and* `requestAutoCert` is set to `false`, the MinIO Tenant deploys *without* TLS enabled. + 
+ Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
+ Each element in the `externalCertSecret` array is an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
+|*Optional* + 
+ Allows MinIO server pods to verify client TLS certificates signed by a Certificate Authority not in the pod's trust store. + 
+ Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. + 
+ Each element in the `externalCertSecret` array is an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the Certificate Authority. + 
+ * - `type` - Specify `kubernetes.io/tls`. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`externalClientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
+|*Optional* + 
+ Enables mTLS authentication between the MinIO Tenant pods and https://github.com/minio/kes[MinIO KES]. *Required* for enabling connectivity between the MinIO Tenant and MinIO KES. + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant. The secret *must* contain the following fields: + 
+ * `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * `type` - Specify `kubernetes.io/tls` + 
+ The specified certificate *must* correspond to an identity on the KES server. See the https://github.com/minio/kes/wiki/Configuration#policy-configuration[KES Wiki] for more information on KES identities. + 
+ If deploying KES with the MinIO Operator, include the hash of the certificate as part of the <<k8s-api-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig,`kes`>> object specification. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`mountPath`* __string__ 
+|*Optional* + 
+ Mount path for MinIO volume (PV). Defaults to `/export`
+
+|*`subPath`* __string__ 
+|*Optional* + 
+ Subpath inside mount path. This is the directory where MinIO stores data. Default to `""`` (empty)
+
+|*`requestAutoCert`* __boolean__ 
+|*Optional* + 
+ Enables using https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/[Kubernetes-based TLS certificate generation] and signing for pods and services in the MinIO Tenant. + 
+ * Specify `true` to explicitly enable automatic certificate generate (Default). + 
+ * Specify `false` to disable automatic certificate generation. + 
+ If `requestAutoCert` is set to `false` *and* `externalCertSecret` is omitted, the MinIO Tenant deploys *without* TLS enabled. 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+
+|*`s3`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features[$$S3Features$$]__ 
+|*Optional* + 
+ S3 related features can be disabled or enabled such as `bucketDNS` etc.
+
+|*`certConfig`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig[$$CertificateConfig$$]__ 
+|*Optional* + 
+ Enables setting the `CommonName`, `Organization`, and `dnsName` attributes for all TLS certificates automatically generated by the Operator. Configuring this object has no effect if `requestAutoCert` is `false`. +
+
+|*`console`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-consoleconfiguration[$$ConsoleConfiguration$$]__ 
+|*Optional* + 
+ Directs the MinIO Operator to deploy the https://github.com/minio/console[MinIO Console] using the specified configuration. The MinIO Console is a first-party graphical user interface for performing administration on the MinIO Tenant. +
+
+|*`kes`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]__ 
+|*Optional* + 
+ Directs the MinIO Operator to deploy the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) using the specified configuration. The MinIO KES supports performing server-side encryption of objects on the MiNIO Tenant. +
+
+|*`log`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig[$$LogConfig$$]__ 
+|*Optional* + 
+ Directs the MinIO Operator to deploy and configure the MinIO Log Search API. The Operator deploys a PostgreSQL instance as part of the tenant to support storing and querying MinIO logs. + 
+ If the tenant spec includes the `console` configuration, the Operator automatically configures and enables MinIO log search via the Console UI. +
+
+|*`prometheus`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig[$$PrometheusConfig$$]__ 
+|*Optional* + 
+ Directs the MinIO Operator to deploy and configure Prometheus for collecting tenant metrics. + 
+ For example, `minio.<namespace>.svc.<cluster-domain>.<example>/minio/v2/metrics/cluster`. The specific DNS name for the service depends on your Kubernetes cluster configuration. See the Kubernetes documentation on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/[DNS for Services and Pods] for more information.
+
+|*`serviceAccountName`* __string__ 
+|*Optional* + 
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO pods created as part of the Tenant. +
+
+|*`priorityClassName`* __string__ 
+|*Optional* + 
+ Indicates the Pod priority and therefore importance of a Pod relative to other Pods in the cluster. This is applied to MinIO pods only. + 
+ Refer Kubernetes https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[Priority Class documentation] for more complete documentation.
+
+|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__ 
+|*Optional* + 
+ The pull policy for the MinIO Docker image. Specify one of the following: + 
+ * `Always` + 
+ * `Never` + 
+ * `IfNotPresent` (Default) + 
+ Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+|*`sideCars`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars[$$SideCars$$]__ 
+|*Optional* + 
+ A list of containers to run as sidecars along every MinIO Pod deployed in the tenant.
+
+|*`exposeServices`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices[$$ExposeServices$$]__ 
+|*Optional* + 
+ Directs the Operator to expose the MinIO and/or Console services. +
+
+|*`serviceMetadata`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-servicemetadata[$$ServiceMetadata$$]__ 
+|*Optional* + 
+ Specify custom labels and annotations to append to the MinIO service and/or Console service.
+
+|===
 
 
 

--- a/docs/templates/asciidoctor/gv_list.tpl
+++ b/docs/templates/asciidoctor/gv_list.tpl
@@ -7,10 +7,12 @@
 [id="{p}-api-reference"]
 == API Reference
 
-.Packages
-{{- range $groupVersions }}
-- {{ asciidocRenderGVLink . }}
-{{- end }}
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2021-03-01T04-20-55Z]
+:console-image: https://hub.docker.com/r/minio/console/tags[minio/console:v0.6.3]
+:kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.13.4]
+:prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
+:logsearch-image: https://hub.docker.com/r/minio/logsearchapi/tags[minio/logsearchapi:v4.0.2]
+:postgres-image: https://github.com/docker-library/postgres[library/postgres]
 
 {{ range $groupVersions }}
 {{ template "gvDetails" . }}

--- a/docs/templates/asciidoctor/type.tpl
+++ b/docs/templates/asciidoctor/type.tpl
@@ -20,13 +20,20 @@
 [cols="25a,75a", options="header"]
 |===
 | Field | Description
+
 {{ if $type.GVK -}}
-| *`apiVersion`* __string__ | `{{ $type.GVK.Group }}/{{ $type.GVK.Version }}`
-| *`kind`* __string__ | `{{ $type.GVK.Kind }}`
+|*`apiVersion`* __string__ 
+|`{{ $type.GVK.Group }}/{{ $type.GVK.Version }}`
+
+|*`kind`* __string__ 
+|`{{ $type.GVK.Kind }}`
+
 {{ end -}}
 
 {{ range $type.Members -}}
-| *`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ | {{ template "type_members" . }}
+|*`{{ .Name  }}`* __{{ asciidocRenderType .Type }}__ 
+|{{ template "type_members" . }}
+
 {{ end -}}
 |===
 {{ end -}}

--- a/docs/templates/config.yaml
+++ b/docs/templates/config.yaml
@@ -5,4 +5,4 @@ processor:
     - "TypeMeta$"
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
-  kubernetesVersion: 1.17
+  kubernetesVersion: 1.19

--- a/pkg/apis/minio.min.io/v2/doc.go
+++ b/pkg/apis/minio.min.io/v2/doc.go
@@ -18,7 +18,13 @@
 // +k8s:deepcopy-gen=package,register
 // go:generate controller-gen crd:trivialVersions=true paths=. output:dir=.
 
-// Package v2 is the v2 version of the API.
+// Package v2 - This page provides a quick automatically generated reference for the MinIO Operator `minio.min.io/v2` CRD. For more complete documentation on the MinIO Operator CRD, see https://docs.min.io/minio/k8s/reference/minio-operator-reference[MinIO Kubernetes Documentation]. +
+//
+// The `minio.min.io/v2` API was released with the v4.0.0 MinIO Operator. The MinIO Operator automatically converts existing tenants using the `/v1` API to `/v2`. +
+//
+// The `minio.min.io/v1` API is deprecated and will be removed in a future release. Update your existing MinIO Tenant object specifications to the `/v2` API. For documentation on the `v1` API, see the https://github.com/minio/operator/blob/v4.0.0/docs/crd.adoc#k8s-api-minio-min-io-v1[MinIO Operator CRD v1 reference]. +
+//
+//
 // +groupName=minio.min.io
 // +versionName=v2
 package v2


### PR DESCRIPTION
# Goals

- Update the CRD comment reference in `types.go` to be more descriptive of what each field is, how to use it, etc.
- Include links to the "Full" MinIO K8s documentation where appropriate
- Include links to examples where appropriate (some temporary until full K8s docs are more mature)
- Remove v1 API reference and prominently mark it as 'deprecated'. 

# Non Goals
- Fix the Go CommentBody behavior to support more asciidoc syntax
- Provide complete examples for each section
- Modify the CRD code itself in any meaningful user-impacting way.

There's a lot here, so let me know if there are any questions. One big note is I had to make a few guesses as to what fields are Optional or Required based on our existing examples and what I could glean from the code. Leave a comment for any field where I've made a mistake on that part.

One note - the `gv_list.tpl` file now contains some variables for the Docker images used by our various properties. It was easier to define them in a single place so we can update the images as we go along from a single (much smaller) file. 