### PR TITLE
Fix typo in operator.go

### DIFF
--- a/pkg/controller/cluster/operator.go
+++ b/pkg/controller/cluster/operator.go
@@ -255,7 +255,7 @@ func (c *Controller) createOperatorCSR(ctx context.Context, operator metav1.Obje
 func (c *Controller) checkAndCreateOperatorCSR(ctx context.Context, operator metav1.Object) error {
 	var err error
 	if useCertificatesV1API {
-		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, c.operatorCSRName(), metav1.GetOptions{})
+		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, c.operatorCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, c.operatorCSRName(), metav1.GetOptions{})
 	}


### PR DESCRIPTION
Both `if` and `else` blocks inside `useCertificatesV1API` had the same
code. Fixed by using `CertificatesV1` instead of `CertificatesV1beta1`
inside the `if` block.