### PR TITLE
Fix: Empty env should not be included

### DIFF
--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -24,11 +24,17 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          {{- if or .Values.operator.clusterDomain .Values.operator.nsToWatch }}
           env:
-          - name: CLUSTER_DOMAIN
-            value: {{ .Values.operator.clusterDomain }}
-          - name: WATCHED_NAMESPACE
-            value: {{ .Values.operator.nsToWatch }}
+            {{- if .Values.operator.clusterDomain }}
+            - name: CLUSTER_DOMAIN
+              value: {{ .Values.operator.clusterDomain }}
+            {{- end }}
+            {{- if .Values.operator.nsToWatch }}
+            - name: WATCHED_NAMESPACE
+              value: {{ .Values.operator.nsToWatch }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
           securityContext:


### PR DESCRIPTION
os.LookupEnv()
LookupEnv retrieves the value of the environment variable named by the key.
If the variable is present in the environment the value (which may be empty) is returned and the boolean is true.