### PR TITLE
Removing certificates.k8s.io/v1beta1 in favor of certificates.k8s.io/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ early development using MinIO for object storage.
 
 ## Prerequisites
 
-- MinIO Operator requires Kubernetes version 1.17.0 or later.
+- Starting with Operator v4.0.0, MinIO requires Kubernetes version 1.19.0 or later. Previous versions of the Operator supported Kubernetes 1.17.0 or later. You must upgrade your Kubernetes cluster to 1.19.0 or later to use Operator v4.0.0+.
 
 - This procedure assumes the cluster contains a
   [namespace](https://github.com/minio/operator/blob/master/README.md#minio-tenant-namespace) for
@@ -196,7 +196,7 @@ to temporarily forward traffic from the local host to the MinIO Tenant.
 
 MinIO supports expanding an existing MinIO Tenant onto additional hosts and storage.
 
-- MinIO requires Kubernetes version 1.17.0 or later.
+- Starting with Operator v4.0.0, MinIO requires Kubernetes version 1.19.0 or later. Previous versions of the Operator supported Kubernetes 1.17.0 or later. You must upgrade your Kubernetes cluster to 1.19.0 or later to use Operator v4.0.0+.
 
 - This procedure assumes the cluster contains a
   [namespace](https://github.com/minio/operator#create-a-namespace) for

--- a/docs/crd.adoc
+++ b/docs/crd.adoc
@@ -4,8 +4,8 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2021-05-26T00-22-46Z]
-:console-image: https://hub.docker.com/r/minio/console/tags[minio/console:v0.7.1]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2021-05-27T22-06-31Z]
+:console-image: https://hub.docker.com/r/minio/console/tags[minio/console:v0.7.3]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.14.0]
 :prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
 :logsearch-image: https://hub.docker.com/r/minio/logsearchapi/tags[minio/logsearchapi:v4.0.11]

--- a/docs/templates/asciidoctor/gv_list.tpl
+++ b/docs/templates/asciidoctor/gv_list.tpl
@@ -7,8 +7,8 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2021-05-26T00-22-46Z]
-:console-image: https://hub.docker.com/r/minio/console/tags[minio/console:v0.7.1]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2021-05-27T22-06-31Z]
+:console-image: https://hub.docker.com/r/minio/console/tags[minio/console:v0.7.3]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.14.0]
 :prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
 :logsearch-image: https://hub.docker.com/r/minio/logsearchapi/tags[minio/logsearchapi:v4.0.11]

--- a/examples/tenant-encryption.yaml
+++ b/examples/tenant-encryption.yaml
@@ -108,7 +108,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -224,7 +224,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: console-secret

--- a/examples/tenant-lite.yaml
+++ b/examples/tenant-lite.yaml
@@ -47,7 +47,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -182,7 +182,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: console-secret

--- a/examples/tenant-log-search.yaml
+++ b/examples/tenant-log-search.yaml
@@ -31,7 +31,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.

--- a/examples/tenant-pod-security-policy.yaml
+++ b/examples/tenant-pod-security-policy.yaml
@@ -76,7 +76,7 @@ metadata:
 #  name: my-custom-scheduler
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   ## Service account to be used for all the MinIO Pods
   serviceAccountName: minio-pods
   pools:

--- a/examples/tenant-prometheus.yaml
+++ b/examples/tenant-prometheus.yaml
@@ -31,7 +31,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.

--- a/examples/tenant-tiny.yaml
+++ b/examples/tenant-tiny.yaml
@@ -47,7 +47,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -182,7 +182,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: console-secret

--- a/examples/tenant-with-autocert-and-custom-certs-encryption-enabled.yaml
+++ b/examples/tenant-with-autocert-and-custom-certs-encryption-enabled.yaml
@@ -101,7 +101,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -174,7 +174,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     externalCertSecret:
       name: minio-autocert-custom-cert-encryption-localhost-cert

--- a/examples/tenant-with-autocert-and-ldap.yaml
+++ b/examples/tenant-with-autocert-and-ldap.yaml
@@ -147,7 +147,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -226,7 +226,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     imagePullPolicy: IfNotPresent
     replicas: 2
     consoleSecret:

--- a/examples/tenant-with-autocert-encryption-disabled.yaml
+++ b/examples/tenant-with-autocert-encryption-disabled.yaml
@@ -47,7 +47,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -116,7 +116,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: minio-autocert-no-encryption-console-secret

