### PR TITLE
Add anti-affinity to Tenants

### DIFF
--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -103,6 +103,15 @@ spec:
       #           values:
       #           - hostname1
       #           - hostname2
+      #   podAntiAffinity:
+      #     requiredDuringSchedulingIgnoredDuringExecution:
+      #     - labelSelector:
+      #         matchExpressions:
+      #         - key: app
+      #           operator: In
+      #           values:
+      #           - store
+      #       topologyKey: "kubernetes.io/hostname" 
 
       ## Configure resource requests and limits for MinIO containers
       # resources:

--- a/kubectl-minio/README.md
+++ b/kubectl-minio/README.md
@@ -43,7 +43,7 @@ Options:
 
 Command: `kubectl minio tenant create TENANT_NAME --servers SERVERS --volumes TOTAL_VOLUMES --capacity TOTAL_RAW_CAPACITY [options]`
 
-Creates a MinIO Tenant based on the passed values.
+Creates a MinIO Tenant based on the passed values. Please note that plugin adds `anti-affinity` rules to the MinIO Tenant pods to ensure multiple pods don't end up on the same physical node. To disable this, use the `-enable-host-sharing` flag during tenant creation.
 
 example: `kubectl minio tenant create tenant1 --servers 4 --volumes 16 --capacity 16Ti`
 

--- a/kubectl-minio/cmd/resources/tenant.go
+++ b/kubectl-minio/cmd/resources/tenant.go
@@ -43,6 +43,7 @@ type TenantOptions struct {
 	ConsoleSecret   string
 	DisableTLS      bool
 	ImagePullSecret string
+	DisableAntiAffinity    bool
 }
 
 // Validate Tenant Options
@@ -138,7 +139,7 @@ func NewTenant(opts *TenantOptions) (*miniov2.Tenant, error) {
 			CredsSecret: &v1.LocalObjectReference{
 				Name: opts.SecretName,
 			},
-			Pools:           []miniov2.Pool{Pool(opts.Servers, volumesPerServer, *capacityPerVolume, opts.StorageClass)},
+			Pools:           []miniov2.Pool{Pool(opts, volumesPerServer, *capacityPerVolume)},
 			RequestAutoCert: &autoCert,
 			CertConfig: &miniov2.CertificateConfig{
 				CommonName:       "",

--- a/kubectl-minio/cmd/tenant-create.go
+++ b/kubectl-minio/cmd/tenant-create.go
@@ -85,6 +85,7 @@ func newTenantCreateCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	f.StringVarP(&c.tenantOpts.NS, "namespace", "n", helpers.DefaultNamespace, "namespace scope for this request")
 	f.StringVarP(&c.tenantOpts.StorageClass, "storage-class", "s", helpers.DefaultStorageclass, "storage class for this MinIO tenant")
 	f.StringVarP(&c.tenantOpts.Image, "image", "i", helpers.DefaultTenantImage, "MinIO image for this tenant")
+	f.BoolVar(&c.tenantOpts.DisableAntiAffinity, "enable-host-sharing", false, "disable anti-affinity to allow pods to be co-located on a single node. Not recommended for production.")
 	f.StringVar(&c.tenantOpts.KmsSecret, "kes-config", "", "name of secret with details for enabling encryption, refer example https://github.com/minio/operator/blob/master/examples/kes-secret.yaml")
 	f.BoolVarP(&c.output, "output", "o", false, "dry run this command and generate requisite yaml")
 

--- a/kubectl-minio/cmd/tenant-expand.go
+++ b/kubectl-minio/cmd/tenant-expand.go
@@ -120,7 +120,7 @@ func (v *expandCmd) run() error {
 		return err
 	}
 
-	t.Spec.Pools = append(t.Spec.Pools, resources.Pool(v.tenantOpts.Servers, volumesPerServer, *capacityPerVolume, v.tenantOpts.StorageClass))
+	t.Spec.Pools = append(t.Spec.Pools, resources.Pool(&v.tenantOpts, volumesPerServer, *capacityPerVolume))
 	expandedCapacity := helpers.TotalCapacity(*t)
 	if !v.output {
 		fmt.Printf(color.Bold(fmt.Sprintf("\nExpanding Tenant '%s/%s' from %s to %s\n\n", t.ObjectMeta.Name, t.ObjectMeta.Namespace, currentCapacity, expandedCapacity)))


### PR DESCRIPTION
This PR adds a flag called --enable-host-sharing to the
kubectl plugin.

With this change, the plugin will add anti-affinity
rules to the tenant by default. To disable this, set this flag
to false.