### PR TITLE
Fix Postgres version for logs to 13

### DIFF
--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -184,7 +184,7 @@ const PrometheusServiceMonitorSecretKey = "token"
 const DefaultLogSearchAPIImage = "minio/logsearchapi:v4.2.12"
 
 // LogPgImage specifies the latest Postgres container image
-const LogPgImage = "library/postgres"
+const LogPgImage = "library/postgres:13"
 
 // LogDBInstanceLabel is applied to the Log (Postgres server) pods
 const LogDBInstanceLabel = "v1.min.io/log-pg"


### PR DESCRIPTION
Due to the recent release of postgres 14 we need to make this version explicit now 

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>