### PR TITLE
doc: fixed yaml formatting and storageClass field

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ spec:
    accessModes:
    - ReadWriteOnce
    persistentVolumeReclaimPolicy: Retain
-   storage-class: local-storage
+   storageClassName: local-storage
    local:
       path: </mnt/disks/ssd1>
    nodeAffinity:
@@ -122,9 +122,9 @@ spec:
          nodeSelectorTerms:
          - matchExpressions:
             - key: kubernetes.io/hostname
-               operator: In
-               values:
-               - <NODE-NAME>
+              operator: In
+              values:
+              - <NODE-NAME>
 ```
 
 Replace values in brackets `<VALUE>` with the appropriate value for the local drive.


### PR DESCRIPTION
Fixed yaml formatting for persistent volume by removed redundant space after mapping declaration:
> error converting YAML to JSON: yaml: line 21: mapping values are not allowed in this context

And fixed error by using correct field `ClassStorageName` instead of `class-storage`:
> error validating data: ValidationError(PersistentVolume.spec): unknown field "storage-class" in io.k8s.api.core.v1.PersistentVolumeSpec;

See: https://kubernetes.io/docs/concepts/storage/persistent-volumes/