### PR TITLE
add prometheus resource permission to operator helm chart

### DIFF
--- a/helm/operator/templates/cluster-role.yaml
+++ b/helm/operator/templates/cluster-role.yaml
@@ -116,11 +116,9 @@ rules:
   - apiGroups:
       - monitoring.coreos.com
     resources:
-      - servicemonitors
+      - prometheuses
     verbs:
-      - get
-      - create
-      - list
+      - '*'
   - apiGroups:
       - "coordination.k8s.io"
     resources:

--- a/manifests/minio-operator.v4.1.2.clusterserviceversion.yaml
+++ b/manifests/minio-operator.v4.1.2.clusterserviceversion.yaml
@@ -300,7 +300,7 @@ spec:
             - apiGroups:
                 - monitoring.coreos.com
               resources:
-                - servicemonitors
+                - prometheuses
               verbs:
                 - '*'
           serviceAccountName: minio-operator


### PR DESCRIPTION
Replaced `servicemonitors` with `prometheus` on the helm chart