### PR TITLE
Add ingresses to tenant helm chart

### DIFF
--- a/helm/operator/templates/console-ingress.yaml
+++ b/helm/operator/templates/console-ingress.yaml
@@ -1,11 +1,5 @@
 {{- if .Values.console.ingress.enabled }}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
-{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "minio-operator.console-fullname" . }}
@@ -26,7 +20,7 @@ spec:
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
-      {{- end }}
+        {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
@@ -35,16 +29,10 @@ spec:
       http:
         paths:
           - path: {{ .Values.console.ingress.path }}
-            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-            pathType: Prefix
+            pathType: {{ .Values.console.ingress.pathType }}
             backend:
               service:
                 name: "console"
                 port:
                   name: http
-            {{- else }}
-            backend:
-              serviceName: "console"
-              servicePort: http
-            {{ end }}
 {{ end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -55,6 +55,6 @@ console:
     tls: [ ]
     host: console.local
     path: /
+    pathType: Prefix
   volumes: [ ]
   volumeMounts: [ ]
-

--- a/helm/tenant/templates/api-ingress.yaml
+++ b/helm/tenant/templates/api-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.api.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.tenant.name }}
+  {{- with .Values.ingress.api.labels }}
+  labels: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.api.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.api.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.api.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.api.tls }}
+  tls:
+    {{- range .Values.ingress.api.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.api.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.api.path }}
+            pathType: {{ .Values.ingress.api.pathType }}
+            backend:
+              service:
+                name: minio
+                port:
+                  {{- if or .Values.tenant.certificate.requestAutoCert (not (empty .Values.tenant.certificate.externalCertSecret)) }}
+                  name: https-minio
+                  {{- else }}
+                  name: http-minio
+                  {{- end }}
+{{ end }}

--- a/helm/tenant/templates/console-ingress.yaml
+++ b/helm/tenant/templates/console-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.console.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.tenant.name }}-console
+  {{- with .Values.ingress.console.labels }}
+  labels: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.ingress.console.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.console.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.console.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.console.tls }}
+  tls:
+    {{- range .Values.ingress.console.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.console.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.console.path }}
+            pathType: {{ .Values.ingress.console.pathType }}
+            backend:
+              service:
+                name: {{ .Values.tenant.name }}-console
+                port:
+                  {{- if or .Values.tenant.certificate.requestAutoCert (not (empty .Values.tenant.certificate.externalCertSecret)) }}
+                  name: https-console
+                  {{- else }}
+                  name: http-console
+                  {{- end }}
+{{ end }}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -80,11 +80,11 @@ spec:
   {{- end }}
   mountPath: {{ dig "mountPath" "/export" . }}
   subPath: {{ dig "subPath" "/data" . }}
-  {{- with (dig "certificate" "externalCaCertSecret" (dict) .) }}
+  {{- with (dig "certificate" "externalCaCertSecret" (list) .) }}
   externalCaCertSecret:
     {{- toYaml . | nindent 6 }}
   {{- end }}
-  {{- with (dig "certificate" "externalCertSecret" (dict) .) }}
+  {{- with (dig "certificate" "externalCertSecret" (list) .) }}
   externalCertSecret:
     {{- toYaml . | nindent 6 }}
   {{- end }}
@@ -128,7 +128,7 @@ spec:
   serviceMetadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with (dig "env" (dict) .) }}
+  {{- with (dig "env" (list) .) }}
   env:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -13,7 +13,7 @@ tenant:
   ## Registry location and Tag to download MinIO Server image
   image:
     repository: quay.io/minio/minio
-    tag: RELEASE.2022-01-08T03-11-54Z
+    tag: RELEASE.2022-05-26T05-48-41Z
     pullPolicy: IfNotPresent
   ## Customize any private registry image pull secret.
   ## currently only one secret registry is supported
@@ -40,7 +40,7 @@ tenant:
       ## Used to specify labels for pods
       labels: { }
       ## Used to specify a toleration for a pod
-      tolerations: { }
+      tolerations: [ ]
       ## nodeSelector parameters for MinIO Pods. It specifies a map of key-value pairs. For the pod to be
       ## eligible to run on a node, the node must have each of the
       ## indicated key-value pairs as labels.
@@ -68,11 +68,11 @@ tenant:
     ## Use this field to provide one or more external CA certificates. This is used by MinIO
     ## to verify TLS connections with other applications:
     ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
-    externalCaCertSecret: { }
-    ## Use this field to provide a list of Secrets with external certificates. This can be used to to configure
+    externalCaCertSecret: [ ]
+    ## Use this field to provide a list of Secrets with external certificates. This can be used to configure
     ## TLS for MinIO Tenant pods. Create secrets as explained here:
     ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
-    externalCertSecret: { }
+    externalCertSecret: [ ]
     ## Enable automatic Kubernetes based certificate generation and signing as explained in
     ## https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster
     requestAutoCert: true
@@ -121,7 +121,7 @@ tenant:
   ## services created by the operator.
   serviceMetadata: { }
   ## Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
-  env: { }
+  env: [ ]
   ## PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods.
   ## This is applied to MinIO pods only.
   ## Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass/
@@ -222,3 +222,23 @@ tenant:
       runAsGroup: 1000
       runAsNonRoot: true
       fsGroup: 1000
+
+ingress:
+  api:
+    enabled: false
+    ingressClassName: ""
+    labels: { }
+    annotations: { }
+    tls: [ ]
+    host: minio.local
+    path: /
+    pathType: Prefix
+  console:
+    enabled: false
+    ingressClassName: ""
+    labels: { }
+    annotations: { }
+    tls: [ ]
+    host: minio-console.local
+    path: /
+    pathType: Prefix


### PR DESCRIPTION
PR implements https://github.com/minio/operator/issues/585 with some additional improvements.

### Implementation notes:
- Two independent Ingress objects have been added to tenant helm chart: `API Ingress` and `Console Ingress`
- Operator Ingress has been simplified due to minimal Kubernetes version requirement
- MinIO version has been updated in tenant helm chart
- Fixed some value types in tenant helm chart

### Testing notes:
Tested locally on minikube
```
$ minikube start
$ minikube addons enable ingress
$ minikube version
minikube version: v1.25.2
```
Tested by deploying without TLS
```
helm install minio-tenant tenant \
 --set tenant.pools[0].volumesPerServer=1 \
 --set tenant.certificate.requestAutoCert=false \
 --set tenant.kes.kesSecret.name="" \
 --set tenant.prometheus.diskCapacityGB="" \
 --set tenant.log.audit.diskCapacityGB="" \
 --set ingress.api.enabled=true \
 --set ingress.console.enabled=true \
 --namespace minio-tenant --create-namespace
```
API check
```
$ mc alias set minio http://minio.local minio minio123
Added `minio` successfully.
$ mc ls minio
[2022-05-26 15:44:44 CEST]     0B test/
```
Console check
![tenant-login](https://user-images.githubusercontent.com/36439732/170744964-a6d99dab-2b02-4fd4-8d17-e9298da0f887.jpg)
![tenant-console](https://user-images.githubusercontent.com/36439732/170745094-ee5d6678-4274-4b99-b16d-698cc63f5cfb.jpg)

