### PR TITLE
Consolidate services specs. Uninstall Console if removed from definition

### DIFF
--- a/pkg/controller/cluster/console.go
+++ b/pkg/controller/cluster/console.go
@@ -320,7 +320,7 @@ func (c *Controller) checkConsoleSvc(ctx context.Context, tenant *miniov2.Tenant
 		consoleSvc.ObjectMeta.Annotations = expectedSvc.ObjectMeta.Annotations
 		consoleSvc.ObjectMeta.Labels = expectedSvc.ObjectMeta.Labels
 		// we can only expose the service, not un-expose it
-		if tenant.Spec.ExposeServices.Console && consoleSvc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		if tenant.Spec.ExposeServices != nil && tenant.Spec.ExposeServices.Console && consoleSvc.Spec.Type != v1.ServiceTypeLoadBalancer {
 			consoleSvc.Spec.Type = v1.ServiceTypeLoadBalancer
 		}
 		_, err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Update(ctx, consoleSvc, metav1.UpdateOptions{})

--- a/pkg/controller/cluster/console.go
+++ b/pkg/controller/cluster/console.go
@@ -25,6 +25,15 @@ import (
 	"encoding/pem"
 	"errors"
 
+	"github.com/minio/madmin-go"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/minio/operator/pkg/resources/services"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/minio/operator/pkg/resources/deployments"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -34,6 +43,127 @@ import (
 
 	"k8s.io/klog/v2"
 )
+
+// checkConsoleStatus checks for the current status of console and it's service
+func (c *Controller) checkConsoleStatus(ctx context.Context, tenant *miniov2.Tenant, totalReplicas int32, adminClnt *madmin.AdminClient, cOpts metav1.CreateOptions, uOpts metav1.UpdateOptions, nsName types.NamespacedName) error {
+	if tenant.HasConsoleEnabled() {
+		// Get the Deployment with the name specified in MirrorInstace.spec
+		consoleDeployment, err := c.deploymentLister.Deployments(tenant.Namespace).Get(tenant.ConsoleDeploymentName())
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+			var userCredentials []*v1.Secret
+			if tenant.Spec.Users != nil {
+				for _, credential := range tenant.Spec.Users {
+					credentialSecret, sErr := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, credential.Name, metav1.GetOptions{})
+					if sErr == nil && credentialSecret != nil {
+						userCredentials = append(userCredentials, credentialSecret)
+					}
+				}
+			}
+			if tenant.HasCredsSecret() && tenant.HasConsoleSecret() {
+				consoleSecretName := tenant.Spec.Console.ConsoleSecret.Name
+				consoleSecret, sErr := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, consoleSecretName, metav1.GetOptions{})
+				if sErr == nil && consoleSecret != nil {
+					_, accessKeyExist := consoleSecret.Data["CONSOLE_ACCESS_KEY"]
+					_, secretKeyExist := consoleSecret.Data["CONSOLE_SECRET_KEY"]
+					if accessKeyExist && secretKeyExist {
+						userCredentials = append(userCredentials, consoleSecret)
+					}
+				} else {
+					// just log the error
+					klog.Info(sErr)
+				}
+			}
+			if len(userCredentials) == 0 {
+				msg := "Please set the credentials"
+				klog.V(2).Infof(msg)
+				if _, terr := c.updateTenantStatus(ctx, tenant, msg, totalReplicas); terr != nil {
+					return err
+				}
+				// return nil so we don't re-queue this work item
+				return err
+			}
+			// Make sure that MinIO is up and running to enable MinIO console user.
+			if !tenant.MinIOHealthCheck() {
+				if _, err = c.updateTenantStatus(ctx, tenant, StatusWaitingForReadyState, totalReplicas); err != nil {
+					return err
+				}
+				return err
+			}
+
+			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusProvisioningConsoleDeployment, totalReplicas); err != nil {
+				return err
+			}
+
+			skipCreateConsoleUser := false
+			// If Console is deployed with the CONSOLE_LDAP_ENABLED="on" configuration that means MinIO is running with LDAP enabled
+			// and we need to skip the console user creation
+			for _, env := range tenant.GetConsoleEnvVars() {
+				if env.Name == "CONSOLE_LDAP_ENABLED" && env.Value == "on" {
+					skipCreateConsoleUser = true
+					break
+				}
+			}
+
+			if pErr := tenant.CreateConsoleUser(adminClnt, userCredentials, skipCreateConsoleUser); pErr != nil {
+				klog.V(2).Infof(pErr.Error())
+				return err
+			}
+
+			// Create Console Deployment
+			consoleDeployment = deployments.NewConsole(tenant)
+			_, err = c.kubeClientSet.AppsV1().Deployments(tenant.Namespace).Create(ctx, consoleDeployment, cOpts)
+			if err != nil {
+				klog.V(2).Infof(err.Error())
+				return err
+			}
+		} else {
+
+			// Verify if this console deployment matches the spec on the tenant (resources, affinity, sidecars, etc)
+			consoleDeploymentMatchesSpec, err := consoleDeploymentMatchesSpec(tenant, consoleDeployment)
+			if err != nil {
+				return err
+			}
+
+			// if the console deployment doesn't match the spec
+			if !consoleDeploymentMatchesSpec {
+				if tenant, err = c.updateTenantStatus(ctx, tenant, StatusUpdatingConsole, totalReplicas); err != nil {
+					return err
+				}
+				consoleDeployment = deployments.NewConsole(tenant)
+				if _, err = c.kubeClientSet.AppsV1().Deployments(tenant.Namespace).Update(ctx, consoleDeployment, uOpts); err != nil {
+					return err
+				}
+			}
+		}
+
+		err = c.checkConsoleSvc(ctx, tenant, nsName)
+		if err != nil {
+			klog.V(2).Infof("error consolidating console service: %s", err.Error())
+			return err
+		}
+
+	} else {
+		// disable console and service if they exists
+		_, err := c.serviceLister.Services(tenant.Namespace).Get(tenant.ConsoleCIServiceName())
+		if err == nil {
+			err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Delete(ctx, tenant.ConsoleCIServiceName(), metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+		_, err = c.deploymentLister.Deployments(tenant.Namespace).Get(tenant.ConsoleDeploymentName())
+		if err == nil {
+			err = c.kubeClientSet.AppsV1().Deployments(tenant.Namespace).Delete(ctx, tenant.ConsoleDeploymentName(), metav1.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
 
 func generateConsoleCryptoData(tenant *miniov2.Tenant) ([]byte, []byte, error) {
 	privateKey, err := newPrivateKey(miniov2.DefaultEllipticCurve)
@@ -122,4 +252,64 @@ func consoleDeploymentMatchesSpec(tenant *miniov2.Tenant, consoleDeployment *app
 		return false, nil
 	}
 	return true, nil
+}
+
+func (c *Controller) checkAndCreateConsoleCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
+	if _, err := c.certClient.CertificateSigningRequests().Get(ctx, tenant.ConsoleCSRName(), metav1.GetOptions{}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusWaitingConsoleCert, 0); err != nil {
+				return err
+			}
+			klog.V(2).Infof("Creating a new Certificate Signing Request for Console Server Certs, cluster %q", nsName)
+			if err = c.createConsoleTLSCSR(ctx, tenant); err != nil {
+				return err
+			}
+			// we want to re-queue this tenant so we can re-check for the console certificate
+			return errors.New("waiting for console cert")
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) checkConsoleSvc(ctx context.Context, tenant *miniov2.Tenant, nsName types.NamespacedName) error {
+	// check the status of the console service
+	consoleSvc, err := c.serviceLister.Services(tenant.Namespace).Get(tenant.ConsoleCIServiceName())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			klog.V(2).Infof("Creating a new Cluster IP Service for console %q", nsName)
+			// Create the clusterIP service for the Tenant
+			consoleSvc = services.NewClusterIPForConsole(tenant)
+			consoleSvc, err = c.kubeClientSet.CoreV1().Services(consoleSvc.Namespace).Create(ctx, consoleSvc, metav1.CreateOptions{})
+			if err != nil {
+				klog.V(2).Infof(err.Error())
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	consoleSvcMatchesSpec := true
+	// compare any other change from what is specified on the tenant
+	expectedSvc := services.NewClusterIPForConsole(tenant)
+	if !equality.Semantic.DeepDerivative(expectedSvc.Spec, consoleSvc.Spec) {
+		// some field set by the operator has changed
+		consoleSvcMatchesSpec = false
+	}
+
+	// check the specification of the Console ClusterIP service
+	if !consoleSvcMatchesSpec {
+		consoleSvc.ObjectMeta.Annotations = expectedSvc.ObjectMeta.Annotations
+		consoleSvc.ObjectMeta.Labels = expectedSvc.ObjectMeta.Labels
+		// we can only expose the service, not un-expose it
+		if tenant.Spec.ExposeServices.Console && consoleSvc.Spec.Type != v1.ServiceTypeLoadBalancer {
+			consoleSvc.Spec.Type = v1.ServiceTypeLoadBalancer
+		}
+		_, err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Update(ctx, consoleSvc, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -773,8 +773,6 @@ func (c *Controller) syncHandler(key string) error {
 	uOpts := metav1.UpdateOptions{}
 	gOpts := metav1.GetOptions{}
 
-	var consoleDeployment *appsv1.Deployment
-
 	// Convert the namespace/name string into a distinct namespace and name
 	if key == "" {
 		runtime.HandleError(fmt.Errorf("Invalid resource key: %s", key))
@@ -850,23 +848,11 @@ func (c *Controller) syncHandler(key string) error {
 		}
 	}
 
-	// Handle the Internal ClusterIP Service for Tenant
-	svc, err := c.serviceLister.Services(tenant.Namespace).Get(tenant.MinIOCIServiceName())
+	// validate the minio service
+	err = c.checkMinIOSvc(ctx, tenant, nsName)
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusProvisioningCIService, 0); err != nil {
-				return err
-			}
-			klog.V(2).Infof("Creating a new Cluster IP Service for cluster %q", nsName)
-			// Create the clusterIP service for the Tenant
-			svc = services.NewClusterIPForMinIO(tenant)
-			_, err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Create(ctx, svc, cOpts)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
+		klog.V(2).Infof("Error when consolidating tenant service: %v", err)
+		return err
 	}
 
 	// Handle the Internal Headless Service for Tenant StatefulSet
@@ -1253,104 +1239,11 @@ func (c *Controller) syncHandler(key string) error {
 
 	}
 
-	if tenant.HasConsoleEnabled() {
-		// Get the Deployment with the name specified in MirrorInstace.spec
-		if consoleDeployment, err = c.deploymentLister.Deployments(tenant.Namespace).Get(tenant.ConsoleDeploymentName()); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				return err
-			}
-			var userCredentials []*v1.Secret
-			if tenant.Spec.Users != nil {
-				for _, credential := range tenant.Spec.Users {
-					credentialSecret, sErr := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, credential.Name, gOpts)
-					if sErr == nil && credentialSecret != nil {
-						userCredentials = append(userCredentials, credentialSecret)
-					}
-				}
-			}
-			if tenant.HasCredsSecret() && tenant.HasConsoleSecret() {
-				consoleSecretName := tenant.Spec.Console.ConsoleSecret.Name
-				consoleSecret, sErr := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, consoleSecretName, gOpts)
-				if sErr == nil && consoleSecret != nil {
-					_, accessKeyExist := consoleSecret.Data["CONSOLE_ACCESS_KEY"]
-					_, secretKeyExist := consoleSecret.Data["CONSOLE_SECRET_KEY"]
-					if accessKeyExist && secretKeyExist {
-						userCredentials = append(userCredentials, consoleSecret)
-					}
-				} else {
-					// just log the error
-					klog.Info(sErr)
-				}
-			}
-			if len(userCredentials) == 0 {
-				msg := "Please set the credentials"
-				klog.V(2).Infof(msg)
-				if _, terr := c.updateTenantStatus(ctx, tenant, msg, totalReplicas); terr != nil {
-					return err
-				}
-				// return nil so we don't re-queue this work item
-				return nil
-			}
-			// Make sure that MinIO is up and running to enable MinIO console user.
-			if !tenant.MinIOHealthCheck() {
-				if _, err = c.updateTenantStatus(ctx, tenant, StatusWaitingForReadyState, totalReplicas); err != nil {
-					return err
-				}
-				return ErrMinIONotReady
-			}
-
-			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusProvisioningConsoleDeployment, totalReplicas); err != nil {
-				return err
-			}
-
-			skipCreateConsoleUser := false
-			// If Console is deployed with the CONSOLE_LDAP_ENABLED="on" configuration that means MinIO is running with LDAP enabled
-			// and we need to skip the console user creation
-			for _, env := range tenant.GetConsoleEnvVars() {
-				if env.Name == "CONSOLE_LDAP_ENABLED" && env.Value == "on" {
-					skipCreateConsoleUser = true
-					break
-				}
-			}
-
-			if pErr := tenant.CreateConsoleUser(adminClnt, userCredentials, skipCreateConsoleUser); pErr != nil {
-				klog.V(2).Infof(pErr.Error())
-				return pErr
-			}
-
-			// Create Console Deployment
-			consoleDeployment = deployments.NewConsole(tenant)
-			_, err = c.kubeClientSet.AppsV1().Deployments(tenant.Namespace).Create(ctx, consoleDeployment, cOpts)
-			if err != nil {
-				klog.V(2).Infof(err.Error())
-				return err
-			}
-			// Create Console service
-			consoleSvc := services.NewClusterIPForConsole(tenant)
-			_, err = c.kubeClientSet.CoreV1().Services(svc.Namespace).Create(ctx, consoleSvc, cOpts)
-			if err != nil {
-				klog.V(2).Infof(err.Error())
-				return err
-			}
-		} else {
-
-			// Verify if this console deployment matches the spec on the tenant (resources, affinity, sidecars, etc)
-			consoleDeploymentMatchesSpec, err := consoleDeploymentMatchesSpec(tenant, consoleDeployment)
-			if err != nil {
-				return err
-			}
-
-			// if the console deployment doesn't match the spec
-			if !consoleDeploymentMatchesSpec {
-				if tenant, err = c.updateTenantStatus(ctx, tenant, StatusUpdatingConsole, totalReplicas); err != nil {
-					return err
-				}
-				consoleDeployment = deployments.NewConsole(tenant)
-				if _, err = c.kubeClientSet.AppsV1().Deployments(tenant.Namespace).Update(ctx, consoleDeployment, uOpts); err != nil {
-					return err
-				}
-			}
-		}
+	// Check whether console is enabled or if it should be removed and the state of it's service
+	err = c.checkConsoleStatus(ctx, tenant, totalReplicas, adminClnt, cOpts, uOpts, nsName)
+	if err != nil {
+		klog.V(2).Infof("Error checking console state %v", err)
+		return err
 	}
 
 	if tenant.HasKESEnabled() && tenant.TLS() {
@@ -1639,24 +1532,6 @@ func (c *Controller) handleObject(obj interface{}) {
 		c.enqueueTenant(tenant)
 		return
 	}
-}
-
-func (c *Controller) checkAndCreateConsoleCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
-	if _, err := c.certClient.CertificateSigningRequests().Get(ctx, tenant.ConsoleCSRName(), metav1.GetOptions{}); err != nil {
-		if k8serrors.IsNotFound(err) {
-			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusWaitingConsoleCert, 0); err != nil {
-				return err
-			}
-			klog.V(2).Infof("Creating a new Certificate Signing Request for Console Server Certs, cluster %q", nsName)
-			if err = c.createConsoleTLSCSR(ctx, tenant); err != nil {
-				return err
-			}
-			// we want to re-queue this tenant so we can re-check for the console certificate
-			return errors.New("waiting for console cert")
-		}
-		return err
-	}
-	return nil
 }
 
 // MinIOControllerRateLimiter is a no-arg constructor for a default rate limiter for a workqueue for our controller.

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -1007,12 +1007,6 @@ func (c *Controller) syncHandler(key string) error {
 						return err
 					}
 				}
