### PR TITLE
Permit passing ENV vars to console

### DIFF
--- a/helm/minio-operator/templates/console-deployment.yaml
+++ b/helm/minio-operator/templates/console-deployment.yaml
@@ -54,6 +54,9 @@ spec:
           env:
           - name: CONSOLE_OPERATOR_MODE
             value: "on"
+          {{- with .Values.console.env }}
+            {{ toYaml . | nindent 10 }}
+          {{- end }}            
           resources:
             {{- toYaml .Values.console.resources | nindent 12 }}
       {{- with .Values.console.initContainers }}


### PR DESCRIPTION
Hey guys,

I've been working on getting SSO working for my operator console, and I realized that if I manually update the deployment to include `CONSOLE_IDP_URL`, `CONSOLE_IDP_CLIENT_ID`, and `CONSOLE_IDP_CALLBACK`, then SSO works! 

It seems that it's not possible currently to pass these env vars to the console deployment though, so this PR simply adds in the optional capability to do so.

I've not bumped the chart version or the docs, since I'm not sure how these are intended to be updated, but I'm happy to do so with some direction :)

Cheers!
D