### PR TITLE
fix [opm alpha bundle validate error]

### DIFF
--- a/resources/templates/olm-template.yaml
+++ b/resources/templates/olm-template.yaml
@@ -15,6 +15,9 @@ spec:
     owned:
       - kind: Tenant
         name: tenants.minio.min.io
+        version: v1
+      - kind: Tenant
+        name: tenants.minio.min.io
         version: v2
   keywords:
     - S3


### PR DESCRIPTION
After run olm.sh。minio-operator.clusterserviceversion.yaml will be generated。but when I try to validate it [opm alpha bundle validate --tag image:tag], I found this:
Error: Bundle validation errors: Error: Value { Tenant tenants.minio.min.io v1}: CRD tenants.minio.min.io/v1 is present in bundle "minio-operator.vx.x.x" but not defined in CSV 。
To solve this, I change template.When olm.sh run:
yq eval-all -i ". as \$item ireduce ({}; . * \$item )" bundles/$RELEASE/manifests/minio-operator.clusterserviceversion.yaml resources/templates/olm-template.yaml
it can generate right minio-operator.clusterserviceversion.yaml。