### PR TITLE
Add support for cluster domain and namespace to watch

### DIFF
--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -24,6 +24,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          env:
+          - name: CLUSTER_DOMAIN
+            value: {{ .Values.operator.clusterDomain }}
+          - name: WATCHED_NAMESPACE
+            value: {{ .Values.operator.nsToWatch }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
           securityContext:

--- a/helm/minio-operator/values.yaml
+++ b/helm/minio-operator/values.yaml
@@ -1,6 +1,8 @@
 # Default values for minio-operator.
 
 operator:
+  clusterDomain: "cluster.test"
+  nsToWatch: "hello"
   image:
     repository: minio/operator
     tag: v4.0.2


### PR DESCRIPTION
This PR adds support for Operator environment variables
CLUSTER_DOMAIN & WATCHED_NAMESPACE to be set via
helm values.yaml file.