### PR TITLE
Change Default Image Pull Policy

### DIFF
--- a/examples/tenant-tiny.yaml
+++ b/examples/tenant-tiny.yaml
@@ -181,7 +181,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.6.6
+    image: minio/console:v0.6.7
     replicas: 2
     consoleSecret:
       name: console-secret

--- a/examples/tenant-with-external-idp.yaml
+++ b/examples/tenant-with-external-idp.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   ## Registry location and Tag to download MinIO Server image
   image: minio/minio:RELEASE.2021-04-06T23-11-00Z
-  imagePullPolicy: Always
+  imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
   ## Refers to the secret object created above.

--- a/helm/minio-operator/values.yaml
+++ b/helm/minio-operator/values.yaml
@@ -22,7 +22,7 @@ operator:
 console:
   image:
     repository: minio/console
-    tag: v0.6.6
+    tag: v0.6.7
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}
@@ -114,7 +114,7 @@ tenants:
     console:
       image:
         repository: minio/console
-        tag: v0.6.6
+        tag: v0.6.7
         pullPolicy: IfNotPresent
       replicaCount: 1
       secrets:

--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -38,7 +38,7 @@ const DefaultPodManagementPolicy = appsv1.ParallelPodManagement
 const DefaultUpdateStrategy = "RollingUpdate"
 
 // DefaultImagePullPolicy specifies the policy to image pulls
-const DefaultImagePullPolicy = corev1.PullAlways
+const DefaultImagePullPolicy = corev1.PullIfNotPresent
 
 // CSRNameSuffix specifies the suffix added to Tenant name to create a CSR
 const CSRNameSuffix = "-csr"

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -41,7 +41,7 @@ const DefaultPodManagementPolicy = appsv1.ParallelPodManagement
 const DefaultUpdateStrategy = "RollingUpdate"
 
 // DefaultImagePullPolicy specifies the policy to image pulls
-const DefaultImagePullPolicy = corev1.PullAlways
+const DefaultImagePullPolicy = corev1.PullIfNotPresent
 
 // CSRNameSuffix specifies the suffix added to Tenant name to create a CSR
 const CSRNameSuffix = "-csr"


### PR DESCRIPTION
This is to help users avoid hitting docker 100 pulls rate limit

Also updates the default Console image