### PR TITLE
Add support for upgrading tenants from operator v3.x.x to v4.4.13

### DIFF
--- a/docs/crd.adoc
+++ b/docs/crd.adoc
@@ -40,6 +40,33 @@ Specify the amount of storage to request in Gigabytes (GB) for storing audit log
 
 |===
 
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-bucket"]
+==== Bucket
+
+Bucket describes the default created buckets
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`name`* __string__
+|
+
+|*`region`* __string__
+|
+
+|*`objectLock`* __boolean__
+|
+
+|===
+
+
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig"]
 ==== CertificateConfig 
 
@@ -57,17 +84,18 @@ These fields have no effect if `spec.autoCert: false`.
 
 |*`commonName`* __string__
 |*Optional* + 
-The `CommonName` or `CN` attribute to associate to automatically generated TLS certificates. +
+ The `CommonName` or `CN` attribute to associate to automatically generated TLS certificates. +
 
-|*`organizationName`* __string array__
+|*`organizationName`* __string array__ 
 |*Optional* + 
-Specify one or more `OrganizationName` or `O` attributes to associate to automatically generated TLS certificates. +
+ Specify one or more `OrganizationName` or `O` attributes to associate to automatically generated TLS certificates. +
 
-|*`dnsNames`* __string array__
+|*`dnsNames`* __string array__ 
 |*Optional* + 
-Specify one or more x.509 Subject Alternative Names (SAN) to associate to automatically generated TLS certificates. MinIO Server pods use SNI to determine which certificate to respond with based on the requested hostname.
+ Specify one or more x.509 Subject Alternative Names (SAN) to associate to automatically generated TLS certificates. MinIO Server pods use SNI to determine which certificate to respond with based on the requested hostname.
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificatestatus"]
 ==== CertificateStatus 
@@ -79,14 +107,15 @@ CertificateStatus keeps track of all the certificates managed by the operator
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantstatus[$$TenantStatus$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`autoCertEnabled`* __boolean__
+|*`autoCertEnabled`* __boolean__ 
 |AutoCertEnabled registers whether we know if the tenant has autocert enabled
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices"]
 ==== ExposeServices 
@@ -98,19 +127,45 @@ ExposeServices (`exposeServices`) defines the exposure of the MinIO object stora
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`minio`* __boolean__
+|*`minio`* __boolean__ 
 |*Optional* + 
-Directs the Operator to expose the MinIO service. Defaults to `true`. +
+ Directs the Operator to expose the MinIO service. Defaults to `true`. +
 
-|*`console`* __boolean__
+|*`console`* __boolean__ 
 |*Optional* + 
-Directs the Operator to expose the MinIO Console service. Defaults to `true`. +
+ Directs the Operator to expose the MinIO Console service. Defaults to `true`. +
 
 |===
+
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-features"]
+==== Features 
+
+Features (`features`) - Object describing which MinIO features to enable/disable in the MinIO Tenant. +
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`bucketDNS`* __boolean__ 
+|*Optional* + 
+ Specify `true` to allow clients to access buckets using the DNS path `<bucket>.minio.default.svc.cluster.local`. Defaults to `false`.
+
+|*`domains`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantdomains[$$TenantDomains$$]__ 
+|*Optional* + 
+ Specify a list of domains used to access MinIO and Console.
+
+|===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-healthstatus"]
 ==== HealthStatus (string) 
@@ -122,105 +177,107 @@ HealthStatus represents whether the tenant is healthy, with decreased service or
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantstatus[$$TenantStatus$$]
 ****
 
+
+
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig"]
 ==== KESConfig 
 
-KESConfig (`kes`) defines the configuration of the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) StatefulSet deployed as part of the MinIO Tenant.
-KES supports Server-Side Encryption of objects using an external Key Management Service (KMS). +
+KESConfig (`kes`) defines the configuration of the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) StatefulSet deployed as part of the MinIO Tenant. KES supports Server-Side Encryption of objects using an external Key Management Service (KMS). +
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`replicas`* __integer__
+|*`replicas`* __integer__ 
 |*Optional* + 
-Specify the number of replica KES pods to deploy in the tenant. Defaults to `2`.
+ Specify the number of replica KES pods to deploy in the tenant. Defaults to `2`.
 
-|*`image`* __string__
+|*`image`* __string__ 
 |*Optional* + 
-The Docker image to use for deploying MinIO KES. Defaults to {kes-image}. +
+ The Docker image to use for deploying MinIO KES. Defaults to {kes-image}. +
 
-|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__
+|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__ 
 |*Optional* + 
-The pull policy for the MinIO Docker image. Specify one of the following: +
-* `Always` +
-* `Never` +
-* `IfNotPresent` (Default) +
-Refer to the Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+ The pull policy for the MinIO Docker image. Specify one of the following: + 
+ * `Always` + 
+ * `Never` + 
+ * `IfNotPresent` (Default) + 
+ Refer to the Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
 
-|*`serviceAccountName`* __string__
+|*`serviceAccountName`* __string__ 
 |*Optional* + 
-The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
 
-|*`kesSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__
+|*`kesSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
 |*Required* + 
-Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] which contains environment variables to use for setting up the MinIO KES service. +
-See the https://github.com/minio/operator/blob/master/examples/kes-secret.yaml[MinIO Operator `console-secret.yaml`] for an example.
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] which contains environment variables to use for setting up the MinIO KES service. + 
+ See the https://github.com/minio/operator/blob/master/examples/kes-secret.yaml[MinIO Operator `console-secret.yaml`] for an example.
 
-|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__
+|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
 |*Optional* + 
-Enables TLS with SNI support on each MinIO KES pod in the tenant. If `externalCertSecret` is omitted *and* `spec.requestAutoCert` is set to `false`, MinIO KES pods deploy *without* TLS enabled. +
-Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret]. The MinIO Operator copies the specified certificate to every MinIO pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. +
-Specify an object containing the following fields: +
-* - `name` - The name of the Kubernetes secret containing the TLS certificate. +
-* - `type` - Specify `kubernetes.io/tls` +
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+ Enables TLS with SNI support on each MinIO KES pod in the tenant. If `externalCertSecret` is omitted *and* `spec.requestAutoCert` is set to `false`, MinIO KES pods deploy *without* TLS enabled. + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret]. The MinIO Operator copies the specified certificate to every MinIO pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
+ Specify an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
-|*`clientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__
+|*`clientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
 |*Optional* + 
