### PR TITLE
Improving Operator's Tests by Attempting the API request until obtained.

### DIFF
--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -74,14 +74,7 @@ function main() {
     )
     echo $COOKIE
 
-    echo 'start - wait for prometheus to be ready'
-    kubectl get pods --namespace tenant-lite
-    try kubectl wait --namespace tenant-lite \
-      --for=condition=ready pod \
-      --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 \
-      --timeout=300s
-    echo 'end - wait for prometheus to be ready'
-
+    sleep 1800
     echo 'start - print the entire output for debug'
     curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
       -H 'cookie: token='$COOKIE'' \

--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -18,6 +18,49 @@
 SCRIPT_DIR=$(dirname "$0")
 export SCRIPT_DIR
 source "${SCRIPT_DIR}/common.sh"
+FINAL_RESULT=1
+
+function perform_attempts_to_get_log_api_response() {
+    # This function will perform some attempts to get the API response.
+    while true; do
+        kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
+        process_id=$!
+        echo "process_id: ${process_id}"
+
+        echo 'Get token from MinIO Console'
+        COOKIE=$(
+          curl 'https://localhost:9443/api/v1/login' -vs \
+          -H 'content-type: application/json' \
+          --data-raw '{"accessKey":"minio","secretKey":"minio123"}' --insecure 2>&1 | \
+          grep "set-cookie: token=" | sed -e "s/< set-cookie: token=//g" | \
+          awk -F ';' '{print $1}'
+        )
+        echo "Cookie: ${COOKIE}"
+        # If there is no cookie, there is no sense to proceed, so fail if no cookie
+        if [ -z "$COOKIE" ]
+        then
+          echo "\$COOKIE is empty"
+        fi
+        echo 'Verify Logs via API'
+        RESULT=$(
+          curl 'https://localhost:9443/api/v1/logs/search?q=reqinfo&pageSize=100&pageNo=0&order=timeDesc' \
+          -H 'cookie: token='$COOKIE'' \
+          --compressed \
+          --insecure | jq '.results[0].response_status'
+        )
+        echo $RESULT
+        EXPECTED_RESULT='"OK"'
+        echo $EXPECTED_RESULT
+        if [ "$EXPECTED_RESULT" = "$RESULT" ]; then
+            echo "Logs are present, no issue found"
+            FINAL_RESULT=0
+            break
+        else
+            echo "Logs are unreachable"
+        fi
+        sleep 30
+    done
+}
 
 function main() {
     destroy_kind
@@ -30,75 +73,16 @@ function main() {
 
 
     echo 'start - wait for prometheus to appears'
-    i=0
     while [[ $(kubectl get pods -n tenant-lite --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]];
     do
-      ((i++))
       echo "waiting for storage-lite-prometheus-0" && sleep 1;
-      if [[ $i -eq 300 ]]; then
-        break
-      fi
     done
     echo 'end - wait for prometheus to appears'
 
-    echo 'Wait for pod to be ready for port forward'
-    try kubectl wait --namespace tenant-lite \
-      --for=condition=ready pod \
-      --selector=statefulset.kubernetes.io/pod-name=storage-lite-ss-0-0 \
-      --timeout=120s
-
-    echo 'port forward without the hop, directly from the tenant/pod'
-    kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
-
-    echo 'start - wait for port-forward to be completed'
-    sleep 15
-    echo 'end - wait for port-forward to be completed'
-
-    echo 'To display port connections'
-    sudo netstat -tunlp # want to see if 9443 is LISTEN state to proceed
-
-    echo 'start - open and allow port connection'
-    sudo apt install ufw
-    sudo ufw allow http
-    sudo ufw allow https
-    sudo ufw allow 9443/tcp
-    echo 'end - open and allow port connection'
-
-    sleep 1800
-    kubectl get pods -n tenant-lite
-
-    echo 'Get token from MinIO Console'
-    COOKIE=$(
-      curl 'https://localhost:9443/api/v1/login' -vs \
-      -H 'content-type: application/json' \
-      --data-raw '{"accessKey":"minio","secretKey":"minio123"}' --insecure 2>&1 | \
-      grep "set-cookie: token=" | sed -e "s/< set-cookie: token=//g" | \
-      awk -F ';' '{print $1}'
-    )
-    echo $COOKIE
-
-    echo 'start - print the entire output for debug'
-    curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
-      -H 'cookie: token='$COOKIE'' \
-      --compressed \
-      --insecure
-    echo 'end - print the entire output for debug'
-
-    echo 'Verify Logs via API'
-    RESULT=$(
-      curl 'https://localhost:9443/api/v1/logs/search?q=reqinfo&pageSize=100&pageNo=0&order=timeDesc' \
-      -H 'cookie: token='$COOKIE'' \
-      --compressed \
-      --insecure | jq '.results[0].response_status'
-    )
-    echo $RESULT
-    EXPECTED_RESULT='"OK"'
-    echo $EXPECTED_RESULT
-    if [ "$EXPECTED_RESULT" = "$RESULT" ]; then
-        echo "Logs are present, no issue found"
-    else
-        echo "Logs are unreachable"
-        exit 111
+    perform_attempts_to_get_log_api_response
+    if [ $FINAL_RESULT = 1 ]; then
+        echo "Test failed"
+        exit 1
     fi
 
     destroy_kind

--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -76,6 +76,7 @@ function main() {
     echo $COOKIE
 
     echo 'start - wait for prometheus to be ready'
+    kubectl get pods --namespace tenant-lite
     try kubectl wait --namespace tenant-lite \
       --for=condition=ready pod \
       --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 \

--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -28,7 +28,6 @@ function main() {
 
     install_tenant
 
-    check_tenant_status tenant-lite storage-lite
 
     echo 'start - wait for prometheus to appears'
     i=0

--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -23,6 +23,18 @@ FINAL_RESULT=1
 function perform_attempts_to_get_log_api_response() {
     # This function will perform some attempts to get the API response.
     while true; do
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo "kubectl get pods -n tenant-lite"
+        kubectl get pods -n tenant-lite
         kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
         process_id=$!
         echo "process_id: ${process_id}"
@@ -63,6 +75,7 @@ function perform_attempts_to_get_log_api_response() {
 }
 
 function main() {
+
     destroy_kind
 
     setup_kind
@@ -70,14 +83,6 @@ function main() {
     install_operator
 
     install_tenant
-
-
-    echo 'start - wait for prometheus to appears'
-    while [[ $(kubectl get pods -n tenant-lite --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]];
-    do
-      echo "waiting for storage-lite-prometheus-0" && sleep 1;
-    done
-    echo 'end - wait for prometheus to appears'
 
     perform_attempts_to_get_log_api_response
     if [ $FINAL_RESULT = 1 ]; then

--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -64,6 +64,9 @@ function main() {
     sudo ufw allow 9443/tcp
     echo 'end - open and allow port connection'
 
+    sleep 1800
+    kubectl get pods -n tenant-lite
+
     echo 'Get token from MinIO Console'
     COOKIE=$(
       curl 'https://localhost:9443/api/v1/login' -vs \
@@ -74,7 +77,6 @@ function main() {
     )
     echo $COOKIE
 
-    sleep 1800
     echo 'start - print the entire output for debug'
     curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
       -H 'cookie: token='$COOKIE'' \

--- a/testing/check-prometheus.sh
+++ b/testing/check-prometheus.sh
@@ -18,8 +18,64 @@
 SCRIPT_DIR=$(dirname "$0")
 export SCRIPT_DIR
 source "${SCRIPT_DIR}/common.sh"
+FINAL_RESULT=1
+
+function perform_attempts_to_get_prometheus_api_response() {
+    # This function will perform some attempts to get the API response.
+    while true; do
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo ""
+        echo "kubectl get pods -n tenant-lite"
+        kubectl get pods -n tenant-lite
+        kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
+        process_id=$!
+        echo "process_id: ${process_id}"
+
+        echo 'Get token from MinIO Console'
+        COOKIE=$(
+          curl 'https://localhost:9443/api/v1/login' -vs \
+          -H 'content-type: application/json' \
+          --data-raw '{"accessKey":"minio","secretKey":"minio123"}' --insecure 2>&1 | \
+          grep "set-cookie: token=" | sed -e "s/< set-cookie: token=//g" | \
+          awk -F ';' '{print $1}'
+        )
+        echo "Cookie: ${COOKIE}"
+        # If there is no cookie, there is no sense to proceed, so fail if no cookie
+        if [ -z "$COOKIE" ]
+        then
+          echo "\$COOKIE is empty"
+        fi
+        echo 'Verify Prometheus via API'
+        RESULT=$(
+          curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
+          -H 'cookie: token='$COOKIE'' \
+          --compressed \
+          --insecure | jq '.title'
+        )
+        echo $RESULT
+        EXPECTED_RESULT='"Number of Buckets"'
+        echo $EXPECTED_RESULT
+        if [ "$EXPECTED_RESULT" = "$RESULT" ]; then
+            echo "Prometheus is present, no issue found"
+            FINAL_RESULT=0
+            break
+        else
+            echo "Prometheus URL is unreachable"
+        fi
+        sleep 30
+    done
+}
 
 function main() {
+
     destroy_kind
 
     setup_kind
@@ -28,85 +84,14 @@ function main() {
 
     install_tenant
 
-    check_tenant_status tenant-lite storage-lite
-
-    echo 'start - wait for prometheus to appears'
-    i=0
-    while [[ $(kubectl get pods -n tenant-lite --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]];
-    do
-      ((i++))
-      echo "waiting for storage-lite-prometheus-0" && sleep 1;
-      if [[ $i -eq 300 ]]; then
-        break
-      fi
-    done
-    echo 'end - wait for prometheus to appears'
-
-    echo 'Wait for pod to be ready for port forward'
-    try kubectl wait --namespace tenant-lite \
-      --for=condition=ready pod \
-      --selector=statefulset.kubernetes.io/pod-name=storage-lite-ss-0-0 \
-      --timeout=120s
-
-    echo 'port forward without the hop, directly from the tenant/pod'
-    kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
-
-    echo 'start - wait for port-forward to be completed'
-    sleep 15
-    echo 'end - wait for port-forward to be completed'
-
-    echo 'To display port connections'
-    sudo netstat -tunlp # want to see if 9443 is LISTEN state to proceed
-
-    echo 'start - open and allow port connection'
-    sudo apt install ufw
-    sudo ufw allow http
-    sudo ufw allow https
-    sudo ufw allow 9443/tcp
-    echo 'end - open and allow port connection'
-
-    echo 'Get token from MinIO Console'
-    COOKIE=$(
-      curl 'https://localhost:9443/api/v1/login' -vs \
-      -H 'content-type: application/json' \
-      --data-raw '{"accessKey":"minio","secretKey":"minio123"}' --insecure 2>&1 | \
-      grep "set-cookie: token=" | sed -e "s/< set-cookie: token=//g" | \
-      awk -F ';' '{print $1}'
-    )
-    echo $COOKIE
-
-    echo 'start - wait for prometheus to be ready'
-    try kubectl wait --namespace tenant-lite \
-      --for=condition=ready pod \
-      --selector=statefulset.kubernetes.io/pod-name=storage-lite-prometheus-0 \
-      --timeout=300s
-    echo 'end - wait for prometheus to be ready'
-
-    echo 'start - print the entire output for debug'
-    curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
-      -H 'cookie: token='$COOKIE'' \
-      --compressed \
-      --insecure
-    echo 'end - print the entire output for debug'
-
-    echo 'Verify Prometheus via API'
-    RESULT=$(
-      curl 'https://localhost:9443/api/v1/admin/info/widgets/66/?step=0&' \
-      -H 'cookie: token='$COOKIE'' \
-      --compressed \
-      --insecure | jq '.title'
-    )
-    echo $RESULT
-    EXPECTED_RESULT='"Number of Buckets"'
-    echo $EXPECTED_RESULT
-    if [ "$EXPECTED_RESULT" = "$RESULT" ]; then
-        echo "Prometheus is present, no issue found"
-    else
-        echo "Prometheus URL is unreachable"
-        exit 111
+    perform_attempts_to_get_prometheus_api_response
+    if [ $FINAL_RESULT = 1 ]; then
+        echo "Test failed"
+        exit 1
     fi
 
     destroy_kind
+
 }
 
 main "$@"


### PR DESCRIPTION
Hello Team,

Long story short, after changes in PR 989: operator:v4.4.4 tests become bit more inestable.
Nevertheless, when tested manually, noticed that Prometheus and Logs API were both reachable if we
attempted couple of times to get the response. The intention of this test, is to make these tests more
stable by adding a loop to re-try getting the answer from API until this is obtained as before.
Notice that previously, we just attempted this once.

Please give me feedback and if we should proceed this way or if you have any other idea,
I am happy to try other experiment.

Thanks! 