### PR TITLE
Tenant events

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"os/signal"
 	"strings"
@@ -28,8 +29,6 @@ import (
 	"time"
 
 	"github.com/minio/minio-go/v7/pkg/set"
-
-	"k8s.io/client-go/tools/clientcmd"
 
 	"k8s.io/client-go/rest"
 

--- a/main.go
+++ b/main.go
@@ -21,12 +21,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/minio/minio-go/v7/pkg/set"
 

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -931,6 +931,16 @@ func (t *Tenant) OwnerRef() []metav1.OwnerReference {
 	}
 }
 
+// ObjectRef returns the ObjectReference to be added to all resources created by Tenant
+func (t *Tenant) ObjectRef() corev1.ObjectReference {
+	return corev1.ObjectReference{
+		Kind:      MinIOCRDResourceKind,
+		Namespace: t.Namespace,
+		Name:      t.Name,
+		UID:       t.UID,
+	}
+}
+
 // TLS indicates whether TLS is enabled for this tenant
 func (t *Tenant) TLS() bool {
 	return t.AutoCert() || t.ExternalCert()

--- a/pkg/controller/cluster/console.go
+++ b/pkg/controller/cluster/console.go
@@ -21,6 +21,7 @@ import (
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/minio/operator/pkg/resources/services"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,7 @@ func (c *Controller) checkConsoleSvc(ctx context.Context, tenant *miniov2.Tenant
 			if err != nil {
 				return err
 			}
+			c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "SvcCreated", "Console Service Created")
 		} else {
 			return err
 		}
@@ -77,6 +79,7 @@ func (c *Controller) checkConsoleSvc(ctx context.Context, tenant *miniov2.Tenant
 		if err != nil {
 			return err
 		}
+		c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "Updated", "Console Service Updated")
 	}
 	return err
 }

--- a/pkg/controller/cluster/events.go
+++ b/pkg/controller/cluster/events.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022, MinIO, Inc.
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package cluster
+
+import (
+	"context"
+	"time"
+
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// RegisterEvent creates an event for a given tenant
+func (c *Controller) RegisterEvent(ctx context.Context, tenant *miniov2.Tenant, eventType, reason, message string) {
+	now := time.Now()
+	_, err := c.kubeClientSet.CoreV1().Events(tenant.Namespace).Create(ctx, &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "tenant-",
+			Namespace:    tenant.Namespace,
+		},
+		InvolvedObject: tenant.ObjectRef(),
+		Reason:         reason,
+		Message:        message,
+		Source: corev1.EventSource{
+			Component: "minio-operator",
+		},
+		FirstTimestamp: metav1.NewTime(now),
+		LastTimestamp:  metav1.NewTime(now),
+
+		Type: eventType,
+
+		ReportingController: "minio-operator",
+	}, metav1.CreateOptions{})
+	if err != nil {
+		klog.Errorf("Error registering event: %s", err)
+	}
+}

--- a/pkg/controller/cluster/log-search.go
+++ b/pkg/controller/cluster/log-search.go
@@ -20,6 +20,7 @@ package cluster
 import (
 	"errors"
 	"fmt"
+
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/minio/operator/pkg/resources/deployments"
 	"github.com/minio/operator/pkg/resources/services"

--- a/pkg/controller/cluster/log-search.go
+++ b/pkg/controller/cluster/log-search.go
@@ -20,7 +20,6 @@ package cluster
 import (
 	"errors"
 	"fmt"
-
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/minio/operator/pkg/resources/deployments"
 	"github.com/minio/operator/pkg/resources/services"

--- a/pkg/controller/cluster/minio-services.go
+++ b/pkg/controller/cluster/minio-services.go
@@ -23,6 +23,7 @@ import (
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/minio/operator/pkg/resources/services"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +50,7 @@ func (c *Controller) checkMinIOSvc(ctx context.Context, tenant *miniov2.Tenant, 
 			if err != nil {
 				return err
 			}
+			c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "SvcCreated", "MinIO Service Created")
 		} else {
 			return err
 		}
@@ -78,6 +80,7 @@ func (c *Controller) checkMinIOSvc(ctx context.Context, tenant *miniov2.Tenant, 
 		if err != nil {
 			return err
 		}
+		c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "Updated", "MinIO Service Updated")
 	}
 	return err
 }


### PR DESCRIPTION
Add support for Events for the tenant. This will allow us to detect re-sync loops and understand which stages of the tenant are stuck without needing to look through the logs.

```shell
kubectl -n ns-1 describe tenant new-tenant
```

<img width="1391" alt="Screen Shot 2022-01-25 at 1 44 33 PM" src="https://user-images.githubusercontent.com/18384552/151066908-b6cb83cc-d06e-414e-99d7-e93f0fad1e32.png">

