### PR TITLE
Allow user to enable or disable creation of secrets

### DIFF
--- a/helm/minio-operator/templates/console-secret.yaml
+++ b/helm/minio-operator/templates/console-secret.yaml
@@ -1,4 +1,5 @@
 {{ range .Values.tenants }}
+{{- if .console.secrets.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ data:
   CONSOLE_ACCESS_KEY: {{ .console.secrets.accessKey | b64enc }}
   ## MinIO User Secret Key (used for Console Login)
   CONSOLE_SECRET_KEY: {{ .console.secrets.secretKey | b64enc}}
+{{- end }}
 {{ end }}

--- a/helm/minio-operator/templates/tenant-secret.yaml
+++ b/helm/minio-operator/templates/tenant-secret.yaml
@@ -1,4 +1,5 @@
 {{ range .Values.tenants }}
+{{- if .secrets.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,5 @@ data:
   accesskey: {{ .secrets.accessKey | b64enc }}
   ## Secret Key for MinIO Tenant
   secretkey: {{ .secrets.secretKey | b64enc }}
+{{- end }}
 {{ end }}

--- a/helm/minio-operator/values.yaml
+++ b/helm/minio-operator/values.yaml
@@ -72,6 +72,7 @@ tenants:
     subPath: /data
     # pool secrets
     secrets:
+      enabled: true
       name: minio1-secret
       accessKey: ThisIsAVeryLongPasswordForExample
       secretKey: ThisIsAVeryLongPasswordForExample
@@ -118,6 +119,7 @@ tenants:
         pullPolicy: IfNotPresent
       replicaCount: 1
       secrets:
+        enabled: true
         name: console-secret
         passphrase: ThisIsAVeryLongPasswordForExample
         salt: ThisIsAVeryLongPasswordForExample


### PR DESCRIPTION
**Feature:**
Allow the user to set the secret's `enabled` field to true or false for tenant and console secret creation. If set to `true`, the secrets will be created. If set to `false`, it is expected that the user provides and creates the secrets.
```
tenants:
  # Tenant name
  - name: minio1
    ...
    secrets:
      enabled: true
    console:
      ...
      secrets:
        enabled: true
```

**Use case:**
This is a useful feature when you want to manage the secrets in some other way (SOPS, sealed-secrets etc.) instead of having this helm chart create them for you.