### PR TITLE
adding new prometheus test

### DIFF
--- a/.github/workflows/prometheus.yaml
+++ b/.github/workflows/prometheus.yaml
@@ -1,0 +1,42 @@
+# This is a basic workflow to execute our Tenant deployment script
+
+name: Prometheus test on Kind
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pull request events but only for the main branch
+  pull_request:
+    branches: [ master ]
+
+# This ensures that previous jobs for the PR are canceled when the PR is
+# updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+    
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      # Runs a set of commands using the runners shell
+      - name: Prometheus test on Kind
+        run: |
+          curl -sLO "https://dl.k8s.io/release/v1.23.1/bin/linux/amd64/kubectl" -o kubectl
+          chmod +x kubectl
+          mv kubectl /usr/local/bin
+          "${GITHUB_WORKSPACE}/testing/check-prometheus.sh"

--- a/testing/check-prometheus.sh
+++ b/testing/check-prometheus.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Copyright (C) 2022, MinIO, Inc.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+# This script requires: kubectl, kind, jq
+
+SCRIPT_DIR=$(dirname "$0")
+export SCRIPT_DIR
+source "${SCRIPT_DIR}/common.sh"
+
+function main() {
+    destroy_kind
+
+    setup_kind
+
+    install_operator
+
+    install_tenant
+
+    check_tenant_status tenant-lite storage-lite
+
+    echo 'start - wait for prometheus to appears'
+    i=0
+    while [[ $(kubectl get pods -n tenant-lite --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]];
+    do
+      ((i++))
+      echo "waiting for storage-lite-prometheus-0" && sleep 1;
+      if [[ $i -eq 300 ]]; then
+        break
+      fi
+    done
+    echo 'end - wait for prometheus to appears'
+
+    echo 'Wait for pod to be ready for port forward'
+    try kubectl wait --namespace tenant-lite \
+      --for=condition=ready pod \
+      --selector=statefulset.kubernetes.io/pod-name=storage-lite-ss-0-0 \
+      --timeout=120s
+
+    echo 'port forward without the hop, directly from the tenant/pod'
+    kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
+
+    echo 'start - wait for port-forward to be completed'
+    sleep 15
+    echo 'end - wait for port-forward to be completed'
+
+    echo 'To display port connections'
+    sudo netstat -tunlp # want to see if 9443 is LISTEN state to proceed
+
+    echo 'start - open and allow port connection'
+    sudo apt install ufw
+    sudo ufw allow http
+    sudo ufw allow https
+    sudo ufw allow 9443/tcp
+    echo 'end - open and allow port connection'
+
+    echo 'Get token from MinIO Console'
+    COOKIE=$(
+      curl 'https://localhost:9443/api/v1/login' -vs \
+      -H 'content-type: application/json' \
+      --data-raw '{"accessKey":"minio","secretKey":"minio123"}' --insecure 2>&1 | \
+      grep "set-cookie: token=" | sed -e "s/< set-cookie: token=//g" | \
+      awk -F ';' '{print $1}'
+    )
+    echo $COOKIE
+
+    echo 'start - wait for prometheus to be ready'
+    try kubectl wait --namespace tenant-lite \
+      --for=condition=ready pod \
+      --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 \
+      --timeout=300s
+    echo 'end - wait for prometheus to be ready'
+
+    echo 'start - print the entire output for debug'
+    curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
+      -H 'cookie: token='$COOKIE'' \
+      --compressed \
+      --insecure
+    echo 'end - print the entire output for debug'
+
+    echo 'Verify Prometheus via API'
+    RESULT=$(
+      curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
+      -H 'cookie: token='$COOKIE'' \
+      --compressed \
+      --insecure | jq '.title'
+    )
+    echo $RESULT
+    EXPECTED_RESULT='"Number of Buckets"'
+    echo $EXPECTED_RESULT
+    if [ "$EXPECTED_RESULT" = "$RESULT" ]; then
+        echo "Prometheus is present, no issue found"
+    else
+        echo "Prometheus URL is unreachable"
+        exit 111
+    fi
+
+    destroy_kind
+}
+
+main "$@"

--- a/testing/common.sh
+++ b/testing/common.sh
@@ -96,3 +96,35 @@ function check_tenant_status() {
 
     echo "Done."
 }
+
+# Install tenant function is being used by deploy-tenant and check-prometheus
+function install_tenant() {
+    echo "Installing lite tenant"
+
+    try kubectl apply -k "${SCRIPT_DIR}/../examples/kustomization/tenant-lite"
+
+    echo "Waiting for the tenant statefulset, this indicates the tenant is being fulfilled"
+    waitdone=0
+    totalwait=0
+    while true; do
+    waitdone=$(kubectl -n tenant-lite get pods -l v1.min.io/tenant=storage-lite --no-headers | wc -l)
+    if [ "$waitdone" -ne 0 ]; then
+        echo "Found $waitdone pods"
+        break
+    fi
+    sleep 5
+    totalwait=$((totalwait + 5))
+    if [ "$totalwait" -gt 300 ]; then
+        echo "Tenant never created statefulset after 5 minutes"
+        try false
+    fi
+    done
+
+    echo "Waiting for tenant pods to come online (5m timeout)"
+    try kubectl wait --namespace tenant-lite \
+    --for=condition=ready pod \
+    --selector="v1.min.io/tenant=storage-lite" \
+    --timeout=300s
+
+    echo "Build passes basic tenant creation"
+}

--- a/testing/deploy-tenant.sh
+++ b/testing/deploy-tenant.sh
@@ -20,40 +20,6 @@ export SCRIPT_DIR
 
 source "${SCRIPT_DIR}/common.sh"
 
-
-
-function install_tenant() {
-    echo "Installing lite tenant"
-
-    try kubectl apply -k "${SCRIPT_DIR}/../examples/kustomization/tenant-lite"
-
-    echo "Waiting for the tenant statefulset, this indicates the tenant is being fulfilled"
-    waitdone=0
-    totalwait=0
-    while true; do
-	waitdone=$(kubectl -n tenant-lite get pods -l v1.min.io/tenant=storage-lite --no-headers | wc -l)
-	if [ "$waitdone" -ne 0 ]; then
-	    echo "Found $waitdone pods"
-	    break
-	fi
-	sleep 5
-	totalwait=$((totalwait + 5))
-	if [ "$totalwait" -gt 300 ]; then
-	    echo "Tenant never created statefulset after 5 minutes"
-	    try false
-	fi
-    done
-
-    echo "Waiting for tenant pods to come online (5m timeout)"
-    try kubectl wait --namespace tenant-lite \
-	--for=condition=ready pod \
-	--selector="v1.min.io/tenant=storage-lite" \
-	--timeout=300s
-
-    echo "Build passes basic tenant creation"
-}
-
-
 function main() {
     destroy_kind
 


### PR DESCRIPTION
This tag is linked to: https://github.com/miniohq/engineering/issues/356
Where the idea is to create new test for operator and make sure that after tenant is deployed
prometheus is reachable.
Fixes miniohq/engineering#356