### PR TITLE
Deploy and manage only one tenant per helm tenant release

### DIFF
--- a/helm/tenant/templates/NOTES.txt
+++ b/helm/tenant/templates/NOTES.txt
@@ -1,15 +1,13 @@
-{{ range .Values.tenants }}
-  To connect to the {{.name}} tenant if it doesn't have a service exposed, you can port-forward to it by running:
-    {{- if dig "certificate" "requestAutoCert" false .}}
+{{- with .Values.tenant }}
+  To connect to the {{ .name }} tenant if it doesn't have a service exposed, you can port-forward to it by running:
+  {{- if dig "certificate" "requestAutoCert" false . }}
 
-  kubectl --namespace {{ .namespace }} port-forward svc/{{ .name }}-console 9443:9443
+  kubectl --namespace {{ $.Release.Namespace }} port-forward svc/{{ .name }}-console 9443:9443
 
   Then visit the MinIO Console at https://127.0.0.1:9443
   {{ else }}
-  kubectl --namespace {{ .namespace }} port-forward svc/{{ .name }}-console 9090:9090
+  kubectl --namespace {{ $.Release.Namespace }} port-forward svc/{{ .name }}-console 9090:9090
 
   Then visit the MinIO Console at http://127.0.0.1:9090
   {{ end }}
-{{ end }}
-
-
+{{- end }}

--- a/helm/tenant/templates/tenant-secret.yaml
+++ b/helm/tenant/templates/tenant-secret.yaml
@@ -1,16 +1,12 @@
-{{ range .Values.tenants }}
-  {{- if dig "secrets" "enabled" false . }}
----
+{{- if dig "secrets" "enabled" false (.Values | merge (dict)) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ dig "secrets" "name" "" . }}
-  namespace: {{ .namespace }}
+  name: {{ dig "secrets" "name" "" (.Values | merge (dict)) }}
 type: Opaque
 data:
   ## Access Key for MinIO Tenant
-  accesskey: {{ dig "secrets" "accessKey" "" . | b64enc }}
+  accesskey: {{ dig "secrets" "accessKey" "" (.Values | merge (dict)) | b64enc }}
   ## Secret Key for MinIO Tenant
-  secretkey: {{ dig "secrets" "secretKey" "" . | b64enc }}
-  {{- end }}
-  {{ end }}
+  secretkey: {{ dig "secrets" "secretKey" "" (.Values | merge (dict)) | b64enc }}
+{{- end }}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -1,39 +1,37 @@
-{{ range .Values.tenants }}
----
+{{- with .Values.tenant }}
 apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: {{ .name }}
-  namespace: {{ .namespace }}
   ## Optionally pass labels to be applied to the statefulset pods
   labels:
     app: minio
-  {{ if dig "metrics" "enabled" false . }}
+  {{- if dig "metrics" "enabled" false . }}
   ## Annotations for MinIO Tenant Pods
   annotations:
     prometheus.io/path: /minio/v2/metrics/cluster
     prometheus.io/port: {{ dig "metrics" "port" 9000 . | quote }}
     prometheus.io/scrape: "true"
     prometheus.io/scheme: {{ dig "metrics" "protocol" "http" . | quote }}
-  {{ end }}
-  {{ if dig "scheduler" "name" "" . }}
+  {{- end }}
+  {{- if dig "scheduler" "name" "" . }}
   scheduler:
     name: {{ dig "scheduler" "name" "" . }}
-  {{ end }}
+  {{- end }}
 spec:
   image: {{ dig "image" "repository" "minio/minio" . }}:{{ dig "image" "tag" "RELEASE.2022-01-08T03-11-54Z" . }}
   imagePullPolicy: {{ dig "image" "pullPolicy" "IfNotPresent" . }}
-  {{ if dig "imagePullSecret" "name" "" . }}
+  {{- if dig "imagePullSecret" "name" "" . }}
   imagePullSecret:
     name: {{ dig "imagePullSecret" "name" "" . }}
-  {{ end }}
+  {{- end }}
+  {{- if dig "secrets" "enabled" false ($.Values | merge (dict)) }}
   ## Secret with credentials to be used by MinIO Tenant.
-  {{ if dig "secrets" "enabled" false . }}
   credsSecret:
-    name: {{ dig "secrets" "name" "" . }}
-  {{ end }}
+    name: {{ dig "secrets" "name" "" ($.Values | merge (dict)) }}
+  {{- end }}
   pools:
-  {{ range (dig "pools" (list) .) }}
+  {{- range (dig "pools" (list) .) }}
     - servers: {{ dig "servers" 4 . }}
       name: {{ dig "name" "" . }}
       volumesPerServer: {{ dig "volumesPerServer" 4 . }}
@@ -49,47 +47,47 @@ spec:
               storage: {{ dig "size" "10Gi" . }}
       {{- with (dig "annotations" (dict) .) }}
       annotations:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "labels" (dict) .) }}
       labels:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "tolerations" (list) .) }}
       tolerations:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "nodeSelector" (dict) .) }}
       nodeSelector:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "affinity" (dict) .) }}
       affinity:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "resources" (dict) .) }}
       resources:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "securityContext" (dict) .) }}
       securityContext:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (dig "topologySpreadConstraints" (list) .) }}
       topologySpreadConstraints:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
-  {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
   mountPath: {{ dig "mountPath" "/export" . }}
   subPath: {{ dig "subPath" "/data" . }}
   {{- with (dig "certificate" "externalCaCertSecret" (dict) .) }}
   externalCaCertSecret:
-    {{ toYaml . | nindent 6 }}
-  {{ end }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   {{- with (dig "certificate" "externalCertSecret" (dict) .) }}
   externalCertSecret:
-    {{ toYaml . | nindent 6 }}
-  {{ end }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   requestAutoCert: {{ dig "certificate" "requestAutoCert" false . }}
   s3:
     bucketDNS: {{ dig "s3" "bucketDNS" false . }}
@@ -103,41 +101,41 @@ spec:
   {{- end }}
   {{- with (dig "certificate" "certConfig" (dict) .) }}
   certConfig:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   podManagementPolicy: {{ dig "podManagementPolicy" "Parallel" . }}
   {{- with (dig "readiness" (dict) .) }}
   readiness:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with (dig "liveness" (dict) .) }}
   liveness:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with (dig "exposeServices" (dict) .) }}
   exposeServices:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{ if dig "serviceAccountName" "" . }}
+  {{- if dig "serviceAccountName" "" . }}
   serviceAccountName: {{ dig "serviceAccountName" "" . }}
-  {{ end }}
+  {{- end }}
   prometheusOperator: {{ dig "prometheusOperator" "false" . }}
   {{- with (dig "logging" (dict) .) }}
   logging:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with (dig "serviceMetadata" (dict) .) }}
   serviceMetadata:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with (dig "env" (dict) .) }}
   env:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{ if dig "priorityClassName" "" . }}
+  {{- if dig "priorityClassName" "" . }}
   priorityClassName: {{ dig "priorityClassName" "" . }}
-  {{ end }}
-  {{ if dig "kes" "kesSecret" "name" false . }}
+  {{- end }}
+  {{- if dig "kes" "kesSecret" "name" false . }}
   kes:
     image: {{ .kes.image | quote }}
     replicas: {{ .kes.replicas | int }}
@@ -150,11 +148,11 @@ spec:
     keyName: {{ .kes.keyName | quote }}
     {{- with (dig "resources" (dict) .) }}
     resources:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with (dig "nodeSelector" (dict) .) }}
     nodeSelector:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     affinity:
       nodeAffinity: { }
@@ -163,11 +161,11 @@ spec:
     tolerations: [ ]
     {{- with (dig "annotations" (dict) .) }}
     annotations:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with (dig "labels" (dict) .) }}
     labels:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     serviceAccountName: {{ .kes.serviceAccountName | quote }}
     securityContext:
@@ -175,10 +173,10 @@ spec:
       runAsGroup: {{ .kes.securityContext.runAsGroup | int }}
       runAsNonRoot: {{ .kes.securityContext.runAsNonRoot }}
       fsGroup: {{ .kes.securityContext.fsGroup | int }}
-  {{ end }}
+  {{- end }}
 
+  {{- if dig "prometheus" "diskCapacityGB" false . }}
   ## Prometheus setup for MinIO Tenant.
-  {{ if dig "prometheus" "diskCapacityGB" false . }}
   prometheus:
     image: {{ .prometheus.image | quote }}
     sidecarimage: {{ .prometheus.sidecarimage | quote }}