-Specify a a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret] containing a custom root Certificate Authority and x.509 certificate to use for performing mTLS authentication with an external Key Management Service, such as Hashicorp Vault. +
-Specify an object containing the following fields: +
-* - `name` - The name of the Kubernetes secret containing the Certificate Authority and x.509 Certificate. +
-* - `type` - Specify `kubernetes.io/tls` +
+ Specify a a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret] containing a custom root Certificate Authority and x.509 certificate to use for performing mTLS authentication with an external Key Management Service, such as Hashicorp Vault. + 
+ Specify an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the Certificate Authority and x.509 Certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` +
 
-|*`annotations`* __object (keys:string, values:string)__
+|*`annotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these annotations for KES Object Meta annotations
+ If provided, use these annotations for KES Object Meta annotations
 
-|*`labels`* __object (keys:string, values:string)__
+|*`labels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these labels for KES Object Meta labels
+ If provided, use these labels for KES Object Meta labels
 
-|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
 |*Optional* + 
-Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
 
-|*`nodeSelector`* __object (keys:string, values:string)__
+|*`nodeSelector`* __object (keys:string, values:string)__ 
 |*Optional* + 
-The filter for the Operator to apply when selecting which nodes on which to deploy MinIO KES pods. The Operator only selects those nodes whose labels match the specified selector. +
-See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+ The filter for the Operator to apply when selecting which nodes on which to deploy MinIO KES pods. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
-|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO KES pods.
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO KES pods.
 
-|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
 |*Optional* + 
-Specify node affinity, pod affinity, and pod anti-affinity for the KES pods. +
+ Specify node affinity, pod affinity, and pod anti-affinity for the KES pods. +
 
-|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$]__
+|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+ Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
-|*`keyName`* __string__
+|*`keyName`* __string__ 
 |*Optional* + 
-If provided, use this as the name of the key that KES creates on the KMS backend
+ If provided, use this as the name of the key that KES creates on the KMS backend
 
-|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
 |Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of MinIO KES pods. The Operator supports only the following pod security fields: + 
-* `fsGroup` +
-* `fsGroupChangePolicy` +
-* `runAsGroup` +
-* `runAsNonRoot` +
-* `runAsUser` +
-* `seLinuxOptions` +
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference"]
 ==== LocalCertificateReference 
@@ -233,92 +290,93 @@ LocalCertificateReference (`externalCertSecret`, `externalCaCertSecret`,`clientC
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`name`* __string__
+|*`name`* __string__ 
 |*Required* + 
-The name of the Kubernetes secret containing the TLS certificate or Certificate Authority file. +
+ The name of the Kubernetes secret containing the TLS certificate or Certificate Authority file. +
 
-|*`type`* __string__
+|*`type`* __string__ 
 |*Required* + 
-The type of Kubernetes secret. Specify `kubernetes.io/tls` +
+ The type of Kubernetes secret. Specify `kubernetes.io/tls` +
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig"]
 ==== LogConfig 
 
-LogConfig (`log`) defines the configuration of the MinIO Log Search API deployed as part of the MinIO Tenant.
-The Operator deploys a PostgreSQL instance as part of the tenant to support storing and querying MinIO logs. +
-If the tenant specification includes the `console` object, the Operator automatically configures and enables MinIO Log Search via the Console UI.
+LogConfig (`log`) defines the configuration of the MinIO Log Search API deployed as part of the MinIO Tenant. The Operator deploys a PostgreSQL instance as part of the tenant to support storing and querying MinIO logs. + 
+ If the tenant specification includes the `console` object, the Operator automatically configures and enables MinIO Log Search via the Console UI.
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`image`* __string__
+|*`image`* __string__ 
 |*Optional* + 
-The Docker image to use for deploying the MinIO Log Search API. Defaults to {logsearch-image}. +
+ The Docker image to use for deploying the MinIO Log Search API. Defaults to {logsearch-image}. +
 
-|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
 |*Optional* + 
-Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
 
-|*`nodeSelector`* __object (keys:string, values:string)__
+|*`nodeSelector`* __object (keys:string, values:string)__ 
 |*Optional* + 
-The filter for the Operator to apply when selecting which nodes on which to deploy MinIO Log Search API pods. The Operator only selects those nodes whose labels match the specified selector. +
-See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+ The filter for the Operator to apply when selecting which nodes on which to deploy MinIO Log Search API pods. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
-|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
 |*Optional* + 
-Specify node affinity, pod affinity, and pod anti-affinity for LogSearch API pods. +
+ Specify node affinity, pod affinity, and pod anti-affinity for LogSearch API pods. +
 
-|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO Log Search API pods.
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO Log Search API pods.
 
-|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$]__
+|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+ Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
-|*`annotations`* __object (keys:string, values:string)__
+|*`annotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these annotations for Log Search Object Meta annotations
+ If provided, use these annotations for Log Search Object Meta annotations
 
-|*`labels`* __object (keys:string, values:string)__
+|*`labels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these labels for Log Search Object Meta labels
+ If provided, use these labels for Log Search Object Meta labels
 
-|*`db`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logdbconfig[$$LogDbConfig$$]__
+|*`db`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logdbconfig[$$LogDbConfig$$]__ 
 |*Optional* + 
-Object specification for configuring the backing PostgreSQL database for the LogSearch API. +
+ Object specification for configuring the backing PostgreSQL database for the LogSearch API. +
 
-|*`audit`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-auditconfig[$$AuditConfig$$]__
+|*`audit`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-auditconfig[$$AuditConfig$$]__ 
 |*Required* + 
-Object specification for configuring LogSearch API.
+ Object specification for configuring LogSearch API.
 
-|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
 |*Optional* + 
-Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods deployed as part of the Log Search API. The Operator supports only the following pod security fields: +
-* `fsGroup` +
-* `fsGroupChangePolicy` +
-* `runAsGroup` +
-* `runAsNonRoot` +
-* `runAsUser` +
-* `seLinuxOptions` +
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods deployed as part of the Log Search API. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
 
-|*`serviceAccountName`* __string__
+|*`serviceAccountName`* __string__ 
 |*Optional* + 
-The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logdbconfig"]
 ==== LogDbConfig 
