### PR TITLE
FSGroupChangePolicy defaults to OnRootMismatch

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -362,7 +362,11 @@ func poolSecurityContext(pool *miniov2.Pool, status *miniov2.PoolStatus) *v1.Pod
 	} else if status.LegacySecurityContext {
 		return nil
 	}
-
+	// Prevents high CPU usage of kubelet by preventing chown on the entire CSI
+	if securityContext.FSGroupChangePolicy == nil {
+		fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+		securityContext.FSGroupChangePolicy = &fsGroupChangePolicy
+	}
 	return &securityContext
 }
 


### PR DESCRIPTION
Prevent performance high cpu usage of kubelet by preventing to run chown on all files inside a volume

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>