### PR TITLE
MinIO first external certificate mounts twice

### DIFF
--- a/pkg/controller/cluster/kes.go
+++ b/pkg/controller/cluster/kes.go
@@ -307,7 +307,7 @@ func (c *Controller) getCertIdentity(ns string, cert *miniov2.LocalCertificateRe
 		return "", err
 	}
 	// Store the Identity to be used later during KES container creation
-	if secret.Type == "kubernetes.io/tls" || secret.Type == "cert-manager.io/v1alpha2" {
+	if secret.Type == "kubernetes.io/tls" || secret.Type == "cert-manager.io/v1alpha2" || secret.Type == "cert-manager.io/v1" {
 		certbytes = secret.Data["tls.crt"]
 	} else {
 		certbytes = secret.Data["public.crt"]

--- a/pkg/resources/deployments/console-deployment.go
+++ b/pkg/resources/deployments/console-deployment.go
@@ -222,7 +222,7 @@ func NewConsole(t *miniov2.Tenant) *appsv1.Deployment {
 		serverCertSecret := t.Spec.Console.ExternalCertSecret.Name
 		// This covers both secrets of type "kubernetes.io/tls" and
 		// "cert-manager.io/v1alpha2" because of same keys in both.
-		if t.Spec.Console.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.Console.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" {
+		if t.Spec.Console.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.Console.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" || t.Spec.Console.ExternalCertSecret.Type == "cert-manager.io/v1" {
 			serverCertPaths = []corev1.KeyToPath{
 				{Key: "tls.crt", Path: certPath},
 				{Key: "tls.key", Path: keyPath},
@@ -275,7 +275,7 @@ func NewConsole(t *miniov2.Tenant) *appsv1.Deployment {
 		for index, secret := range t.Spec.ExternalCertSecret {
 			// This covers both secrets of type "kubernetes.io/tls" and
 			// "cert-manager.io/v1alpha2" because of same keys in both.
-			if secret.Type == "kubernetes.io/tls" || secret.Type == "cert-manager.io/v1alpha2" {
+			if secret.Type == "kubernetes.io/tls" || secret.Type == "cert-manager.io/v1alpha2" || secret.Type == "cert-manager.io/v1" {
 				tenantCertPaths = []corev1.KeyToPath{
 					{Key: "tls.crt", Path: fmt.Sprintf("CAs/minio-hostname-%d.crt", index)},
 				}
@@ -311,7 +311,7 @@ func NewConsole(t *miniov2.Tenant) *appsv1.Deployment {
 				caCertPaths = []corev1.KeyToPath{
 					{Key: "tls.crt", Path: fmt.Sprintf("CAs/ca-%d.crt", index)},
 				}
-			} else if secret.Type == "cert-manager.io/v1alpha2" {
+			} else if secret.Type == "cert-manager.io/v1alpha2" || secret.Type == "cert-manager.io/v1" {
 				caCertPaths = []corev1.KeyToPath{
 					{Key: "ca.crt", Path: fmt.Sprintf("CAs/ca-%d.crt", index)},
 				}

--- a/pkg/resources/jobs/kes-job.go
+++ b/pkg/resources/jobs/kes-job.go
@@ -39,7 +39,7 @@ func NewForKES(t *miniov2.Tenant) *batchv1.Job {
 		clientCertSecret = t.Spec.ExternalClientCertSecret.Name
 		// This covers both secrets of type "kubernetes.io/tls" and
 		// "cert-manager.io/v1alpha2" because of same keys in both.
-		if t.Spec.ExternalClientCertSecret.Type == "kubernetes.io/tls" || t.Spec.ExternalClientCertSecret.Type == "cert-manager.io/v1alpha2" {
+		if t.Spec.ExternalClientCertSecret.Type == "kubernetes.io/tls" || t.Spec.ExternalClientCertSecret.Type == "cert-manager.io/v1alpha2" || t.Spec.ExternalClientCertSecret.Type == "cert-manager.io/v1" {
 			clientCertPaths = []corev1.KeyToPath{
 				{Key: "tls.crt", Path: "minio.crt"},
 				{Key: "tls.key", Path: "minio.key"},

--- a/pkg/resources/statefulsets/kes-statefulset.go
+++ b/pkg/resources/statefulsets/kes-statefulset.go
@@ -118,7 +118,7 @@ func NewForKES(t *miniov2.Tenant, serviceName string) *appsv1.StatefulSet {
 		serverCertSecret = t.Spec.KES.ExternalCertSecret.Name
 		// This covers both secrets of type "kubernetes.io/tls" and
 		// "cert-manager.io/v1alpha2" because of same keys in both.
-		if t.Spec.KES.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.KES.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" {
+		if t.Spec.KES.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.KES.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" || t.Spec.KES.ExternalCertSecret.Type == "cert-manager.io/v1" {
 			serverCertPaths = []corev1.KeyToPath{
 				{Key: "tls.crt", Path: certPath},
 				{Key: "tls.key", Path: keyPath},


### PR DESCRIPTION
- fix: first MinIO externalCertSecret cert was getting mounted twice
- add: support for "cert-manager.io/v1" certificates
- update: external certificates have priority over autogenerated
  certificates for MinIO deployment

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>