### PR TITLE
Update Tenant Health Status when Pods change states

### DIFF
--- a/helm/minio-operator/crds/minio.min.io_tenants.yaml
+++ b/helm/minio-operator/crds/minio.min.io_tenants.yaml
@@ -3778,6 +3778,8 @@ spec:
               drivesOnline:
                 format: int32
                 type: integer
+              healthMessage:
+                type: string
               healthStatus:
                 type: string
               pools:
@@ -7608,6 +7610,8 @@ spec:
               drivesOnline:
                 format: int32
                 type: integer
+              healthMessage:
+                type: string
               healthStatus:
                 type: string
               pools:

--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func main() {
 	mainController := cluster.NewController(kubeClient, controllerClient, promClient,
 		kubeInformerFactory.Apps().V1().StatefulSets(),
 		kubeInformerFactory.Apps().V1().Deployments(),
+		kubeInformerFactory.Core().V1().Pods(),
 		kubeInformerFactory.Batch().V1().Jobs(),
 		minioInformerFactory.Minio().V2().Tenants(),
 		kubeInformerFactory.Core().V1().Services(),

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -419,6 +419,10 @@ type TenantStatus struct {
 	HealthStatus HealthStatus `json:"healthStatus,omitempty"`
 	// *Optional* +
 	//
+	// Health Message regarding the State of the tenant
+	HealthMessage string `json:"healthMessage,omitempty"`
+	// *Optional* +
+	//
 	// If set, we will wait until cleared for up a given time
 	WaitingOnReady *metav1.Time `json:"waitingOnReady,omitempty"`
 }

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -188,20 +188,20 @@ type Controller struct {
 
 	// Webhook server instance
 	ws *http.Server
+
+	// monitor pods in the cluster to update the health information
+	podInformer cache.SharedIndexInformer
+
+	// healthCheckQueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens. This
+	// means we can ensure we only process a fixed amount of resources at a
+	// time, and makes it easy to ensure we are never processing the same item
+	// simultaneously in two different workers.
+	healthCheckQueue queue.RateLimitingInterface
 }
 
 // NewController returns a new sample controller
-func NewController(
-	kubeClientSet kubernetes.Interface,
-	minioClientSet clientset.Interface,
-	promClient promclientset.Interface,
-	statefulSetInformer appsinformers.StatefulSetInformer,
-	deploymentInformer appsinformers.DeploymentInformer,
-	jobInformer batchinformers.JobInformer,
-	tenantInformer informers.TenantInformer,
-	serviceInformer coreinformers.ServiceInformer,
-	serviceMonitorInformer prominformers.ServiceMonitorInformer,
-	hostsTemplate, operatorVersion string) *Controller {
+func NewController(kubeClientSet kubernetes.Interface, minioClientSet clientset.Interface, promClient promclientset.Interface, statefulSetInformer appsinformers.StatefulSetInformer, deploymentInformer appsinformers.DeploymentInformer, podInformer coreinformers.PodInformer, jobInformer batchinformers.JobInformer, tenantInformer informers.TenantInformer, serviceInformer coreinformers.ServiceInformer, serviceMonitorInformer prominformers.ServiceMonitorInformer, hostsTemplate, operatorVersion string) *Controller {
 
 	// Create event broadcaster
 	// Add minio-controller types to the default Kubernetes Scheme so Events can be
@@ -219,6 +219,7 @@ func NewController(
 		promClient:                 promClient,
 		statefulSetLister:          statefulSetInformer.Lister(),
 		statefulSetListerSynced:    statefulSetInformer.Informer().HasSynced,
+		podInformer:                podInformer.Informer(),
 		deploymentLister:           deploymentInformer.Lister(),
 		deploymentListerSynced:     deploymentInformer.Informer().HasSynced,
 		jobLister:                  jobInformer.Lister(),
@@ -229,6 +230,7 @@ func NewController(
 		serviceMonitorLister:       serviceMonitorInformer.Lister(),
 		serviceMonitorListerSynced: serviceMonitorInformer.Informer().HasSynced,
 		workqueue:                  queue.NewNamedRateLimitingQueue(MinIOControllerRateLimiter(), "Tenants"),
+		healthCheckQueue:           queue.NewNamedRateLimitingQueue(MinIOControllerRateLimiter(), "TenantsHealth"),
 		recorder:                   recorder,
 		hostsTemplate:              hostsTemplate,
 		operatorVersion:            operatorVersion,
@@ -287,6 +289,22 @@ func NewController(
 		},
 		DeleteFunc: controller.handleObject,
 	})
+
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: controller.handlePodChange,
+		UpdateFunc: func(old, new interface{}) {
+			newDepl := new.(*corev1.Pod)
+			oldDepl := old.(*corev1.Pod)
+			if newDepl.ResourceVersion == oldDepl.ResourceVersion {
+				// Periodic resync will send update events for all known Deployments.
+				// Two different versions of the same Deployments will always have different RVs.
+				return
+			}
+			controller.handlePodChange(new)
+		},
+		DeleteFunc: controller.handlePodChange,
+	})
+
 	return controller
 }
 
@@ -352,6 +370,9 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}
 
