### PR TITLE
fix prometheus addl config not getting removed

### DIFF
--- a/pkg/apis/minio.min.io/v2/names.go
+++ b/pkg/apis/minio.min.io/v2/names.go
@@ -271,7 +271,13 @@ func (t *Tenant) PrometheusHLServiceName() string {
 // PrometheusConfigJobName returns the name of the prometheus job
 func (t *Tenant) PrometheusConfigJobName() string {
 	if t.Spec.PrometheusOperator {
-		return fmt.Sprintf("%s-minio-job", t.Name)
+		return t.PrometheusOperatorAddlConfigJobName()
 	}
 	return "minio-job"
+}
+
+// PrometheusOperatorAddlConfigJobName returns the name of the prometheus job
+// when prometheus operator is enabled
+func (t *Tenant) PrometheusOperatorAddlConfigJobName() string {
+	return fmt.Sprintf("%s-minio-job", t.Name)
 }

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -1707,7 +1707,7 @@ func (c *Controller) checkAndCreatePrometheusAddlConfig(ctx context.Context, ten
 		// Check if the scrape config is already present
 		hasScrapeConfig := false
 		for _, sc := range scrapeConfigs {
-			if sc.JobName == tenant.PrometheusConfigJobName() {
+			if sc.JobName == tenant.PrometheusOperatorAddlConfigJobName() {
 				hasScrapeConfig = true
 				break
 			}
@@ -1764,7 +1764,7 @@ func (c *Controller) deletePrometheusAddlConfig(ctx context.Context, tenant *min
 	hasScrapeConfig := false
 	scIndex := -1
 	for i, sc := range scrapeConfigs {
-		if sc.JobName == tenant.PrometheusConfigJobName() {
+		if sc.JobName == tenant.PrometheusOperatorAddlConfigJobName() {
 			hasScrapeConfig = true
 			scIndex = i
 			break


### PR DESCRIPTION
When prometheus operator is disabled, the same job name
should be used to remove the scrape config.