@@ -187,15 +185,15 @@ spec:
     storageClassName: {{ .prometheus.storageClassName }}
     {{- with (dig "annotations" (dict) .) }}
     annotations:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with (dig "labels" (dict) .) }}
     labels:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with (dig "nodeSelector" (dict) .) }}
     nodeSelector:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     affinity:
       nodeAffinity: { }
@@ -203,7 +201,7 @@ spec:
       podAntiAffinity: { }
     {{- with (dig "resources" (dict) .) }}
     resources:
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
     serviceAccountName: {{ .prometheus.serviceAccountName | quote }}
     securityContext:
@@ -211,10 +209,10 @@ spec:
       runAsGroup: {{ .prometheus.securityContext.runAsGroup | int }}
       runAsNonRoot: {{ .prometheus.securityContext.runAsNonRoot }}
       fsGroup: {{ .prometheus.securityContext.fsGroup | int }}
-  {{ end }}
+  {{- end }}
 
-## LogSearch API setup for MinIO Tenant.
-  {{ if dig "log" "audit" "diskCapacityGB" false . }}
+  {{- if dig "log" "audit" "diskCapacityGB" false . }}
+  ## LogSearch API setup for MinIO Tenant.
   log:
     image: {{ .log.image | quote }}
     {{- with (dig "resources" (dict) .) }}
@@ -289,5 +287,5 @@ spec:
       runAsGroup: {{ .log.securityContext.runAsGroup | int }}
       runAsNonRoot: true
       fsGroup: {{ .log.securityContext.fsGroup | int }}
