### PR TITLE
fix: parse image version tag during tenant upgrade

### DIFF
--- a/pkg/controller/cluster/artifacts.go
+++ b/pkg/controller/cluster/artifacts.go
@@ -52,7 +52,7 @@ func (c *Controller) fetchTag(path string) (string, error) {
 		return "", err
 	}
 	op := strings.Fields(out.String())
-	if len(op) != 3 {
+	if len(op) < 3 {
 		return "", fmt.Errorf("incorrect output while fetching tag value - %d", len((op)))
 	}
 	return op[2], nil


### PR DESCRIPTION
Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>