### PR TITLE
Add support for EKS custom signer

### DIFF
--- a/pkg/controller/cluster/certificates/csr.go
+++ b/pkg/controller/cluster/certificates/csr.go
@@ -1,0 +1,178 @@
+// Copyright (C) 2022, MinIO, Inc.
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License, version 3,
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package certificates
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+
+	certificatesV1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// OperatorCertificatesVersion is the ENV var to force the certificates api version to use.
+	OperatorCertificatesVersion = "MINIO_OPERATOR_CERTIFICATES_VERSION"
+	// OperatorRuntime tells us which runtime we have. (EKS, Rancher, OpenShift, etc...)
+	OperatorRuntime = "MINIO_OPERATOR_RUNTIME"
+	// CSRSignerName is the name to use for the CSR Signer, will override the default
+	CSRSignerName = "MINIO_OPERATOR_CSR_SIGNER_NAME"
+	// CSRSignerNameClient is the name to use for the CSR Signer, will override the default
+	CSRSignerNameClient = "MINIO_OPERATOR_CSR_SIGNER_NAME_CLIENT"
+	// EKSCsrSignerName is the signer we should use on EKS after version 1.22
+	EKSCsrSignerName = "beta.eks.amazonaws.com/app-serving"
+)
+
+// CSRVersion represents the valid types of CSR that can be used
+type CSRVersion string
+
+// Valid CSR Versions
+const (
+	// CSRV1 is the new version to use after k8s 1.21
+	CSRV1 CSRVersion = "v1"
+	// CSRV1Beta1 is dreprecated and will be removed in k8s 1.22
+	CSRV1Beta1 CSRVersion = "v1beta1"
+)
+
+var (
+	csrVersion                     CSRVersion
+	certificateVersionOnce         sync.Once
+	defaultCsrSignerName           string
+	defaultCsrSignerNameOnce       sync.Once
+	defaultCsrSignerNameClient     string
+	defaultCsrSignerNameClientOnce sync.Once
+	csrSignerName                  string
+	csrSignerNameOnce              sync.Once
+	csrSignerNameClient            string
+	csrSignerNameClientOnce        sync.Once
+)
+
+func getDefaultCsrSignerName() string {
+	defaultCsrSignerNameOnce.Do(func() {
+		if os.Getenv(CSRSignerName) != "" {
+			defaultCsrSignerName = os.Getenv(CSRSignerName)
+		}
+		defaultCsrSignerName = certificatesV1.KubeletServingSignerName
+	})
+	return defaultCsrSignerName
+}
+
+func getDefaultCsrSignerNameClient() string {
+	defaultCsrSignerNameClientOnce.Do(func() {
+		if os.Getenv(CSRSignerNameClient) != "" {
+			defaultCsrSignerNameClient = os.Getenv(CSRSignerNameClient)
+		}
+		defaultCsrSignerNameClient = certificatesV1.KubeAPIServerClientSignerName
+	})
+	return defaultCsrSignerNameClient
+}
+
+// GetCertificatesAPIVersion returns which certificates api version operator will use to generate certificates
+func GetCertificatesAPIVersion(clientSet kubernetes.Interface) CSRVersion {
+	// we will calculate which CSR version to use only once to avoid having to discover the
+	certificateVersionOnce.Do(func() {
+		version, _ := os.LookupEnv(OperatorCertificatesVersion)
+		csrVersion = CSRV1
+		switch version {
+		case "v1":
+			csrVersion = CSRV1
+		case "v1beta1":
+			csrVersion = CSRV1Beta1
+		default:
+			apiVersions, err := clientSet.Discovery().ServerPreferredResources()
+			if err != nil {
+				panic(err)
+			}
+			for _, api := range apiVersions {
+				// if certificates v1beta1 is present operator will use that api by default
+				// based on: https://github.com/aws/containers-roadmap/issues/1604#issuecomment-1072660824
+				if api.GroupVersion == "certificates.k8s.io/v1beta1" {
+					csrVersion = CSRV1Beta1
+					break
+				}
+			}
+		}
+	})
+	return csrVersion
+}
+
+// GetCSRSignerName returns the signer to be used
+func GetCSRSignerName(clientSet kubernetes.Interface) string {
+	csrSignerNameOnce.Do(func() {
+		// At the moment we will use kubernetes.io/kubelet-serving as the default
+		csrSignerName = getDefaultCsrSignerName()
+		// only for csr api v1 we will try to detect if we are running inside an EKS cluster and switch to AWS's way to
+		// get certificates using their CSRSignerName https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html
+		if GetCertificatesAPIVersion(clientSet) == CSRV1 {
+			// if the user specified the EKS runtime, no need to do the check
+			if os.Getenv(OperatorRuntime) == "EKS" {
+				csrSignerName = EKSCsrSignerName
+				return
+			}
+			nodes, err := clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				klog.Infof("Could not retrieve nodes to determine if we are in EKS: %v", err)
+			}
+			// if we find a single node with a kubeletVersion that contains "eks" or a label that starts with
+			// "eks.amazonaws.com", we'll start using AWS EKS signer name
+			for _, n := range nodes.Items {
+				if strings.Contains(n.Status.NodeInfo.KubeletVersion, "eks") {
+					csrSignerName = EKSCsrSignerName
+					break
+				}
+				for k := range n.ObjectMeta.Labels {
+					if strings.HasPrefix(k, "eks.amazonaws.com") {
+						csrSignerName = EKSCsrSignerName
+					}
+				}
+			}
+		}
+	})
+	return csrSignerName
+}
+
+// GetCSRSignerNameForClient returns the signer to be used for client certificates
+func GetCSRSignerNameForClient(clientSet kubernetes.Interface) string {
+	csrSignerNameClientOnce.Do(func() {
+		// At the moment we will use kubernetes.io/kube-apiserver-client as the default
+		csrSignerNameClient = getDefaultCsrSignerNameClient()
+		// only for csr api v1 we will try to detect if we are running inside an EKS cluster and switch to AWS's way to
+		// get certificates using their CSRSignerName https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html
+		if GetCertificatesAPIVersion(clientSet) == CSRV1 {
+			nodes, err := clientSet.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				klog.Infof("Could not retrieve nodes to determine if we are in EKS: %v", err)
+			}
+			// if we find a single node with a kubeletVersion that contains "eks" or a label that starts with
+			// "eks.amazonaws.com", we'll start using AWS EKS signer name
+			for _, n := range nodes.Items {
+				if strings.Contains(n.Status.NodeInfo.KubeletVersion, "eks") {
+					csrSignerNameClient = EKSCsrSignerName
+					break
+				}
+				for k := range n.ObjectMeta.Labels {
+					if strings.HasPrefix(k, "eks.amazonaws.com") {
+						csrSignerNameClient = EKSCsrSignerName
+					}
+				}
+			}
+		}
+	})
+	return csrSignerNameClient
+}

