### PR TITLE
Added flag to allow secret creation or just reference for tenant chart

### DIFF
--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -1,4 +1,4 @@
-{{- if dig "secrets" false (.Values | merge (dict)) }}
+{{- if dig "secrets" "create" false (.Values | merge (dict)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,7 +1,9 @@
 ## Secret with credentials to be used by MinIO Tenant
 secrets:
-  # create a kubernetes configuration secret object with the accessKey and secretKey as defined here.
+  # Secret name
   name: minio1-env-configuration
+  # create a kubernetes configuration secret object with the accessKey and secretKey as defined here.
+  create: true
   accessKey: minio
   secretKey: minio123
 


### PR DESCRIPTION
This is to allow the secret to be only referenced from the helm chart rather than creating a secret.
Related to #1166
This will help with gitops managed environments, so we don't have to store secrets in Git.
This might need to wait for the next release to be added, please let me know what changes would be required for this to go through.