@@ -330,67 +388,68 @@ LogDbConfig (`db`) defines the configuration of the PostgreSQL StatefulSet deplo
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig[$$LogConfig$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`image`* __string__
+|*`image`* __string__ 
 |*Optional* + 
-The Docker image to use for deploying PostgreSQL. Defaults to {postgres-image}. +
+ The Docker image to use for deploying PostgreSQL. Defaults to {postgres-image}. +
 
-|*`initimage`* __string__
+|*`initimage`* __string__ 
 |*Optional* + 
-Defines the Docker image to use as the init container for running the postgres server. Defaults to `busybox`. +
-The specified Docker image *must* be the https://hub.docker.com/_/busybox[`busybox`] package. +
+ Defines the Docker image to use as the init container for running the postgres server. Defaults to `busybox`. + 
+ The specified Docker image *must* be the https://hub.docker.com/_/busybox[`busybox`] package. +
 
-|*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__
+|*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
 |*Optional* + 
-Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the PostgreSQL pod. +
+ Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the PostgreSQL pod. +
 
-|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
 |*Optional* + 
-Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits for the PostgreSQL pod.
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits for the PostgreSQL pod.
 
-|*`nodeSelector`* __object (keys:string, values:string)__
+|*`nodeSelector`* __object (keys:string, values:string)__ 
 |*Optional* + 
-The filter for the Operator to apply when selecting which nodes on which to deploy the PostgreSQL pod. The Operator only selects those nodes whose labels match the specified selector. +
-See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+ The filter for the Operator to apply when selecting which nodes on which to deploy the PostgreSQL pod. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
-|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
 |*Optional* + 
-Specify node affinity, pod affinity, and pod anti-affinity for the PostgreSQL pods. +
+ Specify node affinity, pod affinity, and pod anti-affinity for the PostgreSQL pods. +
 
-|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$]__
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to the PostgreSQL pods.
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to the PostgreSQL pods.
 
-|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$]__
+|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+ Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
-|*`annotations`* __object (keys:string, values:string)__
+|*`annotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these annotations for PostgreSQL Object Meta annotations
+ If provided, use these annotations for PostgreSQL Object Meta annotations
 
-|*`labels`* __object (keys:string, values:string)__
+|*`labels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these labels for PostgreSQL Object Meta labels
+ If provided, use these labels for PostgreSQL Object Meta labels
 
-|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
 |*Optional* + 
-Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of the PostgreSQL pods. The Operator supports only the following pod security fields: +
-* `fsGroup` +
-* `fsGroupChangePolicy` +
-* `runAsGroup` +
-* `runAsNonRoot` +
-* `runAsUser` +
-* `seLinuxOptions` +
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of the PostgreSQL pods. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
 
-|*`serviceAccountName`* __string__
+|*`serviceAccountName`* __string__ 
 |*Optional* + 
-The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logging"]
 ==== Logging 
@@ -402,97 +461,97 @@ Logging describes Logging for MinIO tenants.
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`json`* __boolean__
+|*`json`* __boolean__ 
 |
 
-|*`anonymous`* __boolean__
+|*`anonymous`* __boolean__ 
 |
 
-|*`quiet`* __boolean__
+|*`quiet`* __boolean__ 
 |
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool"]
 ==== Pool 
 
-Pool (`pools`) defines a MinIO server pool on a Tenant.
-Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests.
-Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
+Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`name`* __string__
+|*`name`* __string__ 
 |*Optional* + 
-Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
+ Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
 
-|*`servers`* __integer__
-|*Required*
-The number of MinIO server pods to deploy in the pool. The minimum value is `2`.
-The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+|*`servers`* __integer__ 
+|*Required* 
+ The number of MinIO server pods to deploy in the pool. The minimum value is `2`. 
+ The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 
-|*`volumesPerServer`* __integer__
+|*`volumesPerServer`* __integer__ 
 |*Required* + 
-The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. +
-The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+ The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. + 
+ The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 
-|*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__
+|*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
 |*Required* + 
-Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the MinIO tenant. +
+ Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the MinIO tenant. +
 
-|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
 |*Optional* + 
-Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
 
-|*`nodeSelector`* __object (keys:string, values:string)__
+|*`nodeSelector`* __object (keys:string, values:string)__ 
 |*Optional* + 
-The filter for the Operator to apply when selecting which nodes on which to deploy pods in the pool. The Operator only selects those nodes whose labels match the specified selector. +
-See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+ The filter for the Operator to apply when selecting which nodes on which to deploy pods in the pool. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
-|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
 |*Optional* + 
-Specify node affinity, pod affinity, and pod anti-affinity for pods in the MinIO pool. +
+ Specify node affinity, pod affinity, and pod anti-affinity for pods in the MinIO pool. +
 
-|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$] array__
+|*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#toleration-v1-core[$$Toleration$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to pods deployed in the MinIO pool.
+ Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to pods deployed in the MinIO pool.
 
-|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__
+|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+ Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
-|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
 |*Optional* + 
-Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods in the pool. The Operator supports only the following pod security fields: +
-* `fsGroup` +
-* `fsGroupChangePolicy` +
-* `runAsGroup` +
-* `runAsNonRoot` +
-* `runAsUser` +
-* `seLinuxOptions` +
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods in the pool. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
 
-|*`annotations`* __object (keys:string, values:string)__
+|*`annotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-Specify custom labels and annotations to append to the Pool. *Optional* +
-If provided, use these annotations for the Pool Objects Meta annotations (Statefulset and Pod template)
+ Specify custom labels and annotations to append to the Pool. *Optional* + 
+ If provided, use these annotations for the Pool Objects Meta annotations (Statefulset and Pod template)
 
-|*`labels`* __object (keys:string, values:string)__
+|*`labels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these labels for the Pool Objects Meta annotations (Statefulset and Pod template)
+ If provided, use these labels for the Pool Objects Meta annotations (Statefulset and Pod template)
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstate"]
 ==== PoolState (string) 
@@ -504,6 +563,8 @@ PoolState represents the state of a pool
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstatus[$$PoolStatus$$]
 ****
 
+
+
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstatus"]
 ==== PoolStatus 
 
