### PR TITLE
Have tests use non-existing docker image

### DIFF
--- a/testing/common.sh
+++ b/testing/common.sh
@@ -47,16 +47,16 @@ function install_operator() {
 
   # To compile current branch
   echo "Compiling Current Branch Operator"
-  (cd "${SCRIPT_DIR}/.." && make docker) # will not change your shell's current directory
+  (cd "${SCRIPT_DIR}/.." && TAG=minio/operator:noop make docker) # will not change your shell's current directory
 
   echo 'start - load compiled image so we can use it later on'
-  kind load docker-image docker.io/minio/operator:dev
+  kind load docker-image minio/operator:noop
   echo 'end - load compiled image so we can use it later on'
 
   if [ "$1" = "helm" ]; then
 
     echo "Change the version accordingly for image to be found within the cluster"
-    yq -i '.operator.image.tag = "dev"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
+    yq -i '.operator.image.tag = "noop"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
 
     echo "Installing Current Operator via HELM"
     helm install \

--- a/testing/dev/deployment.yaml
+++ b/testing/dev/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: minio-operator
       containers:
         - name: minio-operator
-          image: minio/operator:dev
+          image: minio/operator:noop
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 1000

--- a/testing/helm/values.yaml
+++ b/testing/helm/values.yaml
@@ -1,5 +1,5 @@
 operator:
   image:
-    repository: miniodev/operator
-    tag: dev
+    repository: minio/operator
+    tag: noop
     pullPolicy: IfNotPresent

--- a/testing/tenant/tenant.yaml
+++ b/testing/tenant/tenant.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: minio-tenant
 spec:
   log:
-    image: minio/operator:dev
+    image: minio/operator:noop


### PR DESCRIPTION
We want to prevent the tests from pulling a docker container from the docker registry, so we want to use the specific version we built in this case, using `minio/operator:noop` which is an image that doesn't exists on the official registry.

This is temporary while we introduce ghcr.io 

Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>