-				// AutoCert will generate Console server certificates if user didn't provide any
-				if tenant.HasConsoleEnabled() && !tenant.ConsoleExternalCert() {
-					if err = c.checkAndCreateConsoleCSR(ctx, nsName, tenant); err != nil {
-						return err
-					}
-				}
 			}
 
 			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusProvisioningStatefulSet, 0); err != nil {

--- a/pkg/controller/cluster/tenant.go
+++ b/pkg/controller/cluster/tenant.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package cluster
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
+	"github.com/minio/operator/pkg/resources/services"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// checkMinIOSvc validates the existence of the MinIO service and validate it's status against what the specification
+// states
+func (c *Controller) checkMinIOSvc(ctx context.Context, tenant *miniov2.Tenant, nsName types.NamespacedName) error {
+	// Handle the Internal ClusterIP Service for Tenant
+	svc, err := c.serviceLister.Services(tenant.Namespace).Get(tenant.MinIOCIServiceName())
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusProvisioningCIService, 0); err != nil {
+				return err
+			}
+			klog.V(2).Infof("Creating a new Cluster IP Service for cluster %q", nsName)
+			// Create the clusterIP service for the Tenant
+			svc = services.NewClusterIPForMinIO(tenant)
+			svc, err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Create(ctx, svc, metav1.CreateOptions{})
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	// check the expose status of the MinIO ClusterIP service
+	minioSvcMatchesSpec := true
+	// compare any other change from what is specified on the tenant
+	expectedSvc := services.NewClusterIPForMinIO(tenant)
+	if !equality.Semantic.DeepDerivative(expectedSvc.Spec, svc.Spec) {
+		// some field set by the operator has changed
+		minioSvcMatchesSpec = false
+	}
+
+	// check the specification of the MinIO ClusterIP service
+	if !minioSvcMatchesSpec {
+		svc.ObjectMeta.Annotations = expectedSvc.ObjectMeta.Annotations
+		svc.ObjectMeta.Labels = expectedSvc.ObjectMeta.Labels
+		// we can only expose the service, not un-expose it
+		if tenant.Spec.ExposeServices.MinIO && svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+			svc.Spec.Type = v1.ServiceTypeLoadBalancer
+		}
+		_, err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Update(ctx, svc, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/pkg/controller/cluster/tenant.go
+++ b/pkg/controller/cluster/tenant.go
@@ -68,7 +68,7 @@ func (c *Controller) checkMinIOSvc(ctx context.Context, tenant *miniov2.Tenant, 
 		svc.ObjectMeta.Annotations = expectedSvc.ObjectMeta.Annotations
 		svc.ObjectMeta.Labels = expectedSvc.ObjectMeta.Labels
 		// we can only expose the service, not un-expose it
-		if tenant.Spec.ExposeServices.MinIO && svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		if tenant.Spec.ExposeServices != nil && tenant.Spec.ExposeServices.MinIO && svc.Spec.Type != v1.ServiceTypeLoadBalancer {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		}
 		_, err = c.kubeClientSet.CoreV1().Services(tenant.Namespace).Update(ctx, svc, metav1.UpdateOptions{})


### PR DESCRIPTION
This PR adds validation to the services we deploy in case the metadata for services or exposure changes on the tenant spec, this will update the services.

This also uninstalls console if it's removed.

If the console TLS certificate secret requested via autocert is missing it will be re-generated

Lastly, I refactored a lot of the code used for these checks into their own functions on separate files as main-controller.go number of lines is getting out of control

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>