@@ -514,150 +575,123 @@ PoolStatus keeps track of all the pools and their current state
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantstatus[$$TenantStatus$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`ssName`* __string__
+|*`ssName`* __string__ 
 |
 
-|*`state`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstate[$$PoolState$$]__
+|*`state`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-poolstate[$$PoolState$$]__ 
 |
 
-|*`legacySecurityContext`* __boolean__
+|*`legacySecurityContext`* __boolean__ 
 |LegacySecurityContext stands for Legacy SecurityContext. It represents that these pool was created before v4.2.3 when we introduced the default securityContext as non-root, thus we should keep running this Pool without a Security Context
 
 |===
 
+
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig"]
 ==== PrometheusConfig 
 
-PrometheusConfig (`prometheus`) defines the configuration of a Prometheus instance as part of the MinIO tenant.
-The Operator automatically configures the Prometheus instance to scrape and store metrics from the MinIO tenant. +
-The Operator deploys each Prometheus pod using the {prometheus-image} Docker image.
+PrometheusConfig (`prometheus`) defines the configuration of a Prometheus instance as part of the MinIO tenant. The Operator automatically configures the Prometheus instance to scrape and store metrics from the MinIO tenant. + 
+ The Operator deploys each Prometheus pod using the {prometheus-image} Docker image.
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`image`* __string__
+|*`image`* __string__ 
 |*Optional* + 
-Defines the Docker image to use for deploying Prometheus pods. Defaults to {prometheus-image}. +
+ Defines the Docker image to use for deploying Prometheus pods. Defaults to {prometheus-image}. +
 
-|*`sidecarimage`* __string__
+|*`sidecarimage`* __string__ 
 |*Optional* + 
-*Deprecated in Operator v4.0.1* +
-Defines the Docker image to use as a sidecar for the Prometheus server. Defaults to `alpine`. +
-The specified Docker image *must* be the https://hub.docker.com/_/alpine[`alpine`] package. +
+ *Deprecated in Operator v4.0.1* + 
+ Defines the Docker image to use as a sidecar for the Prometheus server. Defaults to `alpine`. + 
+ The specified Docker image *must* be the https://hub.docker.com/_/alpine[`alpine`] package. +
 
-|*`initimage`* __string__
+|*`initimage`* __string__ 
 |*Optional* + 
-*Deprecated in Operator v4.0.1* +
-Defines the Docker image to use as the init container for running the Prometheus server. Defaults to `busybox`. +
-The specified Docker image *must* be the https://hub.docker.com/_/busybox[`busybox`] package. +
+ *Deprecated in Operator v4.0.1* + 
+ Defines the Docker image to use as the init container for running the Prometheus server. Defaults to `busybox`. + 
+ The specified Docker image *must* be the https://hub.docker.com/_/busybox[`busybox`] package. +
 
-|*`diskCapacityGB`* __integer__
+|*`diskCapacityGB`* __integer__ 
 |*Optional* + 
-Specify the amount of storage to request in Gigabytes (GB) for supporting the Prometheus pod.
+ Specify the amount of storage to request in Gigabytes (GB) for supporting the Prometheus pod.
 
-|*`storageClassName`* __string__
+|*`storageClassName`* __string__ 
 |*Optional* + 
-Specify the storage class for the PVC to support the Prometheus pod.
+ Specify the storage class for the PVC to support the Prometheus pod.
 
-|*`annotations`* __object (keys:string, values:string)__
+|*`annotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these annotations for Prometheus Object Meta annotations
+ If provided, use these annotations for Prometheus Object Meta annotations
 
-|*`labels`* __object (keys:string, values:string)__
+|*`labels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, use these labels for Prometheus Object Meta labels
+ If provided, use these labels for Prometheus Object Meta labels
 
-|*`nodeSelector`* __object (keys:string, values:string)__
+|*`nodeSelector`* __object (keys:string, values:string)__ 
 |*Optional* + 
-The filter for the Operator to apply when selecting which nodes on which to deploy the Prometheus pod. The Operator only selects those nodes whose labels match the specified selector. +
-See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+ The filter for the Operator to apply when selecting which nodes on which to deploy the Prometheus pod. The Operator only selects those nodes whose labels match the specified selector. + 
+ See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
-|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__
+|*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#affinity-v1-core[$$Affinity$$]__ 
 |*Optional* + 
-Specify node affinity, pod affinity, and pod anti-affinity for the Prometheus pods. +
+ Specify node affinity, pod affinity, and pod anti-affinity for the Prometheus pods. +
 
-|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$]__
+|*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
 |*Optional* + 
-Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+ Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
-|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__
+|*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
 |*Optional* + 
-Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits of the Prometheus pod. +
+ Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits of the Prometheus pod. +
 
-|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__
+|*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
 |*Optional* + 
-Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of the Prometheus pod. The Operator supports only the following pod security fields: +
-* `fsGroup` +
-* `fsGroupChangePolicy` +
-* `runAsGroup` +
-* `runAsNonRoot` +
-* `runAsUser` +
-* `seLinuxOptions` +
+ Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of the Prometheus pod. The Operator supports only the following pod security fields: + 
+ * `fsGroup` + 
+ * `fsGroupChangePolicy` + 
+ * `runAsGroup` + 
+ * `runAsNonRoot` + 
+ * `runAsUser` + 
+ * `seLinuxOptions` +
 
-|*`serviceAccountName`* __string__
+|*`serviceAccountName`* __string__ 
 |*Optional* + 
-The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features"]
 ==== S3Features 
 
-S3Features (`s3`) - Object describing which S3 features to enable/disable in the MinIO Tenant. + 
-Currently only supports `BucketDNS`
+S3Features (`s3`) - Object describing which MinIO features to enable/disable in the MinIO Tenant. + *Deprecated in Operator v4.3.2* +
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`bucketDNS`* __boolean__
+|*`bucketDNS`* __boolean__ 
 |*Optional* + 
-Specify `true` to allow clients to access buckets using the DNS path `<bucket>.minio.default.svc.cluster.local`. Defaults to `false`.
+ Specify `true` to allow clients to access buckets using the DNS path `<bucket>.minio.default.svc.cluster.local`. Defaults to `false`.
 
 |===
 