-  {{ end }}
-{{ end }}
+  {{- end }}
+{{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,183 +1,206 @@
+## Secret with credentials to be used by MinIO Tenant
+secrets:
+  # create a kubernetes secret object with the accessKey and secretKey as defined here.
+  enabled: true
+  name: minio1-secret
+  accessKey: minio
+  secretKey: minio123
+
 ## MinIO Tenant Definition
-tenants:
+tenant:
   # Tenant name
-  - name: minio1
-    ## Registry location and Tag to download MinIO Server image
-    image:
-      repository: quay.io/minio/minio
-      tag: RELEASE.2022-01-08T03-11-54Z
-      pullPolicy: IfNotPresent
-    ## Customize namespace for tenant deployment
-    namespace: default
-    ## Customize any private registry image pull secret.
-    ## currently only one secret registry is supported
-    imagePullSecret: { }
-    ## If a scheduler is specified here, Tenant pods will be dispatched by specified scheduler.
-    ## If not specified, the Tenant pods will be dispatched by default scheduler.
-    scheduler: { }
-    ## Specification for MinIO Pool(s) in this Tenant.
-    pools:
-      ## Servers specifies the number of MinIO Tenant Pods / Servers in this pool.
-      ## For standalone mode, supply 1. For distributed mode, supply 4 or more.
-      ## Note that the operator does not support upgrading from standalone to distributed mode.
-      - servers: 4
-        ## custom name for the pool
-        name: pool-0
-        ## volumesPerServer specifies the number of volumes attached per MinIO Tenant Pod / Server.
-        volumesPerServer: 4
-        ## size specifies the capacity per volume
-        size: 10Gi
-        ## storageClass specifies the storage class name to be used for this pool
-        storageClassName: standard
-        ## Used to specify annotations for pods
-        annotations: { }
-        ## Used to specify labels for pods
-        labels: { }
-        ## Used to specify a toleration for a pod
-        tolerations: { }
-        ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
-        ## eligible to run on a node, the node must have each of the
-        ## indicated key-value pairs as labels.
-        ## Read more here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-        nodeSelector: { }
-        ## Affinity settings for MinIO pods. Read more about affinity
-        ## here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
-        affinity: { }
-        ## Configure resource requests and limits for MinIO containers
-        resources: { }
-        ## Configure security context
-        securityContext: { }
-        ## Configure topology constraints
-        topologySpreadConstraints: [ ]
-    ## Mount path where PV will be mounted inside container(s).
-    mountPath: /export
-    ## Sub path inside Mount path where MinIO stores data.
-    subPath: /data
-    # pool secrets
-    secrets:
-      # create a kubernetes secret object with the accessKey and secretKey as defined here.
-      enabled: true
-      name: minio1-secret
-      accessKey: minio
-      secretKey: minio123
-    # pool metrics to be read by Prometheus
-    metrics:
-      enabled: false
-      port: 9000
-      protocol: http
-    certificate:
-      ## Use this field to provide one or more external CA certificates. This is used by MinIO
-      ## to verify TLS connections with other applications:
-      ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
-      externalCaCertSecret: { }
-      ## Use this field to provide a list of Secrets with external certificates. This can be used to to configure
-      ## TLS for MinIO Tenant pods. Create secrets as explained here:
-      ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
-      externalCertSecret: { }
-      ## Enable automatic Kubernetes based certificate generation and signing as explained in
-      ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
-      requestAutoCert: true
-      ## This field is used only when "requestAutoCert" is set to true. Use this field to set CommonName
-      ## for the auto-generated certificate. Internal DNS name for the pod will be used if CommonName is
-      ## not provided. DNS name format is *.minio.default.svc.cluster.local
-      certConfig: { }
-    ## Enable S3 specific features such as Bucket DNS which would allow `buckets` to be
-    ## accessible as DNS entries of form `<bucketname>.minio.default.svc.cluster.local`
-    s3:
-      ## This feature is turned off by default
-      bucketDNS: false
-    ## List of bucket names to create during tenant provisioning
-    buckets: [ ]
-    ## List of secret names to use for generating MinIO users during tenant provisioning
-    users: [ ]
-    ## PodManagement policy for MinIO Tenant Pods. Can be "OrderedReady" or "Parallel"
-    ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
-    ## for details.
-    podManagementPolicy: Parallel
-    # Liveness Probe for container liveness. Container will be restarted if the probe fails.
-    # Refer https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.
-    liveness: { }
-    # Readiness Probe for container readiness. Container will be removed from service endpoints if the probe fails.
-    # Refer https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-    readiness: { }
-    ## exposeServices defines the exposure of the MinIO object storage and Console services.
-    ## service is exposed as a loadbalancer in k8s service.
-    exposeServices: { }
-    # kubernetes service account associated with a specific tenant
-    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-    serviceAccountName: ""
-    # Tenant scrape configuration will be added to prometheus managed by the prometheus-operator.
-    prometheusOperator: false
-    # Enable JSON, Anonymous logging for MinIO tenants.
-    # Refer https://github.com/minio/operator/blob/master/pkg/apis/minio.min.io/v2/types.go#L303
-    # How logs will look:
-    # $ k logs minio1-pool-0-0 -n default
-    # {"level":"INFO","errKind":"","time":"2022-04-07T21:49:33.740058549Z","message":"All MinIO sub-systems initialized successfully"}
-    # Notice they are in JSON format to be consumed
-    logging:
-      anonymous: true
-      json: true
-      quiet: true
-    ## serviceMetadata allows passing additional labels and annotations to MinIO and Console specific
-    ## services created by the operator.
-    serviceMetadata: { }
-    ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
-    env: { }
-    ## PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods.
-    ## This is applied to MinIO pods only.
-    ## Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass/
-    priorityClassName: ""
-    ## Define configuration for KES (stateless and distributed key-management system)
-    ## Refer https://github.com/minio/kes
-    kes:
-      image: "" # minio/kes:v0.17.6
-      replicas: 2
-      kesSecret:
-        name: kes-configuration
-      imagePullPolicy: "IfNotPresent"
-      externalCertSecret: null
-      clientCertSecret: null
-      ## Key name to be created on the KMS, default is "my-minio-key"
-      keyName: ""
-      resources: { }
-      nodeSelector: { }
-      affinity:
-        nodeAffinity: { }
-        podAffinity: { }
-        podAntiAffinity: { }
-      tolerations: [ ]
-      annotations: { }
-      labels: { }
-      serviceAccountName: ""
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        runAsNonRoot: true
-        fsGroup: 1000
-    ## Prometheus setup for MinIO Tenant.
-    prometheus:
-      image: "" # defaults to quay.io/prometheus/prometheus:latest
-      sidecarimage: "" # defaults to alpine
-      initimage: "" # defaults to busybox:1.33.1
-      diskCapacityGB: 1
+  name: minio1
+  ## Registry location and Tag to download MinIO Server image
+  image:
+    repository: quay.io/minio/minio
+    tag: RELEASE.2022-01-08T03-11-54Z
+    pullPolicy: IfNotPresent
+  ## Customize any private registry image pull secret.
+  ## currently only one secret registry is supported
+  imagePullSecret: { }
+  ## If a scheduler is specified here, Tenant pods will be dispatched by specified scheduler.
+  ## If not specified, the Tenant pods will be dispatched by default scheduler.
+  scheduler: { }
+  ## Specification for MinIO Pool(s) in this Tenant.
+  pools:
+    ## Servers specifies the number of MinIO Tenant Pods / Servers in this pool.
+    ## For standalone mode, supply 1. For distributed mode, supply 4 or more.
+    ## Note that the operator does not support upgrading from standalone to distributed mode.
+    - servers: 4
+      ## custom name for the pool
+      name: pool-0
+      ## volumesPerServer specifies the number of volumes attached per MinIO Tenant Pod / Server.
+      volumesPerServer: 4
+      ## size specifies the capacity per volume
+      size: 10Gi
+      ## storageClass specifies the storage class name to be used for this pool
       storageClassName: standard
+      ## Used to specify annotations for pods
       annotations: { }
+      ## Used to specify labels for pods
       labels: { }
+      ## Used to specify a toleration for a pod
+      tolerations: { }
+      ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
+      ## eligible to run on a node, the node must have each of the
+      ## indicated key-value pairs as labels.
+      ## Read more here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
       nodeSelector: { }
-      affinity:
-        nodeAffinity: { }
-        podAffinity: { }
-        podAntiAffinity: { }
+      ## Affinity settings for MinIO pods. Read more about affinity
+      ## here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity.
+      affinity: { }
+      ## Configure resource requests and limits for MinIO containers
       resources: { }
-      serviceAccountName: ""
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        runAsNonRoot: true
-        fsGroup: 1000
-    ## LogSearch API setup for MinIO Tenant.
-    log:
-      image: "" # defaults to minio/operator:v4.4.17
+      ## Configure security context
+      securityContext: { }
+      ## Configure topology constraints
+      topologySpreadConstraints: [ ]
+  ## Mount path where PV will be mounted inside container(s).
+  mountPath: /export
+  ## Sub path inside Mount path where MinIO stores data.
+  subPath: /data
+  # pool metrics to be read by Prometheus
+  metrics:
+    enabled: false
+    port: 9000
+    protocol: http
+  certificate:
+    ## Use this field to provide one or more external CA certificates. This is used by MinIO
+    ## to verify TLS connections with other applications:
+    ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+    externalCaCertSecret: { }
+    ## Use this field to provide a list of Secrets with external certificates. This can be used to to configure
+    ## TLS for MinIO Tenant pods. Create secrets as explained here:
+    ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+    externalCertSecret: { }
+    ## Enable automatic Kubernetes based certificate generation and signing as explained in
+    ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
+    requestAutoCert: true
+    ## This field is used only when "requestAutoCert" is set to true. Use this field to set CommonName
+    ## for the auto-generated certificate. Internal DNS name for the pod will be used if CommonName is
+    ## not provided. DNS name format is *.minio.default.svc.cluster.local
+    certConfig: { }
+  ## Enable S3 specific features such as Bucket DNS which would allow `buckets` to be
+  ## accessible as DNS entries of form `<bucketname>.minio.default.svc.cluster.local`
+  s3:
+    ## This feature is turned off by default
+    bucketDNS: false
+  ## List of bucket names to create during tenant provisioning
+  buckets: [ ]
+  ## List of secret names to use for generating MinIO users during tenant provisioning
+  users: [ ]
+  ## PodManagement policy for MinIO Tenant Pods. Can be "OrderedReady" or "Parallel"
+  ## Refer https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+  ## for details.
+  podManagementPolicy: Parallel
+  # Liveness Probe for container liveness. Container will be restarted if the probe fails.
+  # Refer https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes.
+  liveness: { }
+  # Readiness Probe for container readiness. Container will be removed from service endpoints if the probe fails.
+  # Refer https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  readiness: { }
+  ## exposeServices defines the exposure of the MinIO object storage and Console services.
+  ## service is exposed as a loadbalancer in k8s service.
+  exposeServices: { }
+  # kubernetes service account associated with a specific tenant
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccountName: ""
+  # Tenant scrape configuration will be added to prometheus managed by the prometheus-operator.
+  prometheusOperator: false
+  # Enable JSON, Anonymous logging for MinIO tenants.
+  # Refer https://github.com/minio/operator/blob/master/pkg/apis/minio.min.io/v2/types.go#L303
+  # How logs will look:
+  # $ k logs minio1-pool-0-0 -n default
+  # {"level":"INFO","errKind":"","time":"2022-04-07T21:49:33.740058549Z","message":"All MinIO sub-systems initialized successfully"}
+  # Notice they are in JSON format to be consumed
+  logging:
+    anonymous: true
+    json: true
+    quiet: true
+  ## serviceMetadata allows passing additional labels and annotations to MinIO and Console specific
+  ## services created by the operator.
+  serviceMetadata: { }
+  ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
+  env: { }
+  ## PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods.
+  ## This is applied to MinIO pods only.
+  ## Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass/
+  priorityClassName: ""
+  ## Define configuration for KES (stateless and distributed key-management system)
+  ## Refer https://github.com/minio/kes
+  kes:
+    image: "" # minio/kes:v0.17.6
+    replicas: 2
+    kesSecret:
+      name: kes-configuration
+    imagePullPolicy: "IfNotPresent"
+    externalCertSecret: null
+    clientCertSecret: null
+    ## Key name to be created on the KMS, default is "my-minio-key"
+    keyName: ""
+    resources: { }
+    nodeSelector: { }
+    affinity:
+      nodeAffinity: { }
+      podAffinity: { }
+      podAntiAffinity: { }
+    tolerations: [ ]
+    annotations: { }
+    labels: { }
+    serviceAccountName: ""
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      fsGroup: 1000
+  ## Prometheus setup for MinIO Tenant.
+  prometheus:
+    image: "" # defaults to quay.io/prometheus/prometheus:latest
+    sidecarimage: "" # defaults to alpine
+    initimage: "" # defaults to busybox:1.33.1
+    diskCapacityGB: 1
+    storageClassName: standard
+    annotations: { }
+    labels: { }
+    nodeSelector: { }
+    affinity:
+      nodeAffinity: { }
+      podAffinity: { }
+      podAntiAffinity: { }
+    resources: { }
+    serviceAccountName: ""
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      fsGroup: 1000
+  ## LogSearch API setup for MinIO Tenant.
+  log:
+    image: "" # defaults to minio/operator:v4.4.17
+    resources: { }
+    nodeSelector: { }
+    affinity:
+      nodeAffinity: { }
+      podAffinity: { }
+      podAntiAffinity: { }
+    tolerations: [ ]
+    annotations: { }
+    labels: { }
+    audit:
+      diskCapacityGB: 1
+    ## Postgres setup for LogSearch API
+    db:
+      image: "" # defaults to library/postgres
+      initimage: "" # defaults to busybox:1.33.1
+      volumeClaimTemplate:
+        metadata: { }
+        spec:
+          storageClassName: standard
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
       resources: { }
       nodeSelector: { }
       affinity:
@@ -187,39 +210,15 @@ tenants:
       tolerations: [ ]
       annotations: { }
       labels: { }
-      audit:
-        diskCapacityGB: 1
-      ## Postgres setup for LogSearch API
-      db:
-        image: "" # defaults to library/postgres
-        initimage: "" # defaults to busybox:1.33.1
-        volumeClaimTemplate:
-          metadata: { }
-          spec:
-            storageClassName: standard
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
-        resources: { }
-        nodeSelector: { }
-        affinity:
-          nodeAffinity: { }
-          podAffinity: { }
-          podAntiAffinity: { }
-        tolerations: [ ]
-        annotations: { }
-        labels: { }
-        serviceAccountName: ""
-        securityContext:
-          runAsUser: 999
-          runAsGroup: 999
-          runAsNonRoot: true
-          fsGroup: 999
       serviceAccountName: ""
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 999
+        runAsGroup: 999
         runAsNonRoot: true
-        fsGroup: 1000
+        fsGroup: 999
+    serviceAccountName: ""
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      fsGroup: 1000


### PR DESCRIPTION
Implements https://github.com/minio/operator/issues/981 enhancement proposal

Implementation notes:
- removed empty lines
- namespace is specified on helm chart level now
- [Sprig dig doesn't dig into chartutil.Values](https://github.com/helm/helm/issues/9266),  so to follow the code style
`{{- if dig "secrets" "enabled" false (.Values | merge (dict)) }}`
is used instead of
`{{- if dig "secrets" "enabled" false .Values }}`
