### PR TITLE
Remove unnecessary code from olm.sh

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -80,16 +80,10 @@ for catalog in "${redhatCatalogs[@]}"; do
 
   myenv=$EXAMPLE yq -i e ".metadata.annotations.alm-examples |= (\"\${myenv}\" | envsubst)" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
 
-  # Avoid message: "There are unpinned images digests!" by using Digest Sha256:xxxx rather than vx.x.x
+  # Set the version, later in olm-post-script.sh we change for Digest form.
   containerImage="quay.io/minio/operator:v${RELEASE}"
   echo "containerImage: ${containerImage}"
-  digest=$(docker pull $containerImage | grep Digest | awk -F ' ' '{print $2}')
   operatorImageDigest="quay.io/minio/operator:v${RELEASE}"
-  if [ -n "${digest}" ]; then
-      echo "digest: ${operatorImageDigest} @ ${digest}"
-  else
-      echo "digest: ${operatorImageDigest}"
-  fi
   yq -i ".metadata.annotations.containerImage |= (\"${operatorImageDigest}\")" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
 
   # Console Image in Digested form: sha256:xxxx


### PR DESCRIPTION
There is an error that is invalid at this point:

```
INFO[0000] Bundle metadata generated suceessfully       
containerImage: quay.io/minio/operator:v4.4.23
Error response from daemon: manifest for quay.io/minio/operator:v4.4.23 not found: manifest unknown: manifest unknown
digest: quay.io/minio/operator:v4.4.23
consoleImage: minio/console:v0.18.1
```

Since registry is not ready, docker command will fail.
This process will take place only after registry is ready in `olm-post-script.sh`