### PR TITLE
Leader Election support

### DIFF
--- a/helm/minio-operator/templates/cluster-role.yaml
+++ b/helm/minio-operator/templates/cluster-role.yaml
@@ -36,6 +36,7 @@ rules:
     verbs:
       - get
       - watch
+      - patch
       - create
       - list
       - delete
@@ -120,3 +121,11 @@ rules:
       - get
       - create
       - list
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - update
+      - create

--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -42,6 +42,11 @@ spec:
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           {{- if or .Values.operator.clusterDomain .Values.operator.nsToWatch }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
             {{- if .Values.operator.clusterDomain }}
             - name: CLUSTER_DOMAIN
               value: {{ .Values.operator.clusterDomain }}

--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -42,11 +42,6 @@ spec:
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           {{- if or .Values.operator.clusterDomain .Values.operator.nsToWatch }}
           env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
             {{- if .Values.operator.clusterDomain }}
             - name: CLUSTER_DOMAIN
               value: {{ .Values.operator.clusterDomain }}

--- a/helm/minio-operator/templates/operator-deployment.yaml
+++ b/helm/minio-operator/templates/operator-deployment.yaml
@@ -67,3 +67,14 @@ spec:
       initContainers:
         {{- toYaml . | nindent 8 }}
     {{- end}}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - minio-operator
+              topologyKey: kubernetes.io/hostname
+

--- a/helm/minio-operator/templates/operator-service.yaml
+++ b/helm/minio-operator/templates/operator-service.yaml
@@ -11,4 +11,5 @@ spec:
     - port: 4222
       name: https
   selector:
+    operator: leader
     {{- include "minio-operator.selectorLabels" . | nindent 4 }}

--- a/main.go
+++ b/main.go
@@ -29,11 +29,13 @@ import (
 	"syscall"
 	"time"
 
+	"k8s.io/client-go/tools/clientcmd"
+
+	"k8s.io/client-go/rest"
+
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/client-go/tools/clientcmd"
 
 	"k8s.io/klog/v2"
 
@@ -45,7 +47,6 @@ import (
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // version provides the version of this operator
@@ -156,8 +157,12 @@ func main() {
 		minioInformerFactory = informers.NewSharedInformerFactory(controllerClient, time.Second*30)
 		promInformerFactory = prominformers.NewSharedInformerFactory(promClient, time.Second*30)
 	}
+	podName := os.Getenv("POD_NAME")
+	if podName == "" {
+		podName = "operator-pod"
+	}
 
-	mainController := cluster.NewController(kubeClient, controllerClient, promClient,
+	mainController := cluster.NewController(podName, kubeClient, controllerClient, promClient,
 		kubeInformerFactory.Apps().V1().StatefulSets(),
 		kubeInformerFactory.Apps().V1().Deployments(),
 		kubeInformerFactory.Core().V1().Pods(),

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func main() {
 		minioInformerFactory = informers.NewSharedInformerFactory(controllerClient, time.Second*30)
 		promInformerFactory = prominformers.NewSharedInformerFactory(promClient, time.Second*30)
 	}
-	podName := os.Getenv("POD_NAME")
+	podName := os.Getenv("HOSTNAME")
 	if podName == "" {
 		podName = "operator-pod"
 	}

--- a/manifests/minio-operator.v4.1.2.clusterserviceversion.yaml
+++ b/manifests/minio-operator.v4.1.2.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
               },
               "podManagementPolicy": "Parallel",
               "console": {
-                "image": "minio/console:v0.10.3",
+                "image": "minio/console:v0.10.4",
                 "replicas": 1,
                 "consoleSecret": {
                   "name": "console-secret"

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -29,9 +29,6 @@ import (
 // MinIOCRDResourceKind is the Kind of a Cluster.
 const MinIOCRDResourceKind = "Tenant"
 
-// OperatorCRDResourceKind is the Kind of a Cluster.
-const OperatorCRDResourceKind = "Operator"
-
 // DefaultPodManagementPolicy specifies default pod management policy as expllained here
 // https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
 const DefaultPodManagementPolicy = appsv1.ParallelPodManagement
@@ -100,19 +97,7 @@ const DefaultMinIOUpdateURL = "https://dl.min.io/server/minio/release/" + runtim
 // MinIOHLSvcNameSuffix specifies the suffix added to Tenant name to create a headless service
 const MinIOHLSvcNameSuffix = "-hl"
 
-// DefaultServers specifies the default MinIO replicas to use for distributed deployment if not specified explicitly by user
-const DefaultServers = 1
-
-// DefaultVolumesPerServer specifies the default number of volumes per MinIO Tenant
-const DefaultVolumesPerServer = 1
-
-// DefaultPoolName specifies the default pool name
-const DefaultPoolName = "pool-0"
-
 // Console Related Constants
-
-// DefaultConsoleImage specifies the latest Console Docker hub image
-const DefaultConsoleImage = "minio/console:v0.10.3"
 
 // ConsoleTenantLabel is applied to the Console pods of a Tenant cluster
 const ConsoleTenantLabel = "v1.min.io/console"
@@ -137,19 +122,6 @@ const ConsoleName = "-console"
 
 // ConsoleAdminPolicyName denotes the policy name for Console user
 const ConsoleAdminPolicyName = "consoleAdmin"
-
-// ConsoleRestartPolicy defines the default restart policy for Console Containers
-const ConsoleRestartPolicy = corev1.RestartPolicyAlways
-
-// ConsoleConfigMountPath specifies the path where Console config file and all secrets are mounted
-// We keep this to /tmp so it doesn't require any special permissions
-const ConsoleConfigMountPath = "/tmp/console"
-
-// DefaultConsoleReplicas specifies the default number of Console pods to be created if not specified
-const DefaultConsoleReplicas = 2
-
-// ConsoleCertPath is the path where all Console certs are mounted
-const ConsoleCertPath = "/tmp/certs"
 
 // Prometheus related constants
 
@@ -315,8 +287,6 @@ const MinIOPrometheusScrapeInterval = 30 * time.Second
 const MinIOPrometheusScrapeTimeout = 2 * time.Second
 
 const tenantMinIOImageEnv = "TENANT_MINIO_IMAGE"
-
-const tenantConsoleImageEnv = "TENANT_CONSOLE_IMAGE"
 
 const tenantKesImageEnv = "TENANT_KES_IMAGE"
 

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -876,14 +876,6 @@ func GetTenantMinIOImage() string {
 	return tenantMinIOImage
 }
 
-// GetTenantConsoleImage returns the default Console Image for a tenant
-func GetTenantConsoleImage() string {
-	tenantConsoleImageOnce.Do(func() {
-		tenantConsoleImage = envGet(tenantConsoleImageEnv, DefaultConsoleImage)
-	})
-	return tenantConsoleImage
-}
-
 // GetTenantKesImage returns the default KES Image for a tenant
 func GetTenantKesImage() string {
 	tenantKesImageOnce.Do(func() {

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -96,12 +96,10 @@ type hostsTemplateValues struct {
 var (
 	once                   sync.Once
 	tenantMinIOImageOnce   sync.Once
-	tenantConsoleImageOnce sync.Once
 	tenantKesImageOnce     sync.Once
 	monitoringIntervalOnce sync.Once
 	k8sClusterDomain       string
 	tenantMinIOImage       string
-	tenantConsoleImage     string
 	tenantKesImage         string
 	monitoringInterval     int
 )

--- a/pkg/controller/cluster/monitoring.go
+++ b/pkg/controller/cluster/monitoring.go
@@ -249,12 +249,12 @@ func (c *Controller) updateHealthStatusForTenant(tenant *miniov2.Tenant) error {
 	metrics, err := getPrometheusMetricsForTenant(tenant, bearerToken)
 	if err != nil {
 		klog.Infof("'%s/%s' Can't generate tenant prometheus token: %v", tenant.Namespace, tenant.Name, err)
-	}
-	tenant.Status.Usage.Usage = metrics.Usage
-	tenant.Status.Usage.Capacity = metrics.UsableCapacity
-
-	if tenant, err = c.updatePoolStatus(context.Background(), tenant); err != nil {
-		klog.Infof("'%s/%s' Can't update tenant status for usage: %v", tenant.Namespace, tenant.Name, err)
+	} else {
+		tenant.Status.Usage.Usage = metrics.Usage
+		tenant.Status.Usage.Capacity = metrics.UsableCapacity
+		if tenant, err = c.updatePoolStatus(context.Background(), tenant); err != nil {
+			klog.Infof("'%s/%s' Can't update tenant status for usage: %v", tenant.Namespace, tenant.Name, err)
+		}
 	}
 
 	return nil

--- a/pkg/controller/cluster/upgrades.go
+++ b/pkg/controller/cluster/upgrades.go
@@ -309,5 +309,5 @@ func (c *Controller) upgrade4215(ctx context.Context, tenant *miniov2.Tenant) (*
 
 	}
 
-	return c.updateTenantSyncVersion(ctx, tenant, version420)
+	return c.updateTenantSyncVersion(ctx, tenant, version4215)
 }

--- a/pkg/controller/cluster/upgrades.go
+++ b/pkg/controller/cluster/upgrades.go
@@ -31,11 +31,11 @@ import (
 )
 
 const (
-	version420  = "v4.2.0"
-	version424  = "v4.2.4"
-	version428  = "v4.2.8"
-	version429  = "v4.2.9"
-	version4215 = "v4.2.15"
+	version420 = "v4.2.0"
+	version424 = "v4.2.4"
+	version428 = "v4.2.8"
+	version429 = "v4.2.9"
+	version430 = "v4.3.0"
 )
 
 type upgradeFunction func(ctx context.Context, tenant *miniov2.Tenant) (*miniov2.Tenant, error)
@@ -45,11 +45,11 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 
 	var upgradesToDo []string
 	upgrades := map[string]upgradeFunction{
-		version420:  c.upgrade420,
-		version424:  c.upgrade424,
-		version428:  c.upgrade428,
-		version429:  c.upgrade429,
-		version4215: c.upgrade4215,
+		version420: c.upgrade420,
+		version424: c.upgrade424,
+		version428: c.upgrade428,
+		version429: c.upgrade429,
+		version430: c.upgrade430,
 	}
 
 	// if the version is empty, do all upgrades
@@ -58,7 +58,7 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 		upgradesToDo = append(upgradesToDo, version424)
 		upgradesToDo = append(upgradesToDo, version428)
 		upgradesToDo = append(upgradesToDo, version429)
-		upgradesToDo = append(upgradesToDo, version4215)
+		upgradesToDo = append(upgradesToDo, version430)
 	} else {
 		currentSyncVersion, err := version.NewVersion(tenant.Status.SyncVersion)
 		if err != nil {
@@ -70,7 +70,7 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 			version424,
 			version428,
 			version429,
-			version4215,
+			version430,
 		}
 		for _, v := range versionsThatNeedUpgrades {
 			vp, _ := version.NewVersion(v)
@@ -282,9 +282,9 @@ func (c *Controller) upgrade429(ctx context.Context, tenant *miniov2.Tenant) (*m
 	return c.updateTenantSyncVersion(ctx, tenant, version429)
 }
 
-// Upgrades the sync version to v4.2.15
+// Upgrades the sync version to v4.3.0
 // in this version we renamed MINIO_QUERY_AUTH_TOKEN to MINIO_LOG_QUERY_AUTH_TOKEN.
-func (c *Controller) upgrade4215(ctx context.Context, tenant *miniov2.Tenant) (*miniov2.Tenant, error) {
+func (c *Controller) upgrade430(ctx context.Context, tenant *miniov2.Tenant) (*miniov2.Tenant, error) {
 	logSearchSecret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.LogSecretName(), metav1.GetOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return nil, err
@@ -309,5 +309,5 @@ func (c *Controller) upgrade4215(ctx context.Context, tenant *miniov2.Tenant) (*
 
 	}
 
-	return c.updateTenantSyncVersion(ctx, tenant, version4215)
+	return c.updateTenantSyncVersion(ctx, tenant, version430)
 }

--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -41,6 +41,7 @@ rules:
       - delete
       - deletecollection
       - update
+      - patch
   - apiGroups:
       - ""
     resources:
@@ -119,3 +120,11 @@ rules:
       - servicemonitors
     verbs:
       - '*'
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - update
+      - create

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -295,7 +295,7 @@ spec:
         env:
         - name: CONSOLE_OPERATOR_MODE
           value: "on"
-        image: minio/console:v0.10.3
+        image: minio/console:v0.10.4
         imagePullPolicy: IfNotPresent
         name: console
         securityContext:

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: minio-operator
   namespace: default
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       name: minio-operator
@@ -18,6 +18,12 @@ spec:
         - name: minio-operator
           image: minio/operator:v4.2.14
           imagePullPolicy: IfNotPresent
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
           resources:
             requests:
               cpu: 200m

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio-operator
-  namespace: default
+  namespace: minio-operator
 spec:
   replicas: 2
   selector:
@@ -33,3 +33,13 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             runAsNonRoot: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - minio-operator
+              topologyKey: kubernetes.io/hostname

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -18,12 +18,6 @@ spec:
         - name: minio-operator
           image: minio/operator:v4.2.14
           imagePullPolicy: IfNotPresent
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
           resources:
             requests:
               cpu: 200m

--- a/resources/base/service.yaml
+++ b/resources/base/service.yaml
@@ -12,3 +12,4 @@ spec:
       name: https
   selector:
     name: minio-operator
+    operator: leader


### PR DESCRIPTION
Introduces support for leader election between multiple replicas of the Operator pod.

Now we pass the name of the pod to each operator pod and start with `2 replicas` by default, using [kubernetes lock leases](https://kubernetes.io/blog/2016/01/simple-leader-election-with-kubernetes/) it then elects a leader, which then patches the pod so that now the operator service only hits that pod (the leader)

We have the requirement to have a single pod serve as the operator API due to the fact that when we are doing online update, the MinIO pods will attempt to download their binary from the operator pod via the operator service, so a single pod should host the downloaded file.

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>