### PR TITLE
update pod name on log test

### DIFF
--- a/testing/check-logs.sh
+++ b/testing/check-logs.sh
@@ -28,7 +28,7 @@ function perform_attempts_to_get_log_api_response() {
 		repeat 10 echo ""
 		echo "kubectl get pods -n tenant-lite"
 		kubectl get pods -n tenant-lite
-		kubectl port-forward storage-lite-ss-0-0 9443 --namespace tenant-lite &
+		kubectl port-forward storage-lite-pool-0-0 9443 --namespace tenant-lite &
 		process_id=$!
 		echo "process_id: ${process_id}"
 		echo 'Get token from MinIO Console'


### PR DESCRIPTION
Sorry guys I missed other spot to update.
Log test is failing too because pod's name is wrong.
This is the same fix we did on Prometheus test.

Previous name was: `storage-lite-ss-0-0`
New name is: `storage-lite-pool-0-0`

related to: https://github.com/minio/operator/pull/1062