--- a/pkg/controller/cluster/kes.go
+++ b/pkg/controller/cluster/kes.go
@@ -26,6 +26,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/minio/operator/pkg/controller/cluster/certificates"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/minio/operator/pkg/resources/services"
@@ -154,7 +156,7 @@ func (c *Controller) checkKESCertificatesStatus(ctx context.Context, tenant *min
 					return err
 				}
 				// TLS secret not found, delete CSR if exists and start certificate generation process again
-				if !useCertificatesV1Beta1API {
+				if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 					if err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, tenant.MinIOClientCSRName(), metav1.DeleteOptions{}); err != nil {
 						return err
 					}
@@ -175,7 +177,7 @@ func (c *Controller) checkKESCertificatesStatus(ctx context.Context, tenant *min
 					return err
 				}
 				// TLS secret not found, delete CSR if exists and start certificate generation process again
-				if !useCertificatesV1Beta1API {
+				if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 					if err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, tenant.KESCSRName(), metav1.DeleteOptions{}); err != nil {
 						return err
 					}
@@ -269,7 +271,7 @@ func (c *Controller) checkKESStatus(ctx context.Context, tenant *miniov2.Tenant,
 
 func (c *Controller) checkAndCreateMinIOClientCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
 	var err error
-	if !useCertificatesV1Beta1API {
+	if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.MinIOClientCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.MinIOClientCSRName(), metav1.GetOptions{})
@@ -295,7 +297,7 @@ func (c *Controller) checkAndCreateMinIOClientCSR(ctx context.Context, nsName ty
 
 func (c *Controller) checkAndCreateKESCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
 	var err error
-	if !useCertificatesV1Beta1API {
+	if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.KESCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.KESCSRName(), metav1.GetOptions{})

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/minio/operator/pkg/controller/cluster/certificates"
+
 	"k8s.io/klog/v2"
 
 	"github.com/minio/minio-go/v7/pkg/set"
@@ -351,7 +353,8 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 
 		go func() {
 			// Request kubernetes version from Kube ApiServer
-			c.getCertificatesAPIVersion()
+			apiCsrVersion := certificates.GetCertificatesAPIVersion(c.kubeClientSet)
+			klog.Infof("Using Kubernetes CSR Version: %s", apiCsrVersion)
 
 			if isOperatorTLS() {
 				publicCertPath, publicKeyPath := c.generateTLSCert()
@@ -660,7 +663,7 @@ func (c *Controller) syncHandler(key string) error {
 		if tenant.Spec.RequestAutoCert == nil && tenant.APIVersion != "" {
 			// If we get certificate signing requests for MinIO is safe to assume the Tenant v1 was deployed using AutoCert
 			// otherwise AutoCert will be false
-			if !useCertificatesV1Beta1API {
+			if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 				tenantCSR, err := c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.MinIOCSRName(), metav1.GetOptions{})
 				if err != nil || tenantCSR == nil {
 					autoCertEnabled = false

--- a/pkg/controller/cluster/minio.go
+++ b/pkg/controller/cluster/minio.go
@@ -27,6 +27,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/minio/operator/pkg/controller/cluster/certificates"
+
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +40,7 @@ import (
 
 func (c *Controller) checkAndCreateMinIOCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
 	var err error
-	if !useCertificatesV1Beta1API {
+	if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.MinIOCSRName(), metav1.GetOptions{})
 	} else {
 		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.MinIOCSRName(), metav1.GetOptions{})
@@ -61,7 +63,7 @@ func (c *Controller) checkAndCreateMinIOCSR(ctx context.Context, nsName types.Na
 }
 
 func (c *Controller) deleteMinIOCSR(ctx context.Context, csrName string) error {
-	if !useCertificatesV1Beta1API {
+	if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
 		if err := c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, csrName, metav1.DeleteOptions{}); err != nil {
 			return err
 		}

--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -22,6 +22,7 @@ rules:
       - ""
     resources:
       - namespaces
+      - nodes
     verbs:
       - get
       - watch
@@ -97,6 +98,7 @@ rules:
       - kubernetes.io/legacy-unknown
       - kubernetes.io/kube-apiserver-client
       - kubernetes.io/kubelet-serving
+      - beta.eks.amazonaws.com/app-serving
     resources:
       - signers
     verbs:


### PR DESCRIPTION
Adds support to use the signer name `beta.eks.amazonaws.com/app-serving` for CSRs, but only when using the API `v1` of CSRs, and only if we can detect we are running inside EKS.

I tested this on:

- EKS 1.22
- Upstream 1.21

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>