### PR TITLE
Improve Certificates API detection

### DIFF
--- a/pkg/controller/cluster/csr.go
+++ b/pkg/controller/cluster/csr.go
@@ -71,7 +71,7 @@ func (c *Controller) createCertificateSigningRequest(ctx context.Context, labels
 	encodedBytes := pem.EncodeToMemory(&pem.Block{Type: csrType, Bytes: csrBytes})
 	// for the right set of csr configurations regarding CSR signers and Key usages please read:
 	// https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers
-	if useCertificatesV1API {
+	if !useCertificatesV1Beta1API {
 		csrSignerName := certificatesV1.KubeletServingSignerName
 		csrKeyUsage := []certificatesV1.KeyUsage{
 			certificatesV1.UsageDigitalSignature,
@@ -205,7 +205,7 @@ func (c *Controller) fetchCertificate(ctx context.Context, csrName string) ([]by
 			return nil, fmt.Errorf("%s", s.String())
 
 		case <-tick.C:
-			if useCertificatesV1API {
+			if !useCertificatesV1Beta1API {
 				r, err := c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, csrName, v1.GetOptions{})
 				if err != nil {
 					klog.Errorf("Unexpected error during certificate fetching of csr/%s V1: %s", csrName, err)

--- a/pkg/controller/cluster/kes.go
+++ b/pkg/controller/cluster/kes.go
@@ -154,7 +154,7 @@ func (c *Controller) checkKESCertificatesStatus(ctx context.Context, tenant *min
 					return err
 				}
 				// TLS secret not found, delete CSR if exists and start certificate generation process again
-				if useCertificatesV1API {
+				if !useCertificatesV1Beta1API {
 					if err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, tenant.MinIOClientCSRName(), metav1.DeleteOptions{}); err != nil {
 						return err
 					}
@@ -175,7 +175,7 @@ func (c *Controller) checkKESCertificatesStatus(ctx context.Context, tenant *min
 					return err
 				}
 				// TLS secret not found, delete CSR if exists and start certificate generation process again
-				if useCertificatesV1API {
+				if !useCertificatesV1Beta1API {
 					if err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, tenant.KESCSRName(), metav1.DeleteOptions{}); err != nil {
 						return err
 					}
@@ -269,7 +269,7 @@ func (c *Controller) checkKESStatus(ctx context.Context, tenant *miniov2.Tenant,
 
 func (c *Controller) checkAndCreateMinIOClientCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
 	var err error
-	if useCertificatesV1API {
+	if !useCertificatesV1Beta1API {
 		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.MinIOClientCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.MinIOClientCSRName(), metav1.GetOptions{})
@@ -295,7 +295,7 @@ func (c *Controller) checkAndCreateMinIOClientCSR(ctx context.Context, nsName ty
 
 func (c *Controller) checkAndCreateKESCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
 	var err error
-	if useCertificatesV1API {
+	if !useCertificatesV1Beta1API {
 		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.KESCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.KESCSRName(), metav1.GetOptions{})

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -351,7 +351,7 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 
 		go func() {
 			// Request kubernetes version from Kube ApiServer
-			c.getKubeAPIServerVersion()
+			c.getCertificatesAPIVersion()
 
 			if isOperatorTLS() {
 				publicCertPath, publicKeyPath := c.generateTLSCert()
@@ -660,7 +660,7 @@ func (c *Controller) syncHandler(key string) error {
 		if tenant.Spec.RequestAutoCert == nil && tenant.APIVersion != "" {
 			// If we get certificate signing requests for MinIO is safe to assume the Tenant v1 was deployed using AutoCert
 			// otherwise AutoCert will be false
-			if useCertificatesV1API {
+			if !useCertificatesV1Beta1API {
 				tenantCSR, err := c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.MinIOCSRName(), metav1.GetOptions{})
 				if err != nil || tenantCSR == nil {
 					autoCertEnabled = false

--- a/pkg/controller/cluster/minio.go
+++ b/pkg/controller/cluster/minio.go
@@ -38,7 +38,7 @@ import (
 
 func (c *Controller) checkAndCreateMinIOCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
 	var err error
-	if useCertificatesV1API {
+	if !useCertificatesV1Beta1API {
 		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.MinIOCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.MinIOCSRName(), metav1.GetOptions{})
@@ -61,7 +61,7 @@ func (c *Controller) checkAndCreateMinIOCSR(ctx context.Context, nsName types.Na
 }
 
 func (c *Controller) deleteMinIOCSR(ctx context.Context, csrName string) error {
-	if useCertificatesV1API {
+	if !useCertificatesV1Beta1API {
 		if err := c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, csrName, metav1.DeleteOptions{}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Check the for the available certificates api versions, by default operator will use v1beta1 if available.

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>