### PR TITLE
feat: add an option to disable OperatorTLS based on env var

### DIFF
--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -50,6 +50,11 @@ spec:
             - name: WATCHED_NAMESPACE
               value: {{ .Values.operator.nsToWatch }}
             {{- end }}
+          {{ else }}
+          {{- with .Values.operator.env }}
+          env:
+            {{ toYaml . | nindent 10 }}
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}

--- a/helm/minio-operator/values.yaml
+++ b/helm/minio-operator/values.yaml
@@ -1,8 +1,18 @@
 # Default values for minio-operator.
 
 operator:
-  clusterDomain: ""
-  nsToWatch: ""
+  ## DEPRECATED: Please use the "CLUSTER_DOMAIN" or "WATCHED_NAMESPACE" env variable
+  ## instead of clusterDomain and nsToWatch.
+  # clusterDomain: "cluster.local"
+  # nsToWatch: ""
+  ## Setup environment variables for the Operator
+  # env:
+  #   - name: MINIO_OPERATOR_TLS_ENABLE
+  #     value: "off"
+  #   - name: CLUSTER_DOMAIN
+  #     value: "cluster.domain"
+  #   - name: WATCHED_NAMESPACE
+  #     value: ""
   image:
     repository: minio/operator
     tag: v4.1.3

--- a/kubectl-minio/cmd/tenant-upgrade.go
+++ b/kubectl-minio/cmd/tenant-upgrade.go
@@ -60,6 +60,7 @@ func newTenantUpgradeCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 			if err := c.validate(args); err != nil {
 				return err
 			}
+			c.tenantOpts.Name = args[0]
 			klog.Info("upgrade tenant command started")
 			err := c.run()
 			if err != nil {
@@ -80,12 +81,11 @@ func newTenantUpgradeCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 }
 
 func (u *upgradeCmd) validate(args []string) error {
-	u.tenantOpts.Name = args[0]
 	if args == nil {
 		return errors.New("provide the name of the tenant, e.g. 'kubectl minio tenant upgrade tenant1'")
 	}
 	if len(args) != 1 {
-		return errors.New("info command supports a single argument, e.g. 'kubectl minio tenant upgrade tenant1'")
+		return errors.New("upgrade command requires a single argument, e.g. 'kubectl minio tenant upgrade tenant1'")
 	}
 	if args[0] == "" {
 		return errors.New("provide the name of the tenant, e.g. 'kubectl minio tenant upgrade tenant1'")

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -273,7 +273,7 @@ func minioSecurityContext(pool *miniov2.Pool) *corev1.PodSecurityContext {
 }
 
 // NewPool creates a new StatefulSet for the given Cluster.
-func NewPool(t *miniov2.Tenant, wsSecret *v1.Secret, pool *miniov2.Pool, serviceName string, hostsTemplate, operatorVersion string) *appsv1.StatefulSet {
+func NewPool(t *miniov2.Tenant, wsSecret *v1.Secret, pool *miniov2.Pool, serviceName string, hostsTemplate, operatorVersion string, operatorTLS bool) *appsv1.StatefulSet {
 	var podVolumes []corev1.Volume
 	var replicas = pool.Servers
 	var podVolumeSources []corev1.VolumeProjection
@@ -430,21 +430,22 @@ func NewPool(t *miniov2.Tenant, wsSecret *v1.Secret, pool *miniov2.Pool, service
 		}
 	}
 
-	// Mount Operator TLS certificate to MinIO ~/cert/CAs
-	operatorTLSSecretName := "operator-tls"
-	podVolumeSources = append(podVolumeSources, []corev1.VolumeProjection{
-		{
-			Secret: &corev1.SecretProjection{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: operatorTLSSecretName,
-				},
-				Items: []corev1.KeyToPath{
-					{Key: "public.crt", Path: "CAs/operator.crt"},
+	if operatorTLS {
+		// Mount Operator TLS certificate to MinIO ~/cert/CAs
+		operatorTLSSecretName := "operator-tls"
+		podVolumeSources = append(podVolumeSources, []corev1.VolumeProjection{
+			{
+				Secret: &corev1.SecretProjection{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: operatorTLSSecretName,
+					},
+					Items: []corev1.KeyToPath{
+						{Key: "public.crt", Path: "CAs/operator.crt"},
+					},
 				},
 			},
-		},
-	}...)
-
+		}...)
+	}
 	// If KES is enable mount TLS certificate secrets
 	if t.HasKESEnabled() {
 		// External Client certificates will have priority over AutoCert generated certificates


### PR DESCRIPTION
This PR adds support to disable automatic certificate
creation for Operator webhook server. This is required for
some k8s distros where CSR support is not mature yet.

Operator still uses TLS by default for its webhook server.

This PR also adds a fix in kubectl plugin tenant
upgrade command to ensure proper error message is sent
to the user.