### PR TITLE
Disable KES for default tenant deployments using Helm

### DIFF
--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -128,31 +128,31 @@ tenant:
   priorityClassName: ""
   ## Define configuration for KES (stateless and distributed key-management system)
   ## Refer https://github.com/minio/kes
-  kes:
-    image: "" # minio/kes:v0.17.6
-    replicas: 2
-    kesSecret:
-      name: kes-configuration
-    imagePullPolicy: "IfNotPresent"
-    externalCertSecret: null
-    clientCertSecret: null
-    ## Key name to be created on the KMS, default is "my-minio-key"
-    keyName: ""
-    resources: { }
-    nodeSelector: { }
-    affinity:
-      nodeAffinity: { }
-      podAffinity: { }
-      podAntiAffinity: { }
-    tolerations: [ ]
-    annotations: { }
-    labels: { }
-    serviceAccountName: ""
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
-      runAsNonRoot: true
-      fsGroup: 1000
+  #kes:
+  #  image: "" # minio/kes:v0.17.6
+  #  replicas: 2
+  #  kesSecret:
+  #    name: kes-configuration
+  #  imagePullPolicy: "IfNotPresent"
+  #  externalCertSecret: null
+  #  clientCertSecret: null
+  #  ## Key name to be created on the KMS, default is "my-minio-key"
+  #  keyName: ""
+  #  resources: { }
+  #  nodeSelector: { }
+  #  affinity:
+  #    nodeAffinity: { }
+  #    podAffinity: { }
+  #    podAntiAffinity: { }
+  #  tolerations: [ ]
+  #  annotations: { }
+  #  labels: { }
+  #  serviceAccountName: ""
+  #  securityContext:
+  #    runAsUser: 1000
+  #    runAsGroup: 1000
+  #    runAsNonRoot: true
+  #    fsGroup: 1000
   ## Prometheus setup for MinIO Tenant.
   prometheus:
     image: "" # defaults to quay.io/prometheus/prometheus:latest


### PR DESCRIPTION
Documentation in: https://github.com/minio/operator/tree/master/helm/operator
is not working because deploying a tenant via helm via:

```
helm install --namespace tenant-ns \
  --create-namespace tenant minio/tenant
```

will try to enable KES on the tenant by default, the tenant will never
run because there is no VAULT/KMS configured on the cluster

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>