+	// Launcha  single worker for Health Check reacting to Pod Changes
+	go wait.Until(c.runHealthCheckWorker, time.Second, stopCh)
+
 	// Launch a goroutine to monitor all Tenants
 	go c.recurrentTenantStatusMonitor(stopCh)
 
@@ -368,6 +389,7 @@ func (c *Controller) Stop() {
 
 	klog.Info("Stopping the minio controller")
 	c.workqueue.ShutDown()
+	c.healthCheckQueue.ShutDown()
 }
 
 // runWorker is a long-running function that will continually call the
@@ -376,6 +398,15 @@ func (c *Controller) Stop() {
 func (c *Controller) runWorker() {
 	defer runtime.HandleCrash()
 	for c.processNextWorkItem() {
+	}
+}
+
+// runHealthCheckWorker is a long-running function that will continually call the
+// processNextWorkItem function in order to read and process a message on the
+// healthCheckQueue.
+func (c *Controller) runHealthCheckWorker() {
+	defer runtime.HandleCrash()
+	for c.processNextHealthCheckItem() {
 	}
 }
 

--- a/pkg/controller/cluster/pods.go
+++ b/pkg/controller/cluster/pods.go
@@ -1,0 +1,62 @@
+// This file is part of MinIO Console Server
+// Copyright (c) 2021 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// handlePodChange will handle changes in pods and see if they are a MinIO pod, if so, queue it for processing
+func (c *Controller) handlePodChange(obj interface{}) {
+	var object metav1.Object
+	var ok bool
+	if object, ok = obj.(metav1.Object); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("error decoding object, invalid type"))
+			return
+		}
+		object, ok = tombstone.Obj.(metav1.Object)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
+			return
+		}
+		klog.V(4).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+	}
+	// if the pod is a MinIO pod, we do process it
+	if tenantName, ok := object.GetLabels()[miniov2.TenantLabel]; ok {
+		// check this is still a valid tenant
+		_, err := c.minioClientSet.MinioV2().Tenants(object.GetNamespace()).Get(context.Background(), tenantName, metav1.GetOptions{})
+		if err != nil {
+			klog.V(4).Infof("ignoring orphaned object '%s' of tenant '%s'", object.GetSelfLink(), tenantName)
+			return
+		}
+		key := fmt.Sprintf("%s/%s", object.GetNamespace(), tenantName)
+		// check if already in queue before re-queueing
+
+		c.healthCheckQueue.Add(key)
+		return
+	}
+}

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3778,6 +3778,8 @@ spec:
               drivesOnline:
                 format: int32
                 type: integer
+              healthMessage:
+                type: string
               healthStatus:
                 type: string
               pools:
@@ -7608,6 +7610,8 @@ spec:
               drivesOnline:
                 format: int32
                 type: integer
+              healthMessage:
+                type: string
               healthStatus:
                 type: string
               pools:


### PR DESCRIPTION
This PR introduces a shared informer that monitor pods in the cluster for tenant pods, upon seeing a change in the pods, it initiates a health check agains the MinIO to see what is it's current state after losing a Pod, thus updating the .status.healthStatus field almost immediately.

Also updated the logic of how we update colors and health messages for status.

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>