-[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-bucket"]
-==== Bucket
-
-Bucket (`buckets`) defines a bucket that should be created upon creation of tenant
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
-****
-
-[cols="25a,75a",options="header"]
-|===
-| Field | Description
-
-|*`name`* __string__
-|*Required* +
-Specify bucket name
-
-|*`region`* __string__
-|*Optional* +
-Specify bucket region
-
-|*`objectLock`* __boolean__
-|*Optional* +
-Specify objectLock for a bucket
-
-|===
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-servicemetadata"]
 ==== ServiceMetadata 
@@ -669,27 +703,28 @@ ServiceMetadata (`serviceMetadata`) defines custom labels and annotations for th
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`minioServiceLabels`* __object (keys:string, values:string)__
+|*`minioServiceLabels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, append these labels to the MinIO service
+ If provided, append these labels to the MinIO service
 
-|*`minioServiceAnnotations`* __object (keys:string, values:string)__
+|*`minioServiceAnnotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, append these annotations to the MinIO service
+ If provided, append these annotations to the MinIO service
 
-|*`consoleServiceLabels`* __object (keys:string, values:string)__
+|*`consoleServiceLabels`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, append these labels to the Console service
+ If provided, append these labels to the Console service
 
-|*`consoleServiceAnnotations`* __object (keys:string, values:string)__
+|*`consoleServiceAnnotations`* __object (keys:string, values:string)__ 
 |*Optional* + 
-If provided, append these annotations to the Console service
+ If provided, append these annotations to the Console service
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars"]
 ==== SideCars 
@@ -701,23 +736,24 @@ SideCars (`sidecars`) defines a list of containers that the Operator attaches to
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`containers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core[$$Container$$] array__
+|*`containers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core[$$Container$$] array__ 
 |*Optional* + 
-List of containers to run inside the Pod
+ List of containers to run inside the Pod
 
-|*`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__
+|*`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ 
 |*Optional* + 
-volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+ volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
 
-|*`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core[$$Volume$$] array__
+|*`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core[$$Volume$$] array__ 
 |*Optional* + 
-List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+ List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenant"]
 ==== Tenant 
@@ -729,22 +765,45 @@ Tenant is a https://kubernetes.io/docs/concepts/overview/working-with-objects/ku
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantlist[$$TenantList$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta[$$ObjectMeta$$]__
+|*`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#objectmeta-v1-meta[$$ObjectMeta$$]__ 
 |Refer to Kubernetes API documentation for fields of `metadata`.
 
 
-|*`scheduler`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler[$$TenantScheduler$$]__
+|*`scheduler`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler[$$TenantScheduler$$]__ 
 |
 
-|*`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]__
+|*`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]__ 
 |*Required* + 
-The root field for the MinIO Tenant object.
+ The root field for the MinIO Tenant object.
 
 |===
+
+
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantdomains"]
+==== TenantDomains 
+
+TenantDomains (`domains`) - List of domains used to access the tenant from outside the kubernetes clusters. this will only configure MinIO for the domains listed, but external DNS configuration is still needed.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-features[$$Features$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`minio`* __string array__ 
+|List of Domains used by MinIO. This will enable DNS style access to the object store where the bucket name is inferred from a subdomain in the domain.
+
+|===
+
+
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantscheduler"]
 ==== TenantScheduler 
@@ -756,188 +815,195 @@ TenantScheduler (`scheduler`) - Object describing Kubernetes Scheduler to use fo
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenant[$$Tenant$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`name`* __string__
+|*`name`* __string__ 
 |*Optional* + 
-Specify the name of the https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/[Kubernetes scheduler] to be used to schedule Tenant pods
+ Specify the name of the https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/[Kubernetes scheduler] to be used to schedule Tenant pods
 
 |===
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec"]
 ==== TenantSpec 
 
 TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. + 
-The following parameters are specific to the `minio.min.io/v2` MinIO CRD API `spec` definition added as part of the MinIO Operator v4.0.0. +
-For more complete documentation on this object, see the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#minio-operator-yaml-reference[MinIO Kubernetes Documentation]. +
+ The following parameters are specific to the `minio.min.io/v2` MinIO CRD API `spec` definition added as part of the MinIO Operator v4.0.0. + 
+ For more complete documentation on this object, see the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#minio-operator-yaml-reference[MinIO Kubernetes Documentation]. +
 
 .Appears In:
 ****
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenant[$$Tenant$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`pools`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool[$$Pool$$] array__
+|*`pools`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool[$$Pool$$] array__ 
 |*Required* + 
-An array of objects describing each MinIO server pool deployed in the MinIO Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
-The MinIO Tenant `spec` *must have* at least *one* element in the `pools` array. +
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
+ An array of objects describing each MinIO server pool deployed in the MinIO Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. + 
+ The MinIO Tenant `spec` *must have* at least *one* element in the `pools` array. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
 
-|*`image`* __string__
+|*`image`* __string__ 
 |*Optional* + 
-The Docker image to use when deploying `minio` server pods. Defaults to {minio-image}. +
+ The Docker image to use when deploying `minio` server pods. Defaults to {minio-image}. +
 
-|*`imagePullSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__
+|*`imagePullSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
 |*Optional* + 
-Specify the secret key to use for pulling images from a private Docker repository. +
+ Specify the secret key to use for pulling images from a private Docker repository. +
 
-|*`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__
+|*`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ 
 |*Optional* + 
-Pod Management Policy for pod created by StatefulSet
+ Pod Management Policy for pod created by StatefulSet
 
-|*`credsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__
+|*`credsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
 |*Required* + 
-Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] to use for setting the MinIO root access key and secret key. Specify the secret as `name: <secret>`. The Kubernetes secret must contain the following fields: +
-* `data.accesskey` - The access key for the root credentials +
-* `data.secretkey` - The secret key for the root credentials +
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] to use for setting the MinIO root access key and secret key. Specify the secret as `name: <secret>`. The Kubernetes secret must contain the following fields: + 
+ * `data.accesskey` - The access key for the root credentials + 
+ * `data.secretkey` - The secret key for the root credentials +
 
-|*`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core[$$EnvVar$$] array__
+|*`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvar-v1-core[$$EnvVar$$] array__ 
 |*Optional* + 
-If provided, the MinIO Operator adds the specified environment variables when deploying the Tenant resource.
+ If provided, the MinIO Operator adds the specified environment variables when deploying the Tenant resource.
 
-|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__
+|*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ 
 |*Optional* + 
-Enables TLS with SNI support on each MinIO pod in the tenant. If `externalCertSecret` is omitted *and* `requestAutoCert` is set to `false`, the MinIO Tenant deploys *without* TLS enabled. +
-Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. +
-Each element in the `externalCertSecret` array is an object containing the following fields: +
-* - `name` - The name of the Kubernetes secret containing the TLS certificate. +
-* - `type` - Specify `kubernetes.io/tls` +
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+ Enables TLS with SNI support on each MinIO pod in the tenant. If `externalCertSecret` is omitted *and* `requestAutoCert` is set to `false`, the MinIO Tenant deploys *without* TLS enabled. + 
+ Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
+ Each element in the `externalCertSecret` array is an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * - `type` - Specify `kubernetes.io/tls` + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
-|*`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__
+|*`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ 
 |*Optional* + 
-Allows MinIO server pods to verify client TLS certificates signed by a Certificate Authority not in the pod's trust store. +
-Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. +
-Each element in the `externalCertSecret` array is an object containing the following fields: +
-* - `name` - The name of the Kubernetes secret containing the Certificate Authority. +
-* - `type` - Specify `kubernetes.io/tls`. +
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+ Allows MinIO server pods to verify client TLS certificates signed by a Certificate Authority not in the pod's trust store. + 
+ Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. + 
+ Each element in the `externalCertSecret` array is an object containing the following fields: + 
+ * - `name` - The name of the Kubernetes secret containing the Certificate Authority. + 
+ * - `type` - Specify `kubernetes.io/tls`. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
-|*`externalClientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__
+|*`externalClientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
 |*Optional* + 
-Enables mTLS authentication between the MinIO Tenant pods and https://github.com/minio/kes[MinIO KES]. *Required* for enabling connectivity between the MinIO Tenant and MinIO KES. +
-Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant. The secret *must* contain the following fields: +
-* `name` - The name of the Kubernetes secret containing the TLS certificate. +
-* `type` - Specify `kubernetes.io/tls` +
-The specified certificate *must* correspond to an identity on the KES server. See the https://github.com/minio/kes/wiki/Configuration#policy-configuration[KES Wiki] for more information on KES identities. +
-If deploying KES with the MinIO Operator, include the hash of the certificate as part of the <<k8s-api-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig,`kes`>> object specification. +
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+ Enables mTLS authentication between the MinIO Tenant pods and https://github.com/minio/kes[MinIO KES]. *Required* for enabling connectivity between the MinIO Tenant and MinIO KES. + 
+ Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant. The secret *must* contain the following fields: + 
+ * `name` - The name of the Kubernetes secret containing the TLS certificate. + 
+ * `type` - Specify `kubernetes.io/tls` + 
+ The specified certificate *must* correspond to an identity on the KES server. See the https://github.com/minio/kes/wiki/Configuration#policy-configuration[KES Wiki] for more information on KES identities. + 
+ If deploying KES with the MinIO Operator, include the hash of the certificate as part of the <<k8s-api-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig,`kes`>> object specification. + 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
-|*`mountPath`* __string__
+|*`mountPath`* __string__ 
 |*Optional* + 
-Mount path for MinIO volume (PV). Defaults to `/export`
+ Mount path for MinIO volume (PV). Defaults to `/export`
 
-|*`subPath`* __string__
+|*`subPath`* __string__ 
 |*Optional* + 
-Subpath inside mount path. This is the directory where MinIO stores data. Default to `""`` (empty)
+ Subpath inside mount path. This is the directory where MinIO stores data. Default to `""`` (empty)
 
-|*`requestAutoCert`* __boolean__
+|*`requestAutoCert`* __boolean__ 
 |*Optional* + 
-Enables using https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/[Kubernetes-based TLS certificate generation] and signing for pods and services in the MinIO Tenant. +
-* Specify `true` to explicitly enable automatic certificate generate (Default). +
-* Specify `false` to disable automatic certificate generation. +
-If `requestAutoCert` is set to `false` *and* `externalCertSecret` is omitted, the MinIO Tenant deploys *without* TLS enabled.
-See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+ Enables using https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/[Kubernetes-based TLS certificate generation] and signing for pods and services in the MinIO Tenant. + 
+ * Specify `true` to explicitly enable automatic certificate generate (Default). + 
+ * Specify `false` to disable automatic certificate generation. + 
+ If `requestAutoCert` is set to `false` *and* `externalCertSecret` is omitted, the MinIO Tenant deploys *without* TLS enabled. 
+ See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
-|*`liveness`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#probe-v1-core[$$Probe$$]__
+|*`liveness`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#probe-v1-core[$$Probe$$]__ 
 |Liveness Probe for container liveness. Container will be restarted if the probe fails.
 
-|*`readiness`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#probe-v1-core[$$Probe$$]__
+|*`readiness`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#probe-v1-core[$$Probe$$]__ 
 |Readiness Probe for container readiness. Container will be removed from service endpoints if the probe fails.
 
-|*`s3`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features[$$S3Features$$]__
-|*Optional* + 
-S3 related features can be disabled or enabled such as `bucketDNS` etc.
+|*`s3`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-s3features[$$S3Features$$]__ 
+|*Optional* + *Deprecated in Operator v4.3.2* + 
+ S3 related features can be disabled or enabled such as `bucketDNS` etc.
 
-|*`buckets`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-bucket[$$Bucket$$] array__
-|*Optional* +
-An array of objects describing buckets should be created upon creation of tenant.
+|*`features`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-features[$$Features$$]__ 
+|S3 related features can be disabled or enabled such as `bucketDNS` etc.
 
-|*`certConfig`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig[$$CertificateConfig$$]__
+|*`certConfig`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig[$$CertificateConfig$$]__ 
 |*Optional* + 
-Enables setting the `CommonName`, `Organization`, and `dnsName` attributes for all TLS certificates automatically generated by the Operator. Configuring this object has no effect if `requestAutoCert` is `false`. +
+ Enables setting the `CommonName`, `Organization`, and `dnsName` attributes for all TLS certificates automatically generated by the Operator. Configuring this object has no effect if `requestAutoCert` is `false`. +
 
-|*`kes`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]__
+|*`kes`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]__ 
 |*Optional* + 
-Directs the MinIO Operator to deploy the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) using the specified configuration. The MinIO KES supports performing server-side encryption of objects on the MiNIO Tenant. +
+ Directs the MinIO Operator to deploy the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) using the specified configuration. The MinIO KES supports performing server-side encryption of objects on the MiNIO Tenant. +
 
-|*`log`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig[$$LogConfig$$]__
+|*`log`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logconfig[$$LogConfig$$]__ 
 |*Optional* + 
-Directs the MinIO Operator to deploy and configure the MinIO Log Search API. The Operator deploys a PostgreSQL instance as part of the tenant to support storing and querying MinIO logs. +
-If the tenant spec includes the `log` configuration, the Operator automatically configures and enables MinIO log search via the Console UI. +
+ Directs the MinIO Operator to deploy and configure the MinIO Log Search API. The Operator deploys a PostgreSQL instance as part of the tenant to support storing and querying MinIO logs. + 
+ If the tenant spec includes the `log` configuration, the Operator automatically configures and enables MinIO log search via the Console UI. +
 
-|*`prometheus`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig[$$PrometheusConfig$$]__
+|*`prometheus`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-prometheusconfig[$$PrometheusConfig$$]__ 
 |*Optional* + 
-Directs the MinIO Operator to deploy and configure Prometheus for collecting tenant metrics. +
-For example, `minio.<namespace>.svc.<cluster-domain>.<example>/minio/v2/metrics/cluster`. The specific DNS name for the service depends on your Kubernetes cluster configuration. See the Kubernetes documentation on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/[DNS for Services and Pods] for more information.
+ Directs the MinIO Operator to deploy and configure Prometheus for collecting tenant metrics. + 
+ For example, `minio.<namespace>.svc.<cluster-domain>.<example>/minio/v2/metrics/cluster`. The specific DNS name for the service depends on your Kubernetes cluster configuration. See the Kubernetes documentation on https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/[DNS for Services and Pods] for more information.
 
-|*`prometheusOperator`* __boolean__
+|*`prometheusOperator`* __boolean__ 
 |*Optional* + 
-Directs the MinIO Operator to use prometheus operator. +
-Tenant scrape configuration will be added to prometheus managed by the prometheus-operator.
+ Directs the MinIO Operator to use prometheus operator. + 
+ Tenant scrape configuration will be added to prometheus managed by the prometheus-operator.
 
-|*`serviceAccountName`* __string__
+|*`serviceAccountName`* __string__ 
 |*Optional* + 
-The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO pods created as part of the Tenant. +
+ The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO pods created as part of the Tenant. +
 
-|*`priorityClassName`* __string__
+|*`priorityClassName`* __string__ 
 |*Optional* + 
-Indicates the Pod priority and therefore importance of a Pod relative to other Pods in the cluster. This is applied to MinIO pods only. +
-Refer Kubernetes https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[Priority Class documentation] for more complete documentation.
+ Indicates the Pod priority and therefore importance of a Pod relative to other Pods in the cluster. This is applied to MinIO pods only. + 
+ Refer Kubernetes https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[Priority Class documentation] for more complete documentation.
 
-|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__
+|*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pullpolicy-v1-core[$$PullPolicy$$]__ 
 |*Optional* + 
-The pull policy for the MinIO Docker image. Specify one of the following: +
-* `Always` +
-* `Never` +
-* `IfNotPresent` (Default) +
-Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+ The pull policy for the MinIO Docker image. Specify one of the following: + 
+ * `Always` + 
+ * `Never` + 
+ * `IfNotPresent` (Default) + 
+ Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
 
-|*`sideCars`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars[$$SideCars$$]__
+|*`sideCars`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars[$$SideCars$$]__ 
 |*Optional* + 
-A list of containers to run as sidecars along every MinIO Pod deployed in the tenant.
+ A list of containers to run as sidecars along every MinIO Pod deployed in the tenant.
 
-|*`exposeServices`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices[$$ExposeServices$$]__
+|*`exposeServices`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices[$$ExposeServices$$]__ 
 |*Optional* + 
-Directs the Operator to expose the MinIO and/or Console services. +
+ Directs the Operator to expose the MinIO and/or Console services. +
 
-|*`serviceMetadata`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-servicemetadata[$$ServiceMetadata$$]__
+|*`serviceMetadata`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-servicemetadata[$$ServiceMetadata$$]__ 
 |*Optional* + 
-Specify custom labels and annotations to append to the MinIO service and/or Console service.
+ Specify custom labels and annotations to append to the MinIO service and/or Console service.
 
-|*`users`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__
+|*`users`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$] array__ 
 |*Optional* + 
-An array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secrets] to use for generating MinIO users during tenant provisioning. +
-Each element in the array is an object consisting of a key-value pair `name: <string>`, where the `<string>` references an opaque Kubernetes secret. +
-Each referenced Kubernetes secret must include the following fields: +
-* `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user +
-* `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user +
-The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
+ An array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secrets] to use for generating MinIO users during tenant provisioning. + 
+ Each element in the array is an object consisting of a key-value pair `name: <string>`, where the `<string>` references an opaque Kubernetes secret. + 
+ Each referenced Kubernetes secret must include the following fields: + 
+ * `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user + 
+ * `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user + 
+ The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
 
-|*`logging`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logging[$$Logging$$]__
+|*`buckets`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-bucket[$$Bucket$$] array__ 
 |*Optional* + 
-Enable JSON, Anonymous logging for MinIO tenants.
+ Create buckets when creating a new tenant. Skip if bucket with given name already exists
 
-|*`configuration`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__
+|*`logging`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logging[$$Logging$$]__ 
 |*Optional* + 
-Specify a secret that contains additional environment variable configurations to be used for the MinIO pools. The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
+ Enable JSON, Anonymous logging for MinIO tenants.
+
+|*`configuration`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
+|*Optional* + 
+ Specify a secret that contains additional environment variable configurations to be used for the MinIO pools. The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
 
 |===
+
+
+
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantusage"]
 ==== TenantUsage 
@@ -949,20 +1015,20 @@ TenantUsage are metrics regarding the usage and capacity of the tenant
 - xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantstatus[$$TenantStatus$$]
 ****
 
-[cols="25a,75a",options="header"]
+[cols="25a,75a", options="header"]
 |===
 | Field | Description
 
-|*`capacity`* __integer__
+|*`capacity`* __integer__ 
 |Capacity the usage capacity of this tenant in bytes.
 
-|*`rawCapacity`* __integer__
+|*`rawCapacity`* __integer__ 
 |Capacity the raw capacity of this tenant in bytes.
 
-|*`usage`* __integer__
+|*`usage`* __integer__ 
 |Usage is how much data is managed by MinIO in bytes.
 
-|*`rawUsage`* __integer__
+|*`rawUsage`* __integer__ 
 |Usage is the raw usage on disks in bytes.
 
 |===

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,76 @@
+# Upgrading from an old version of MinIO Operator [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
+
+This document explains how to upgrade your `MinIO tenants` and the `MinIO Operator` from an old version, such as `v3.x.x`,
+to `4.4.13` and newer.
+
+## Getting Started
+
+### Prerequisites
+
+- `kubectl` access to your `k8s` cluster
+- MinIO Operator `v3.x.x` running on your cluster
+
+### Prepare existing tenants to be migrated
+
+Before upgrading the `MinIO Operator` you need to make the following changes to all the existing `MinIO Tenants`.
+
+- Make sure every `zone` in `tenant.spec.zones` explicitly set a zone `name` if not configured already.
+- Make sure every `zone` in `tenant.spec.zones` explicitly set a `securityContext` if not configured already.
+
+### Example
+
+```yaml
+  zones:
+    - servers: 4
+      name: "zone-0"
+      volumesPerServer: 4
+      volumeClaimTemplate:
+        metadata:
+          name: data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Ti
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        fsGroup: 0
+  - servers: 4
+      name: "zone-1"
+      volumesPerServer: 4
+      volumeClaimTemplate:
+        metadata:
+          name: data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Ti
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        fsGroup: 0
+```
+
+You can make all the changes directly via `kubectl edit tenants $(TENANT-NAME) -n $(NAMESPACE)` or edit your
+`tenant.yaml` and apply the changes: `kubectl apply -f tenant.yaml`. 
+
+Failing to apply this changes will cause some issues during the upgrade such as the tenants not able to provision because
+of wrong `persistent volume claims` (this happens if you don't add the zone name) or MinIO not able to `read/write` on
+existing volumes (this happens if you don't add the right `securityContext`).
+
+### Upgrade MinIO Operator and Upgrade tenants
+
+Once all your tenants are prepared for the upgrade it's time to upgrade Operator:
+
+```bash
+kubectl apply -k github.com/minio/operator/\?ref\=v4.4.3
+```
+
+The above command will update the MinIO `Tenant CRD`, update the MinIO Operator `image` and trigger the upgrade for each
+existing tenant.

--- a/helm/operator/crds/minio.min.io_tenants.yaml
+++ b/helm/operator/crds/minio.min.io_tenants.yaml
@@ -3740,6 +3740,14 @@ spec:
                               type: array
                           type: object
                       type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     name:
                       type: string
                     nodeSelector:
@@ -3765,6 +3773,68 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
                     servers:
                       format: int32
                       type: integer
@@ -3782,6 +3852,45 @@ spec:
                             type: integer
                           value:
                             type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          maxSkew:
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     volumeClaimTemplate:

--- a/pkg/apis/minio.min.io/v1/conversion.go
+++ b/pkg/apis/minio.min.io/v1/conversion.go
@@ -39,14 +39,18 @@ func (src *Tenant) ConvertTo(dstRaw conversion.Hub) error {
 
 	for _, zone := range src.Spec.Zones {
 		pools = append(pools, v2.Pool{
-			Name:                zone.Name,
-			Servers:             zone.Servers,
-			VolumesPerServer:    zone.VolumesPerServer,
-			VolumeClaimTemplate: zone.VolumeClaimTemplate,
-			Resources:           zone.Resources,
-			NodeSelector:        zone.NodeSelector,
-			Affinity:            zone.Affinity,
-			Tolerations:         zone.Tolerations,
+			Name:                      zone.Name,
+			Servers:                   zone.Servers,
+			VolumesPerServer:          zone.VolumesPerServer,
+			VolumeClaimTemplate:       zone.VolumeClaimTemplate,
+			Resources:                 zone.Resources,
+			NodeSelector:              zone.NodeSelector,
+			Affinity:                  zone.Affinity,
+			Tolerations:               zone.Tolerations,
+			TopologySpreadConstraints: zone.TopologySpreadConstraints,
+			SecurityContext:           zone.SecurityContext,
+			Annotations:               zone.Annotations,
+			Labels:                    zone.Labels,
 		})
 	}
 

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -156,6 +156,43 @@ type Zone struct {
 	// Tolerations allows users to set entries like effect, key, operator, value.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// *Optional* +
+	//
+	// Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	// *Optional* +
+	//
+	// Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods in the pool. The Operator supports only the following pod security fields: +
+	//
+	// * `fsGroup` +
+	//
+	// * `fsGroupChangePolicy` +
+	//
+	// * `runAsGroup` +
+	//
+	// * `runAsNonRoot` +
+	//
+	// * `runAsUser` +
+	//
+	// * `seLinuxOptions` +
+	//
+	// +optional
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// *Optional* +
+	//
+	// Specify custom labels and annotations to append to the Pool.
+	// +optional
+	// *Optional* +
+	//
+	// If provided, use these annotations for the Pool Objects Meta annotations (Statefulset and Pod template)
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+	// *Optional* +
+	//
+	// If provided, use these labels for the Pool Objects Meta annotations (Statefulset and Pod template)
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
@@ -241,6 +241,32 @@ func (in *Zone) DeepCopyInto(out *Zone) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]corev1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(corev1.PodSecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -54,6 +54,9 @@ const TenantLabel = "v1.min.io/tenant"
 // PoolLabel is applied to all components in a Pool of a Tenant cluster
 const PoolLabel = "v1.min.io/pool"
 
+// ZoneLabel is used for compatibility with tenants deployed prior to operator 4.0.0
+const ZoneLabel = "v1.min.io/zone"
+
 // LogDbLabel is applied to all log db components of a Tenant cluster
 const LogDbLabel = "v1.min.io/logdb"
 

--- a/pkg/controller/cluster/pools.go
+++ b/pkg/controller/cluster/pools.go
@@ -137,7 +137,15 @@ func (c *Controller) restartInitializedPool(ctx context.Context, tenant *miniov2
 	})
 	if err != nil {
 		klog.Warning("Could not validate state of statefulset for pool", err)
-		return err
+	}
+	if len(livePods.Items) == 0 {
+		livePods, err = c.kubeClientSet.CoreV1().Pods(tenant.Namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", miniov2.ZoneLabel, pool.Name),
+		})
+		if err != nil {
+			klog.Warning("Could not validate state of statefulset for zone", err)
+			return err
+		}
 	}
 	var livePod *corev1.Pod
 	for _, p := range livePods.Items {

--- a/pkg/controller/cluster/webhook.go
+++ b/pkg/controller/cluster/webhook.go
@@ -43,6 +43,26 @@ func restQueries(keys ...string) []string {
 	return accumulator
 }
 
+func configureHTTPUpgradeServer(c *Controller) *http.Server {
+	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
+
+	router.Methods(http.MethodGet).
+		PathPrefix(miniov2.WebhookAPIUpdate).
+		Handler(http.StripPrefix(miniov2.WebhookAPIUpdate, http.FileServer(http.Dir(updatePath))))
+
+	router.NotFoundHandler = http.NotFoundHandler()
+
+	s := &http.Server{
+		Addr:           ":4221",
+		Handler:        router,
+		ReadTimeout:    time.Minute,
+		WriteTimeout:   time.Minute,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	return s
+}
+
 func configureWebhookServer(c *Controller) *http.Server {
 	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
 

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3740,6 +3740,14 @@ spec:
                               type: array
                           type: object
                       type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     name:
                       type: string
                     nodeSelector:
@@ -3765,6 +3773,68 @@ spec:
                             x-kubernetes-int-or-string: true
                           type: object
                       type: object
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
                     servers:
                       format: int32
                       type: integer
@@ -3782,6 +3852,45 @@ spec:
                             type: integer
                           value:
                             type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          maxSkew:
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            type: string
+                          whenUnsatisfiable:
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     volumeClaimTemplate:

--- a/resources/base/service.yaml
+++ b/resources/base/service.yaml
@@ -10,6 +10,8 @@ spec:
   ports:
     - port: 4222
       name: https
+    - port: 4221
+      name: http
   selector:
     name: minio-operator
     operator: leader


### PR DESCRIPTION
- Fixed some bugs that were preventing the upgrade of tenants deployed
  with operator v3.x.x
- Added documentation on how to upgrade operator and tenants from v3.x.x
  to v4.4.13

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>