### PR TITLE
fix: logsearchapi bug again

### DIFF
--- a/logsearchapi/server/db.go
+++ b/logsearchapi/server/db.go
@@ -332,7 +332,7 @@ func (c *DBClient) Search(ctx context.Context, s *SearchQuery, w io.Writer) erro
 			whereClauses = append(whereClauses, timeRangeClause)
 		}
 		whereClause := strings.Join(whereClauses, " AND ")
-		if len(whereClauses) >= 0 {
+		if len(whereClauses) > 0 {
 			whereClause = fmt.Sprintf("WHERE %s", whereClause)
 		}
 


### PR DESCRIPTION
Add where clause only when it is present.

Thanks to @krisis for spotting it early.