### PR TITLE
Fix Kustomize at root level

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -7,5 +7,13 @@ commonAnnotations:
   operator.min.io/support: "https://subnet.min.io"
 
 resources:
-  - resources/
+  - resources/base/namespace.yaml
+  - resources/base/service-account.yaml
+  - resources/base/cluster-role.yaml
+  - resources/base/cluster-role-binding.yaml
+  - resources/base/crds/minio.min.io_tenants.yaml
+  - resources/base/service.yaml
+  - resources/base/deployment.yaml
+  - resources/base/console-ui.yaml
+
 


### PR DESCRIPTION
Fixes installing operator using `kubectl apply -k github.com/minio/operator/\?ref\=v4.0.6` which I broke via https://github.com/minio/operator/pull/548

the current problem is that `kubectl` still hips kustomize 2x https://github.com/kubernetes/kubectl/issues/818