### PR TITLE
Add nodeSelector, affinity and tolerations to Operator and Operator console

### DIFF
--- a/helm/minio-operator/templates/console-deployment.yaml
+++ b/helm/minio-operator/templates/console-deployment.yaml
@@ -20,6 +20,18 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: console-sa
+    {{- with .Values.console.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.console.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.console.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.console.image.repository }}:{{ .Values.console.image.tag }}"

--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -24,6 +24,18 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"

--- a/helm/minio-operator/values.yaml
+++ b/helm/minio-operator/values.yaml
@@ -14,6 +14,9 @@ operator:
     runAsGroup: 1000
     runAsNonRoot: true
     fsGroup: 1000
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
   resources:
     requests:
       cpu: 200m
@@ -26,6 +29,9 @@ console:
     tag: v0.7.4
     pullPolicy: IfNotPresent
   replicaCount: 1
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
   resources: {}
 
 ## MinIO Tenant Definition


### PR DESCRIPTION
Changes allow to set nodeSelector, affinity and tolerations values for Operator and Operator console in helm chart

This PR fixes [issue#586](https://github.com/minio/operator/issues/586)