### PR TITLE
Add support for helm to upgrade tenant crd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
 HELM_HOME=helm/operator
-HELM_CRDS=$(HELM_HOME)/crds
+HELM_TEMPLATES=$(HELM_HOME)/templates
 
 KUSTOMIZE_HOME=resources
 KUSTOMIZE_CRDS=$(KUSTOMIZE_HOME)/base/crds/
@@ -65,7 +65,7 @@ regen-crd:
 	@${GOPATH}/bin/controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true paths="./..." output:crd:artifacts:config=$(KUSTOMIZE_CRDS)
 	@kustomize build resources/patch-crd > $(TMPFILE)
 	@mv -f $(TMPFILE) resources/base/crds/minio.min.io_tenants.yaml
-	@cp -f resources/base/crds/minio.min.io_tenants.yaml $(HELM_CRDS)/minio.min.io_tenants.yaml
+	@cp -f resources/base/crds/minio.min.io_tenants.yaml $(HELM_TEMPLATES)/minio.min.io_tenants.yaml
 
 regen-crd-docs:
 	@which crd-ref-docs 1>/dev/null || (echo "Installing crd-ref-docs" && GO111MODULE=on go install -v github.com/elastic/crd-ref-docs@latest)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -80,6 +80,30 @@ existing tenant.
 
 ---
 
+# Upgrade MinIO Operator via Helm Charts
+
+Make sure your current version of the `tenants.minio.min.io` `CRD` includes the necessary `labels` and `annotations` for `Helm`
+to perform the upgrade:
+
+```bash
+kubectl label crd tenants.minio.min.io app.kubernetes.io/managed-by=Helm --overwrite
+kubectl annotate crd tenants.minio.min.io meta.helm.sh/release-name=minio-operator meta.helm.sh/release-namespace=minio-operator --overwrite
+```
+
+Run the `helm upgrade` command:
+
+```bash
+helm upgrade -n minio-operator [RELEASE] [CHART] [flags]
+```
+
+or
+
+```bash
+helm upgrade -n minio-operator minio-operator [RELEASE-FOLDER]
+```
+
+---
+
 # Upgrading from MinIO Operator `v4.2.2` to `v4.2.3` [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
 This document explains how to upgrade your MinIO tenants and the MinIO Operator `v4.2.2`, to `v4.2.3` or newer.

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3,6 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.7
+    meta.helm.sh/release-name: minio-operator
+    meta.helm.sh/release-namespace: minio-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
   name: tenants.minio.min.io
 spec:
   conversion:

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3,6 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.7
+    meta.helm.sh/release-name: minio-operator
+    meta.helm.sh/release-namespace: minio-operator
+  labels:
+    app.kubernetes.io/managed-by: Helm
   name: tenants.minio.min.io
 spec:
   conversion:

--- a/resources/patch-crd/crd-conversion.yaml
+++ b/resources/patch-crd/crd-conversion.yaml
@@ -1,6 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-namespace: minio-operator
+    meta.helm.sh/release-name: minio-operator
   name: tenants.minio.min.io
 spec:
   preserveUnknownFields: false


### PR DESCRIPTION
- Moved tenant crd from `helm/crds` to `helm/templates` folder so helm
  is able to perform upgrades on the custom resource

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>