### PR TITLE
Use the correct yaml package in main controller

### DIFF
--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -29,7 +29,7 @@ import (
 	"github.com/minio/operator/pkg/resources/configmaps"
 	"github.com/minio/operator/pkg/resources/deployments"
 	"github.com/minio/operator/pkg/resources/secrets"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v2"
 
 	"github.com/minio/madmin-go"
 	"k8s.io/klog/v2"


### PR DESCRIPTION
Currently the wrong yaml package is used in the main controller.

This causes the Prometheus scrape config to be in the wrong format.

This PR switches back to using the "gopkg.in/yaml.v2" version instead of "sigs.k8s.io/yaml"

Fixes #990