--- a/examples/tenant-with-autocert-encryption-enabled.yaml
+++ b/examples/tenant-with-autocert-encryption-enabled.yaml
@@ -90,7 +90,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -159,7 +159,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: minio-autocert-encryption-console-secret

--- a/examples/tenant-with-custom-ca-certs.yaml
+++ b/examples/tenant-with-custom-ca-certs.yaml
@@ -86,7 +86,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -170,7 +170,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: minio-custom-cert-no-encryption-console-secret

--- a/examples/tenant-with-custom-cert-encryption-disabled.yaml
+++ b/examples/tenant-with-custom-cert-encryption-disabled.yaml
@@ -78,7 +78,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -156,7 +156,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: minio-custom-cert-no-encryption-console-secret

--- a/examples/tenant-with-custom-cert-encryption-enabled.yaml
+++ b/examples/tenant-with-custom-cert-encryption-enabled.yaml
@@ -141,7 +141,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -223,7 +223,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: minio-custom-cert-encryption-console-secret

--- a/examples/tenant-with-external-idp.yaml
+++ b/examples/tenant-with-external-idp.yaml
@@ -47,7 +47,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -186,7 +186,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     imagePullPolicy: "IfNotPresent"
     replicas: 2
     consoleSecret:

--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -47,7 +47,7 @@ metadata:
 
 spec:
   ## Registry location and Tag to download MinIO Server image
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   imagePullPolicy: IfNotPresent
 
   ## Secret with credentials to be used by MinIO Tenant.
@@ -214,7 +214,7 @@ spec:
   ## Define configuration for Console (Graphical user interface for MinIO)
   ## Refer https://github.com/minio/console
   console:
-    image: minio/console:v0.7.1
+    image: minio/console:v0.7.3
     replicas: 2
     consoleSecret:
       name: console-secret

--- a/helm/minio-operator/templates/cluster-role.yaml
+++ b/helm/minio-operator/templates/cluster-role.yaml
@@ -93,6 +93,8 @@ rules:
       - certificates.k8s.io
     resourceNames:
       - kubernetes.io/legacy-unknown
+      - kubernetes.io/kube-apiserver-client
+      - kubernetes.io/kubelet-serving
     resources:
       - signers
     verbs:

--- a/kubectl-minio/README.md
+++ b/kubectl-minio/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Kubernetes >= v1.17.0.
+- Kubernetes >= v1.19.0.
 - kubectl installed on your local machine, configured to talk to the Kubernetes cluster.
 - Create PVs.
 
@@ -84,7 +84,7 @@ Command: `kubectl minio tenant upgrade TENANT_NAME --image IMAGE_TAG [options]`
 
 Upgrade MinIO Docker image for the given MinIO Tenant.
 
-example: `kubectl minio tenant upgrade tenant1 --image minio/minio:RELEASE.2021-05-26T00-22-46Z`
+example: `kubectl minio tenant upgrade tenant1 --image minio/minio:RELEASE.2021-05-27T22-06-31Z`
 
 Options:
 

