### PR TITLE
Adding OpenShift Supported Version in the Bundle

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -35,6 +35,10 @@ sed -i -e '/metrics/d' bundles/$RELEASE/metadata/annotations.yaml
 sed -i -e '/scorecard/d' bundles/$RELEASE/metadata/annotations.yaml
 sed -i -e '/testing/d' bundles/$RELEASE/metadata/annotations.yaml
 
+# Add openshift supported version
+echo "  # Annotations to specify OCP versions compatibility." >> bundles/$RELEASE/metadata/annotations.yaml
+echo "  com.redhat.openshift.versions: v4.6-v4.10" >> bundles/$RELEASE/metadata/annotations.yaml
+
 # clean root level annotations.yaml
 sed -i -e '/metrics/d' metadata/annotations.yaml
 sed -i -e '/scorecard/d' metadata/annotations.yaml


### PR DESCRIPTION
Fixes: https://github.com/miniohq/engineering/issues/743

This addition is needed to get Pull Request accepted in https://github.com/redhat-openshift-ecosystem/certified-operators repository as shown in url below:

https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md#get-supported-versions

Where we can see this text:

- Your `annotations.yaml` file needs to include an `com.redhat.openshift.versions` annotation indicating the OpenShift versions supported by your Operator.

As a result, we are going to observe:

```yaml
annotations:
  # Core bundle annotations.
  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
  operators.operatorframework.io.bundle.manifests.v1: manifests/
  operators.operatorframework.io.bundle.metadata.v1: metadata/
  operators.operatorframework.io.bundle.package.v1: minio-operator
  operators.operatorframework.io.bundle.channels.v1: stable

  # Annotations to specify OCP versions compatibility.
  com.redhat.openshift.versions: v4.6-v4.10

```

Then `get-supported-versions` is going to pass `rh-operator-bundle-bot` validation