### PR TITLE
Properly use custom kubeconfig for all clientsets

### DIFF
--- a/kubectl-minio/cmd/helpers/helpers.go
+++ b/kubectl-minio/cmd/helpers/helpers.go
@@ -88,8 +88,11 @@ func GetKubeClient(path string) (*kubernetes.Clientset, error) {
 }
 
 // GetKubeExtensionClient provides k8s client for CRDs
-func GetKubeExtensionClient() (*apiextension.Clientset, error) {
+func GetKubeExtensionClient(path string) (*apiextension.Clientset, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if path != "" {
+		loadingRules.ExplicitPath = path
+	}
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
@@ -107,8 +110,11 @@ func GetKubeExtensionClient() (*apiextension.Clientset, error) {
 }
 
 // GetKubeDynamicClient provides k8s client for CRDs
-func GetKubeDynamicClient() (dynamic.Interface, error) {
+func GetKubeDynamicClient(path string) (dynamic.Interface, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if path != "" {
+		loadingRules.ExplicitPath = path
+	}
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
@@ -121,8 +127,11 @@ func GetKubeDynamicClient() (dynamic.Interface, error) {
 }
 
 // GetKubeOperatorClient provides k8s client for operator
-func GetKubeOperatorClient() (*operatorv1.Clientset, error) {
+func GetKubeOperatorClient(path string) (*operatorv1.Clientset, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if path != "" {
+		loadingRules.ExplicitPath = path
+	}
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 

--- a/kubectl-minio/cmd/tenant-create.go
+++ b/kubectl-minio/cmd/tenant-create.go
@@ -123,11 +123,11 @@ func (c *createCmd) validate(args []string) error {
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
 func (c *createCmd) run(args []string) error {
 	// Create operator and kube client
-	operatorClient, err := helpers.GetKubeOperatorClient()
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	operatorClient, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}
-	path, _ := rootCmd.Flags().GetString(kubeconfig)
 	kubeClient, err := helpers.GetKubeClient(path)
 	if err != nil {
 		return err

--- a/kubectl-minio/cmd/tenant-delete.go
+++ b/kubectl-minio/cmd/tenant-delete.go
@@ -88,11 +88,11 @@ func (d *tenantDeleteCmd) validate(args []string) error {
 
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
 func (d *tenantDeleteCmd) run(args []string) error {
-	oclient, err := helpers.GetKubeOperatorClient()
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	oclient, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}
-	path, _ := rootCmd.Flags().GetString(kubeconfig)
 	kclient, err := helpers.GetKubeClient(path)
 	if err != nil {
 		return err

--- a/kubectl-minio/cmd/tenant-expand.go
+++ b/kubectl-minio/cmd/tenant-expand.go
@@ -103,7 +103,8 @@ func (v *expandCmd) validate(args []string) error {
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
 func (v *expandCmd) run() error {
 	// Create operator client
-	client, err := helpers.GetKubeOperatorClient()
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	client, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}

--- a/kubectl-minio/cmd/tenant-info.go
+++ b/kubectl-minio/cmd/tenant-info.go
@@ -84,7 +84,8 @@ func (d *infoCmd) validate(args []string) error {
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
 func (d *infoCmd) run(args []string) error {
 	// Create operator client
-	oclient, err := helpers.GetKubeOperatorClient()
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	oclient, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}

--- a/kubectl-minio/cmd/tenant-list.go
+++ b/kubectl-minio/cmd/tenant-list.go
@@ -71,7 +71,8 @@ func (d *listCmd) validate(args []string) error {
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
 func (d *listCmd) run(args []string) error {
 	// Create operator client
-	oclient, err := helpers.GetKubeOperatorClient()
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	oclient, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}

--- a/kubectl-minio/cmd/tenant-report.go
+++ b/kubectl-minio/cmd/tenant-report.go
@@ -87,11 +87,13 @@ func (d *reportCmd) validate(args []string) error {
 func (d *reportCmd) run(args []string) error {
 	// Create operator client
 	ctx := context.Background()
-	oclient, err := helpers.GetKubeOperatorClient()
+
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	oclient, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}
-	client, err := helpers.GetKubeClient("")
+	client, err := helpers.GetKubeClient(path)
 	if err != nil {
 		return err
 	}

--- a/kubectl-minio/cmd/tenant-upgrade.go
+++ b/kubectl-minio/cmd/tenant-upgrade.go
@@ -93,7 +93,9 @@ func (u *upgradeCmd) validate(args []string) error {
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
 func (u *upgradeCmd) run() error {
 	// Create operator client
-	client, err := helpers.GetKubeOperatorClient()
+
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+	client, err := helpers.GetKubeOperatorClient(path)
 	if err != nil {
 		return err
 	}

--- a/kubectl-minio/cmd/tenant.go
+++ b/kubectl-minio/cmd/tenant.go
@@ -54,7 +54,8 @@ func newTenantCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		Short: "Manage MinIO tenant(s)",
 		Long:  tenantDesc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			client, err := helpers.GetKubeExtensionClient()
+			path, _ := rootCmd.Flags().GetString(kubeconfig)
+			client, err := helpers.GetKubeExtensionClient(path)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Closes #1109 

## Notes

This change works for me. I think it would make sense to pull the `clientcmd.ClientConfig` creation in a separate function to avoid code duplication (and similar issues in the future), but I decided against it, as it touches more parts of the codebase than I believe are required.

I'd be willing to go ahead with the change if the maintainers find that it is OK.