--- a/kubectl-minio/cmd/helpers/constants.go
+++ b/kubectl-minio/cmd/helpers/constants.go
@@ -74,13 +74,13 @@ const (
 	DefaultOperatorImage = "minio/operator:v4.0.11"
 
 	// DefaultTenantImage is the default MinIO image used while creating tenant
-	DefaultTenantImage = "minio/minio:RELEASE.2021-05-26T00-22-46Z"
+	DefaultTenantImage = "minio/minio:RELEASE.2021-05-27T22-06-31Z"
 
 	// DefaultKESImage is the default KES image used while creating tenant
 	DefaultKESImage = "minio/kes:v0.14.0"
 
 	// DefaultConsoleImage is the default console image used while creating tenant
-	DefaultConsoleImage = "minio/console:v0.7.1"
+	DefaultConsoleImage = "minio/console:v0.7.3"
 
 	// DefaultOperatorServiceName is the default service name for operator
 	DefaultOperatorServiceName = "operator"

--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -49,7 +49,6 @@ import (
 
 	"github.com/minio/kubectl-minio/cmd/helpers"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 var resourcesFS = resources.GetStaticResources()
@@ -106,7 +105,6 @@ func GetSchemeDecoder() func(data []byte, defaults *schema.GroupVersionKind, int
 	sch := runtime.NewScheme()
 	scheme.AddToScheme(sch)
 	apiextensionv1.AddToScheme(sch)
-	apiextensionv1beta1.AddToScheme(sch)
 	appsv1.AddToScheme(sch)
 	rbacv1.AddToScheme(sch)
 	corev1.AddToScheme(sch)

--- a/kubectl-minio/cmd/tenant-upgrade.go
+++ b/kubectl-minio/cmd/tenant-upgrade.go
@@ -39,7 +39,7 @@ import (
 const (
 	upgradeDesc = `
 'upgrade' command upgrades a MinIO tenant to the specified MinIO version`
-	upgradeExample = `  kubectl minio tenant upgrade tenant1 --image minio/minio:RELEASE.2021-05-26T00-22-46Z --namespace tenant1-ns`
+	upgradeExample = `  kubectl minio tenant upgrade tenant1 --image minio/minio:RELEASE.2021-05-27T22-06-31Z --namespace tenant1-ns`
 )
 
 type upgradeCmd struct {

--- a/kubectl-minio/cmd/tenant.go
+++ b/kubectl-minio/cmd/tenant.go
@@ -49,7 +49,7 @@ func newTenantCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			// Load Resources
 			decode := resources.GetSchemeDecoder()
 			crdObj := resources.LoadTenantCRD(decode)
-			_, err = client.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.Background(), crdObj.GetObjectMeta().GetName(), v1.GetOptions{})
+			_, err = client.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdObj.GetObjectMeta().GetName(), v1.GetOptions{})
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
 					return fmt.Errorf("CustomResourceDefinition %s: not found, please run 'kubectl minio init' before using tenant command", crdObj.ObjectMeta.Name)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	certapi "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	certapi "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	"k8s.io/client-go/rest"
 )
 

--- a/pkg/apis/minio.min.io/v1/constants.go
+++ b/pkg/apis/minio.min.io/v1/constants.go
@@ -83,7 +83,7 @@ const MinIOVolumeMountPath = "/export"
 const MinIOVolumeSubPath = ""
 
 // DefaultMinIOImage specifies the default MinIO Docker hub image
-const DefaultMinIOImage = "minio/minio:RELEASE.2021-05-26T00-22-46Z"
+const DefaultMinIOImage = "minio/minio:RELEASE.2021-05-27T22-06-31Z"
 
 // DefaultMinIOUpdateURL specifies the default MinIO URL where binaries are
 // pulled from during MinIO upgrades
@@ -104,7 +104,7 @@ const DefaultZoneName = "zone-0"
 // Console Related Constants
 
 // DefaultConsoleImage specifies the latest Console Docker hub image
-const DefaultConsoleImage = "minio/console:v0.7.1"
+const DefaultConsoleImage = "minio/console:v0.7.3"
 
 // ConsoleTenantLabel is applied to the Console pods of a Tenant cluster
 const ConsoleTenantLabel = "v1.min.io/console"
@@ -182,7 +182,7 @@ const DefaultKESReplicas = 2
 var DefaultEllipticCurve = elliptic.P256()
 
 // DefaultOrgName specifies the default Org name to be used in automatic certificate generation
-var DefaultOrgName = []string{"Acme Co"}
+var DefaultOrgName = []string{"system:nodes"}
 
 // DefaultQueryInterval specifies the interval between each query for CSR Status
 var DefaultQueryInterval = time.Second * 5

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -288,17 +288,17 @@ func (t *Tenant) EnsureDefaults() *Tenant {
 			if t.Spec.CertConfig.CommonName == "" {
 				t.Spec.CertConfig.CommonName = t.MinIOWildCardName()
 			}
-			if t.Spec.CertConfig.DNSNames == nil {
+			if t.Spec.CertConfig.DNSNames == nil || len(t.Spec.CertConfig.DNSNames) == 0 {
 				t.Spec.CertConfig.DNSNames = t.MinIOHosts()
 			}
-			if t.Spec.CertConfig.OrganizationName == nil {
-				t.Spec.CertConfig.OrganizationName = DefaultOrgName
+			if t.Spec.CertConfig.OrganizationName == nil || len(t.Spec.CertConfig.OrganizationName) == 0 {
+				t.Spec.CertConfig.OrganizationName = miniov2.DefaultOrgName
 			}
 		} else {
 			t.Spec.CertConfig = &miniov2.CertificateConfig{
 				CommonName:       t.MinIOWildCardName(),
 				DNSNames:         t.MinIOHosts(),
-				OrganizationName: DefaultOrgName,
+				OrganizationName: miniov2.DefaultOrgName,
 			}
 		}
 	} else {

--- a/pkg/apis/minio.min.io/v1/names.go
+++ b/pkg/apis/minio.min.io/v1/names.go
@@ -100,7 +100,7 @@ func (t *Tenant) MinIOCSRName() string {
 // MinIOClientCSRName returns the name of CSR that is generated for Client side authentication
 // Used by KES Pods
 func (t *Tenant) MinIOClientCSRName() string {
-	return t.Name + "-client" + CSRNameSuffix
+	return t.Name + "-client-" + t.Namespace + CSRNameSuffix
 }
 
 // KES Related Names

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -92,7 +92,7 @@ const MinIOVolumeMountPath = "/export"
 const MinIOVolumeSubPath = ""
 
 // DefaultMinIOImage specifies the default MinIO Docker hub image
-const DefaultMinIOImage = "minio/minio:RELEASE.2021-05-26T00-22-46Z"
+const DefaultMinIOImage = "minio/minio:RELEASE.2021-05-27T22-06-31Z"
 
 // DefaultMinIOUpdateURL specifies the default MinIO URL where binaries are
 // pulled from during MinIO upgrades
@@ -113,7 +113,7 @@ const DefaultPoolName = "pool-0"
 // Console Related Constants
 
 // DefaultConsoleImage specifies the latest Console Docker hub image
-const DefaultConsoleImage = "minio/console:v0.7.1"
+const DefaultConsoleImage = "minio/console:v0.7.3"
 
 // ConsoleTenantLabel is applied to the Console pods of a Tenant cluster
 const ConsoleTenantLabel = "v1.min.io/console"
@@ -283,7 +283,7 @@ const DefaultKESReplicas = 2
 var DefaultEllipticCurve = elliptic.P256()
 
 // DefaultOrgName specifies the default Org name to be used in automatic certificate generation
-var DefaultOrgName = []string{"Acme Co"}
+var DefaultOrgName = []string{"system:nodes"}
 
 // DefaultQueryInterval specifies the interval between each query for CSR Status
 var DefaultQueryInterval = time.Second * 5

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -336,10 +336,10 @@ func (t *Tenant) EnsureDefaults() *Tenant {
 			if t.Spec.CertConfig.CommonName == "" {
 				t.Spec.CertConfig.CommonName = t.MinIOWildCardName()
 			}
-			if t.Spec.CertConfig.DNSNames == nil {
+			if t.Spec.CertConfig.DNSNames == nil || len(t.Spec.CertConfig.DNSNames) == 0 {
 				t.Spec.CertConfig.DNSNames = t.MinIOHosts()
 			}
-			if t.Spec.CertConfig.OrganizationName == nil {
+			if t.Spec.CertConfig.OrganizationName == nil || len(t.Spec.CertConfig.OrganizationName) == 0 {
 				t.Spec.CertConfig.OrganizationName = DefaultOrgName
 			}
 		} else {

--- a/pkg/apis/minio.min.io/v2/names.go
+++ b/pkg/apis/minio.min.io/v2/names.go
@@ -127,7 +127,7 @@ func (t *Tenant) MinIOCSRName() string {
 // MinIOClientCSRName returns the name of CSR that is generated for Client side authentication
 // Used by KES Pods
 func (t *Tenant) MinIOClientCSRName() string {
-	return t.Name + "-client" + CSRNameSuffix
+	return t.Name + "-client-" + t.Namespace + CSRNameSuffix
 }
 
 // KES Related Names

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -63,7 +63,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	certapi "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	certapi "k8s.io/client-go/kubernetes/typed/certificates/v1"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	batchlisters "k8s.io/client-go/listers/batch/v1"
@@ -153,7 +153,7 @@ type Controller struct {
 	// minioClientSet is a clientset for our own API group
 	minioClientSet clientset.Interface
 	// certClient is a clientset for our certficate management
-	certClient certapi.CertificatesV1beta1Client
+	certClient certapi.CertificatesV1Client
 	// promClient is a clientset for Prometheus service monitor
 	promClient promclientset.Interface
 	// statefulSetLister is able to list/get StatefulSets from a shared
@@ -222,7 +222,7 @@ type Controller struct {
 func NewController(
 	kubeClientSet kubernetes.Interface,
 	minioClientSet clientset.Interface,
-	certClient certapi.CertificatesV1beta1Client,
+	certClient certapi.CertificatesV1Client,
 	promClient promclientset.Interface,
 	statefulSetInformer appsinformers.StatefulSetInformer,
 	deploymentInformer appsinformers.DeploymentInformer,
@@ -1383,7 +1383,7 @@ func (c *Controller) checkAndCreateMinIOCSR(ctx context.Context, nsName types.Na
 				return err
 			}
 			klog.V(2).Infof("Creating a new Certificate Signing Request for MinIO Server Certs, cluster %q", nsName)
-			if err = c.createCSR(ctx, tenant); err != nil {
+			if err = c.createMinIOCSR(ctx, tenant); err != nil {
 				return err
 			}
 			// we want to re-queue this tenant so we can re-check for the health at a later stage
@@ -1399,7 +1399,7 @@ func (c *Controller) checkAndCreateMinIOCSR(ctx context.Context, nsName types.Na
 					return err
 				}
 				klog.V(2).Infof("Creating a new Certificate Signing Request for MinIO Client Certs, cluster %q", nsName)
-				if err = c.createMinIOClientTLSCSR(ctx, tenant); err != nil {
+				if err = c.createMinIOClientCSR(ctx, tenant); err != nil {
 					return err
 				}
 				// we want to re-queue this tenant so we can re-check for the health at a later stage
@@ -1419,7 +1419,7 @@ func (c *Controller) checkAndCreateKESCSR(ctx context.Context, nsName types.Name
 				return err
 			}
 			klog.V(2).Infof("Creating a new Certificate Signing Request for KES Server Certs, cluster %q", nsName)
-			if err = c.createKESTLSCSR(ctx, tenant); err != nil {
+			if err = c.createKESCSR(ctx, tenant); err != nil {
 				return err
 			}
 			return errors.New("waiting for kes cert")

--- a/pkg/controller/cluster/minio.go
+++ b/pkg/controller/cluster/minio.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2020, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
+	"k8s.io/klog/v2"
+)
+
+func generateMinIOCryptoData(tenant *miniov2.Tenant, hostsTemplate string) ([]byte, []byte, error) {
+	var dnsNames []string
+	var csrExtensions []pkix.Extension
+
+	klog.V(0).Infof("Generating private key")
+	privateKey, err := newPrivateKey(miniov2.DefaultEllipticCurve)
+	if err != nil {
+		klog.Errorf("Unexpected error during the ECDSA Key generation: %v", err)
+		return nil, nil, err
+	}
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		klog.Errorf("Unexpected error during encoding the ECDSA Private Key: %v", err)
+		return nil, nil, err
+	}
+
+	klog.V(0).Infof("Generating CSR with CN=%s", tenant.Spec.CertConfig.CommonName)
+
+	hosts := tenant.AllMinIOHosts()
+	if hostsTemplate != "" {
+		hosts = tenant.TemplatedMinIOHosts(hostsTemplate)
+	}
+
+	if isEqual(tenant.Spec.CertConfig.DNSNames, hosts) {
+		dnsNames = tenant.Spec.CertConfig.DNSNames
+	} else {
+		dnsNames = append(tenant.Spec.CertConfig.DNSNames, hosts...)
+	}
+	dnsNames = append(dnsNames, tenant.MinIOBucketBaseWildcardDomain())
+
+	for _, dnsName := range dnsNames {
+		csrExtensions = append(csrExtensions, pkix.Extension{
+			Id:       nil,
+			Critical: false,
+			Value:    []byte(dnsName),
+		})
+	}
+
+	csrTemplate := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("system:node:%s", tenant.Spec.CertConfig.CommonName),
+			Organization: tenant.Spec.CertConfig.OrganizationName,
+		},
+		SignatureAlgorithm: x509.ECDSAWithSHA512,
+		DNSNames:           dnsNames,
+		Extensions:         csrExtensions,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, privateKey)
+	if err != nil {
+		klog.Errorf("Unexpected error during creating the CSR: %v", err)
+		return nil, nil, err
+	}
+	return privKeyBytes, csrBytes, nil
+}
+
+// createMinIOCSR handles all the steps required to create the CSR: from creation of keys, submitting CSR and
+// finally creating a secret that MinIO statefulset will use to mount private key and certificate for TLS
+// This Method Blocks till the CSR Request is approved via kubectl approve
+func (c *Controller) createMinIOCSR(ctx context.Context, tenant *miniov2.Tenant) error {
+	privKeysBytes, csrBytes, err := generateMinIOCryptoData(tenant, c.hostsTemplate)
+	if err != nil {
+		klog.Errorf("Private Key and CSR generation failed with error: %v", err)
+		return err
+	}
+
+	err = c.createCertificateSigningRequest(ctx, tenant.MinIOPodLabels(), tenant.MinIOCSRName(), tenant.Namespace, csrBytes, tenant, "server")
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.MinIOCSRName(), err)
+		return err
+	}
+
+	// fetch certificate from CSR
+	certbytes, err := c.fetchCertificate(ctx, tenant.MinIOCSRName())
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.MinIOCSRName(), err)
+		return err
+	}
+
+	// PEM encode private ECDSA key
+	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})
+
+	// Create secret for MinIO Statefulset to use
+	err = c.createSecret(ctx, tenant, tenant.MinIOPodLabels(), tenant.MinIOTLSSecretName(), encodedPrivKey, certbytes)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", tenant.MinIOTLSSecretName(), err)
+		return err
+	}
+
+	return nil
+}
+
+// createMinIOClientCSR handles all the steps required to create the CSR: from creation of keys, submitting CSR and
+// finally creating a secret that MinIO will use to authenticate (mTLS) with KES or other services
+func (c *Controller) createMinIOClientCSR(ctx context.Context, tenant *miniov2.Tenant) error {
+	privKeysBytes, csrBytes, err := generateMinIOCryptoData(tenant, c.hostsTemplate)
+	if err != nil {
+		klog.Errorf("Private Key and CSR generation failed with error: %v", err)
+		return err
+	}
+
+	err = c.createCertificateSigningRequest(ctx, tenant.MinIOPodLabels(), tenant.MinIOClientCSRName(), tenant.Namespace, csrBytes, tenant, "client")
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.MinIOClientCSRName(), err)
+		return err
+	}
+
+	// fetch certificate from CSR
+	certbytes, err := c.fetchCertificate(ctx, tenant.MinIOClientCSRName())
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.MinIOClientCSRName(), err)
+		return err
+	}
+
+	// parse the certificate here to generate the identity for this certifcate.
+	// This is later used to update the identity in KES Server Config File
+	h := sha256.New()
+	cert, err := parseCertificate(bytes.NewReader(certbytes))
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.MinIOClientCSRName(), err)
+		return err
+	}
+
+	_, err = h.Write(cert.RawSubjectPublicKeyInfo)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.MinIOClientCSRName(), err)
+		return err
+	}
+
+	// PEM encode private ECDSA key
+	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})
+
+	// Create secret for KES StatefulSet to use
+	err = c.createSecret(ctx, tenant, tenant.MinIOPodLabels(), tenant.MinIOClientTLSSecretName(), encodedPrivKey, certbytes)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", tenant.MinIOClientTLSSecretName(), err)
+		return err
+	}
+
+	return nil
+}

--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -93,6 +93,8 @@ rules:
       - certificates.k8s.io
     resourceNames:
       - kubernetes.io/legacy-unknown
+      - kubernetes.io/kube-apiserver-client
+      - kubernetes.io/kubelet-serving
     resources:
       - signers
     verbs:

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -158,7 +158,7 @@ spec:
         env:
         - name: CONSOLE_OPERATOR_MODE
           value: "on"
-        image: minio/console:v0.7.1
+        image: minio/console:v0.7.3
         imagePullPolicy: IfNotPresent
         name: console
         ports:

--- a/testing/patching/upgrade-one-zone-step-1.yaml
+++ b/testing/patching/upgrade-one-zone-step-1.yaml
@@ -12,7 +12,7 @@ kind: Tenant
 metadata:
   name: upgrade-one-pool
 spec:
-  image: minio/minio:RELEASE.2021-05-26T00-22-46Z
+  image: minio/minio:RELEASE.2021-05-27T22-06-31Z
   pools:
     - servers: 1
       volumesPerServer: 4


### PR DESCRIPTION
- Added support for certificate signers on cluster-role
- Using certificates.k8s.io/v1
- Upgrade MinIO and Console images on example deployment yaml files

Fixes https://github.com/minio/operator/issues/657

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>