### PR TITLE
fix: Wrong env variable for logsearch api token

### DIFF
--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -231,7 +231,7 @@ const LogAuditTokenKey = "LOGSEARCH_AUDIT_AUTH_TOKEN"
 
 // LogQueryTokenKey is the k8s secret/environment variable key name referring to
 // the token used to perform search query on audit logs persisted.
-const LogQueryTokenKey = "MINIO_QUERY_AUTH_TOKEN"
+const LogQueryTokenKey = "MINIO_LOG_QUERY_AUTH_TOKEN"
 
 // ConsolePrometheusURL is the url to the prometheus the console should use to pull metrics from.
 const ConsolePrometheusURL = "MINIO_PROMETHEUS_URL"


### PR DESCRIPTION
Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>