### PR TITLE
Remove MINIO_ENDPOINTS env var

### DIFF
--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -864,6 +864,8 @@ func (c *Controller) syncHandler(key string) error {
 			c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "PoolCreated", fmt.Sprintf("Tenant pool %s created", pool.Name))
 			// Report the pool is properly created
 			tenant.Status.Pools[i].State = miniov2.PoolCreated
+			// mark we are adding a new pool to the next block can act accordingly
+			addingNewPool = true
 			// push updates to status
 			if tenant, err = c.updatePoolStatus(ctx, tenant); err != nil {
 				return err
@@ -901,6 +903,7 @@ func (c *Controller) syncHandler(key string) error {
 		if initializedPool.Name != "" && addingNewPool {
 			// Restart services to get new args since we are expanding the deployment here.
 			if err := c.restartInitializedPool(ctx, tenant, initializedPool, tenantConfiguration); err != nil {
+				klog.Infof("'%s' restart call failed", key)
 				return err
 			}
 			metaNowTime := metav1.Now()

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -89,10 +89,6 @@ func minioEnvironmentVars(t *miniov2.Tenant, wsSecret *v1.Secret, hostsTemplate 
 				},
 			},
 		}, corev1.EnvVar{
-			// Add a fallback in-case operator is down.
-			Name:  "MINIO_ENDPOINTS",
-			Value: strings.Join(GetContainerArgs(t, hostsTemplate), " "),
-		}, corev1.EnvVar{
 			Name:  "MINIO_OPERATOR_VERSION",
 			Value: opVersion,
 		}, corev1.EnvVar{


### PR DESCRIPTION
Removing the MINIO_ENDPOINTS to avoid having to do a statefulset rolling restart when adding new pools

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>