### PR TITLE
Adding missing line for default bundle channel

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -35,9 +35,16 @@ sed -i -e '/metrics/d' bundles/$RELEASE/metadata/annotations.yaml
 sed -i -e '/scorecard/d' bundles/$RELEASE/metadata/annotations.yaml
 sed -i -e '/testing/d' bundles/$RELEASE/metadata/annotations.yaml
 
-# Add openshift supported version
-echo "  # Annotations to specify OCP versions compatibility." >> bundles/$RELEASE/metadata/annotations.yaml
-echo "  com.redhat.openshift.versions: v4.6-v4.10" >> bundles/$RELEASE/metadata/annotations.yaml
+# Add openshift supported version & default channel
+# It needs to be added, since you have to declare both the potential eligible
+# channels for an operator via operators.operatorframework.io.bundle.channels
+# as well as the default.
+{
+  echo "  # Annotations to specify OCP versions compatibility."
+  echo "  com.redhat.openshift.versions: v4.6-v4.10"
+  echo "  # Annotation to add default bundle channel as potential is declared"
+  echo "  operators.operatorframework.io.bundle.channel.default.v1: stable"
+} >> bundles/$RELEASE/metadata/annotations.yaml
 
 # clean root level annotations.yaml
 sed -i -e '/metrics/d' metadata/annotations.yaml


### PR DESCRIPTION
As per the conversation with John Francini from RedHat team, this line is needed because we are specifying the potential but not the default one:

```yaml
  # needs to be added, since you have to declare both the potential eligible 
  # channels for an operator via operators.operatorframework.io.bundle.channels
  # as well as the default.
  operators.operatorframework.io.bundle.channel.default.v1: stable
```

### Red Hat case information:
```
---------------------------------------
|         Case Information            |
---------------------------------------

Case Title       : Getting submission-validation when there is only one PR open
Case Number      : 03201702
Case Open Date   : 2022-04-20 16:54:13
Problem Type     : Product Certification
Product          : OpenShift Container Platform
Version          : 4.9

Most recent comment: On 2022-04-20 19:40:25, Francini, John commented:

"Hello Cesar,

Just to let you know - I did not close the other case (03201410); it's merely waiting for you to reply to my last response to you.

In the meantime, it looks like you didn't follow the other part of my recommendation:

add the line

                  operators.operatorframework.io.bundle.channel.default.v1: stable
```