### PR TITLE
Fix sync state cycling if log search image is not set

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -384,6 +384,12 @@ func (t *Tenant) EnsureDefaults() *Tenant {
 		}
 	}
 
+	if t.HasLogEnabled() {
+		if t.Spec.Log.Image == "" {
+			t.Spec.Log.Image = DefaultLogSearchAPIImage
+		}
+	}
+
 	return t
 }
 


### PR DESCRIPTION
This fixes a bug on operator where if the log search image is not set then the operator would cycle on this stage forever, this is because it's set log search with an image and it defaults

Signed-off-by: Daniel Valdivia <hola@danielvaldivia.com>