### PR TITLE
Adding default FSGroupChangePolicy configuration on SecurityContext

### DIFF
--- a/pkg/resources/deployments/log-search-api.go
+++ b/pkg/resources/deployments/log-search-api.go
@@ -129,11 +129,14 @@ func logSearchAPISecurityContext(t *miniov2.Tenant) *corev1.PodSecurityContext {
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 1000
 	var fsGroup int64 = 1000
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
 	securityContext := corev1.PodSecurityContext{
-		RunAsNonRoot: &runAsNonRoot,
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		FSGroup:      &fsGroup,
+		RunAsNonRoot:        &runAsNonRoot,
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}
 	if t.HasLogEnabled() && t.Spec.Log.SecurityContext != nil {
 		securityContext = *t.Spec.Log.SecurityContext

--- a/pkg/resources/statefulsets/kes-statefulset.go
+++ b/pkg/resources/statefulsets/kes-statefulset.go
@@ -93,11 +93,14 @@ func kesSecurityContext(t *miniov2.Tenant) *corev1.PodSecurityContext {
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 1000
 	var fsGroup int64 = 1000
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
 	securityContext := corev1.PodSecurityContext{
-		RunAsNonRoot: &runAsNonRoot,
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		FSGroup:      &fsGroup,
+		RunAsNonRoot:        &runAsNonRoot,
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}
 	if t.HasKESEnabled() && t.Spec.KES.SecurityContext != nil {
 		securityContext = *t.Spec.KES.SecurityContext

--- a/pkg/resources/statefulsets/log.go
+++ b/pkg/resources/statefulsets/log.go
@@ -131,11 +131,14 @@ func postgresSecurityContext(t *miniov2.Tenant) *corev1.PodSecurityContext {
 	var runAsUser int64 = 999
 	var runAsGroup int64 = 999
 	var fsGroup int64 = 999
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
 	securityContext := corev1.PodSecurityContext{
-		RunAsNonRoot: &runAsNonRoot,
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		FSGroup:      &fsGroup,
+		RunAsNonRoot:        &runAsNonRoot,
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}
 	if t.HasLogEnabled() && t.Spec.Log.Db != nil && t.Spec.Log.Db.SecurityContext != nil {
 		securityContext = *t.Spec.Log.Db.SecurityContext

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -404,11 +404,14 @@ func poolSecurityContext(pool *miniov2.Pool, status *miniov2.PoolStatus) *v1.Pod
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 1000
 	var fsGroup int64 = 1000
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
 	securityContext := corev1.PodSecurityContext{
-		RunAsNonRoot: &runAsNonRoot,
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		FSGroup:      &fsGroup,
+		RunAsNonRoot:        &runAsNonRoot,
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}
 
 	if pool != nil && pool.SecurityContext != nil {

--- a/pkg/resources/statefulsets/prometheus.go
+++ b/pkg/resources/statefulsets/prometheus.go
@@ -125,11 +125,14 @@ func prometheusSecurityContext(t *miniov2.Tenant) *corev1.PodSecurityContext {
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 1000
 	var fsGroup int64 = 1000
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
 	securityContext := corev1.PodSecurityContext{
-		RunAsNonRoot: &runAsNonRoot,
-		RunAsUser:    &runAsUser,
-		RunAsGroup:   &runAsGroup,
-		FSGroup:      &fsGroup,
+		RunAsNonRoot:        &runAsNonRoot,
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
 	}
 	if t.HasPrometheusEnabled() && t.Spec.Prometheus.SecurityContext != nil {
 		securityContext = *t.Spec.Prometheus.SecurityContext


### PR DESCRIPTION
Adding default value of FSGroupChangeOnRootMismatch for
FSGroupChangePolicy for SecurityContext of all deployments

For more details on "OnRootMismatch" setting, please refer [https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-users-to-skip-recu[…]mission-changes-on-mount](https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-users-to-skip-recursive-permission-changes-on-mount)

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>