### PR TITLE
Relax validation to allow 1x1 setups

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -822,7 +822,7 @@ func (z *Pool) Validate(zi int) error {
 		case 2:
 			return fmt.Errorf("pool #%d with 2 servers must have at least 4 volumes in total", zi)
 		case 3:
-			return fmt.Errorf("pool #%d with 3 servers must have at least 4 volumes in total", zi)
+			return fmt.Errorf("pool #%d with 3 servers must have at least 6 volumes in total", zi)
 		}
 	}
 

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -819,12 +819,10 @@ func (z *Pool) Validate(zi int) error {
 	if z.Servers*z.VolumesPerServer < 4 {
 		// Erasure coding has few requirements.
 		switch z.Servers {
-		case 1:
-			return fmt.Errorf("pool #%d setup must have a minimum of 4 volumes per server", zi)
 		case 2:
-			return fmt.Errorf("pool #%d setup must have a minimum of 2 volumes per server", zi)
+			return fmt.Errorf("pool #%d with 2 servers must have at least 4 volumes in total", zi)
 		case 3:
-			return fmt.Errorf("pool #%d setup must have a minimum of 2 volumes per server", zi)
+			return fmt.Errorf("pool #%d with 3 servers must have at least 4 volumes in total", zi)
 		}
 	}
 


### PR DESCRIPTION
To test this, create a tenant with 1 server and 1 drive, or 1 server and X drives

<img width="1608" alt="Screen Shot 2022-06-14 at 3 02 41 PM" src="https://user-images.githubusercontent.com/18384552/173697444-d62102af-ec85-41c1-86c0-26d45d553cc2.png">


Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>