### PR TITLE
Strip extra data from versions before comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/minio/operator
 go 1.17
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/google/go-containerregistry v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=

--- a/pkg/controller/cluster/upgrades.go
+++ b/pkg/controller/cluster/upgrades.go
@@ -18,8 +18,8 @@ package cluster
 
 import (
 	"context"
-	"regexp"
 	"github.com/blang/semver/v4"
+	"regexp"
 
 	"github.com/hashicorp/go-version"
 
@@ -170,7 +170,6 @@ func (c *Controller) upgrade424(ctx context.Context, tenant *miniov2.Tenant) (*m
 // Returns 1 if v2 is smaller, -1
 // if v1 is smaller, 0 if equal
 func versionCompare(version1 string, version2 string) int {
-	klog.Infof("Comparing %s and %s", version1, version2)
 	vs1, err := semver.ParseTolerant(version1)
 	if err != nil {
 		klog.Errorf("Error parsing version %s: %v", version1, err)

--- a/pkg/controller/cluster/upgrades.go
+++ b/pkg/controller/cluster/upgrades.go
@@ -18,8 +18,9 @@ package cluster
 
 import (
 	"context"
-	"github.com/blang/semver/v4"
 	"regexp"
+
+	"github.com/blang/semver/v4"
 
 	"github.com/hashicorp/go-version"
 

--- a/pkg/controller/cluster/upgrades.go
+++ b/pkg/controller/cluster/upgrades.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 
@@ -171,6 +172,8 @@ func (c *Controller) upgrade424(ctx context.Context, tenant *miniov2.Tenant) (*m
 func versionCompare(version1 string, version2 string) int {
 	version1 = version1[1:]
 	version2 = version2[1:]
+	version1 = strings.Split(version1, "-")[0]
+	version2 = strings.Split(version2, "-")[0]
 	i := 0
 	j := 0
 	n := len(version1)

--- a/pkg/controller/cluster/upgrades.go
+++ b/pkg/controller/cluster/upgrades.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"regexp"
 	"github.com/blang/semver/v4"
 
 	"github.com/hashicorp/go-version"

--- a/pkg/controller/cluster/upgrades_test.go
+++ b/pkg/controller/cluster/upgrades_test.go
@@ -1,0 +1,64 @@
+package cluster
+
+import "testing"
+
+func Test_versionCompare(t *testing.T) {
+	type args struct {
+		v1 string
+		v2 string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "v1 == v2",
+			args: args{
+				v1: "v1.0.0",
+				v2: "v1.0.0",
+			},
+			want: 0,
+		},
+		{
+			name: "v1 > v2",
+			args: args{
+				v1: "v1.1.0",
+				v2: "v1.0.0",
+			},
+			want: 1,
+		},
+		{
+			name: "v2 > v1",
+			args: args{
+				v1: "v1.0.0",
+				v2: "v1.1.0",
+			},
+			want: -1,
+		},
+		{
+			name: "v1 > v2",
+			args: args{
+				v1: "v1.1.1-123+123-dirty",
+				v2: "v1.1.0",
+			},
+			want: 1,
+		},
+		{
+			name: "-1 if invalid",
+			args: args{
+				v1: "a-2.c",
+				v2: "v1.1.0",
+			},
+			want: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := versionCompare(tt.args.v1, tt.args.v2)
+			if got != tt.want {
+				t.Errorf("versionCompare() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/cluster/upgrades_test.go
+++ b/pkg/controller/cluster/upgrades_test.go
@@ -1,3 +1,17 @@
+// Copyright (C) 2021, MinIO, Inc.
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License, version 3,
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
 package cluster
 
 import "testing"

--- a/pkg/controller/cluster/upgrades_test.go
+++ b/pkg/controller/cluster/upgrades_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021, MinIO, Inc.
+// Copyright (C) 2022, MinIO, Inc.
 //
 // This code is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License, version 3,


### PR DESCRIPTION
This allows other non vanilla distributions which ship with a modified version of Kubernetes to still be used, example, OKD / OpenShift 9 returns a Kubernetes server version of "v1.22.1-1829+2cb60681522d23-dirty". Since this method is used to check the Kubernetes API version, we strip out the extra version data.