### PR TITLE
Add support to specify Console domain to pass MinIO for redirect

### DIFF
--- a/helm/operator/crds/minio.min.io_tenants.yaml
+++ b/helm/operator/crds/minio.min.io_tenants.yaml
@@ -4179,6 +4179,8 @@ spec:
                     type: boolean
                   domains:
                     properties:
+                      console:
+                        type: string
                       minio:
                         items:
                           type: string

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -1027,3 +1027,8 @@ func GetPrometheusName() string {
 func (t *Tenant) HasMinIODomains() bool {
 	return t.Spec.Features != nil && t.Spec.Features.Domains != nil && len(t.Spec.Features.Domains.Minio) > 0
 }
+
+// HasConsoleDomains indicates whether a domain is being specified for Console
+func (t *Tenant) HasConsoleDomains() bool {
+	return t.Spec.Features != nil && t.Spec.Features.Domains != nil && t.Spec.Features.Domains.Console != ""
+}

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -66,6 +66,8 @@ type TenantDomains struct {
 	// List of Domains used by MinIO. This will enable DNS style access to the object store where the bucket name is
 	// inferred from a subdomain in the domain.
 	Minio []string `json:"minio,omitempty"`
+	// Domain used to expose the MinIO Console, this will configure the redirect on MinIO when visiting from the browser
+	Console string `json:"console,omitempty"`
 }
 
 // S3Features (`s3`) - Object describing which MinIO features to enable/disable in the MinIO Tenant. +

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -131,6 +131,17 @@ func minioEnvironmentVars(t *miniov2.Tenant, wsSecret *v1.Secret, hostsTemplate 
 			Value: strings.Join(domains, ","),
 		})
 	}
+	// Set the redirect url for console
+	if t.HasConsoleDomains() {
+		schema := "http"
+		if t.TLS() {
+			schema = "https"
+		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "MINIO_BROWSER_REDIRECT_URL",
+			Value: fmt.Sprintf("%s://%s", schema, t.Spec.Features.Domains.Console),
+		})
+	}
 
 	// Add env variables from credentials secret, if no secret provided, dont use
 	// env vars. MinIO server automatically creates default credentials

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -4179,6 +4179,8 @@ spec:
                     type: boolean
                   domains:
                     properties:
+                      console:
+                        type: string
                       minio:
                         items:
                           type: string


### PR DESCRIPTION
adds `.spec.features.domains.console` to configure the public domain for console, this in turns configures `MINIO_BROWSER_REDIRECT_URL`

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>