### PR TITLE
Fix partition creation logic and add tests

### DIFF
--- a/logsearchapi/server/partitions.go
+++ b/logsearchapi/server/partitions.go
@@ -1,19 +1,19 @@
-/*
- * Copyright (C) 2020, MinIO, Inc.
- *
- * This code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License, version 3,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- */
+//
+// This file is part of MinIO Operator
+// Copyright (C) 2020-2022, MinIO, Inc.
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License, version 3,
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+//
 
 package server
 
@@ -49,8 +49,8 @@ type partitionTimeRange struct {
 // newPartitionTimeRange computes the partitionTimeRange including the
 // givenTime.
 func newPartitionTimeRange(givenTime time.Time) partitionTimeRange {
-	// Zero out the time and use UTC
-	t := givenTime
+	// Convert to UTC and zero out the time.
+	t := givenTime.In(time.UTC)
 	t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 	lastDateOfMonth := t.AddDate(0, 1, -t.Day())
 	daysInMonth := lastDateOfMonth.Day()
@@ -246,8 +246,8 @@ func (c *DBClient) partitionTables() {
 	bgCtx := context.Background()
 	tables := []Table{auditLogEventsTable, requestInfoTable}
 	for {
-		// Check if the partition table to store audit logs 24hrs from now exists
-		aDayLater := time.Now().Add(24 * time.Hour)
+		// Check if the partition table to store audit logs 48hrs from now exists
+		aDayLater := time.Now().Add(48 * time.Hour)
 		for _, table := range tables {
 			partitionExists, err := c.checkPartitionTableExists(bgCtx, table.Name, aDayLater)
 			if err != nil {

--- a/logsearchapi/server/partitions_test.go
+++ b/logsearchapi/server/partitions_test.go
@@ -1,0 +1,84 @@
+//
+// This file is part of MinIO Operator
+// Copyright (C) 2022, MinIO, Inc.
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License, version 3,
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+//
+
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewPartitionTimeRange(t *testing.T) {
+	pst, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("Could not load loc: %v", err)
+	}
+	ist, err := time.LoadLocation("Asia/Kolkata")
+	if err != nil {
+		t.Fatalf("Could not load loc: %v", err)
+	}
+
+	utc11hr := time.Date(2022, 1, 24, 11, 0, 0, 0, time.UTC)
+	pst15hr := time.Date(2022, 1, 24, 15, 48, 0, 0, pst)
+	pst16hr := time.Date(2022, 1, 24, 16, 48, 0, 0, pst)
+	ist4hr := time.Date(2022, 1, 25, 4, 30, 0, 0, ist)
+
+	testCases := []struct {
+		givenTime                  time.Time
+		expectedPartitionTimeRange partitionTimeRange
+	}{
+		{
+			givenTime: utc11hr,
+			expectedPartitionTimeRange: partitionTimeRange{
+				GivenTime: utc11hr,
+				StartDate: time.Date(2022, 1, 17, 0, 0, 0, 0, time.UTC),
+				EndDate:   time.Date(2022, 1, 25, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			givenTime: pst15hr,
+			expectedPartitionTimeRange: partitionTimeRange{
+				GivenTime: pst15hr,
+				StartDate: time.Date(2022, time.January, 17, 0, 0, 0, 0, time.UTC),
+				EndDate:   time.Date(2022, time.January, 25, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			givenTime: pst16hr,
+			expectedPartitionTimeRange: partitionTimeRange{
+				GivenTime: pst16hr,
+				StartDate: time.Date(2022, time.January, 25, 0, 0, 0, 0, time.UTC),
+				EndDate:   time.Date(2022, time.February, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			givenTime: ist4hr,
+			expectedPartitionTimeRange: partitionTimeRange{
+				GivenTime: ist4hr,
+				StartDate: time.Date(2022, time.January, 17, 0, 0, 0, 0, time.UTC),
+				EndDate:   time.Date(2022, time.January, 25, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		got := newPartitionTimeRange(testCase.givenTime)
+		if got != testCase.expectedPartitionTimeRange {
+			t.Errorf("%v:\ngot: %#v\nexpected: %#v", i+1, got, testCase.expectedPartitionTimeRange)
+		}
+	}
+}


### PR DESCRIPTION
- Fixes a case where `newPartitionTimeRange` returns an invalid result. Tests
added to address this case.