### PR TITLE
Add tenant.features.bucketDNS and tenant.features.domains to tenant helm chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -92,8 +92,15 @@ spec:
     {{- toYaml . | nindent 6 }}
   {{- end }}
   requestAutoCert: {{ dig "certificate" "requestAutoCert" false . }}
-  s3:
-    bucketDNS: {{ dig "s3" "bucketDNS" false . }}
+  {{- if dig "s3" "bucketDNS" false . }}
+  {{- fail "Value 'tenant.s3.bucketDNS' is deprecated since Operator v4.3.2, use 'tenant.features.bucketDNS' instead" }}
+  {{- end }}
+  features:
+    bucketDNS: {{ dig "features" "bucketDNS" false . }}
+    {{- with (dig "features" "domains" (dict) .) }}
+    domains:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- with (dig "buckets" (list) .) }}
   buckets:
     {{- toYaml . | nindent 4 }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -79,11 +79,11 @@ tenant:
     ## for the auto-generated certificate. Internal DNS name for the pod will be used if CommonName is
     ## not provided. DNS name format is *.minio.default.svc.cluster.local
     certConfig: { }
-  ## Enable S3 specific features such as Bucket DNS which would allow `buckets` to be
-  ## accessible as DNS entries of form `<bucketname>.minio.default.svc.cluster.local`
-  s3:
-    ## This feature is turned off by default
+  ## MinIO features to enable or disable in the MinIO Tenant
+  ## https://github.com/minio/operator/blob/master/docs/crd.adoc#features
+  features:
     bucketDNS: false
+    domains: { }
   ## List of bucket names to create during tenant provisioning
   buckets: [ ]
   ## List of secret names to use for generating MinIO users during tenant provisioning


### PR DESCRIPTION
The PR adds `tenant.features.bucketDNS` and `tenant.features.domains` to tenant helm chart.
Also it throws an exception if `tenant.s3.bucketDNS` is set to `true`.

Signed-off-by: dnskr <dnskrv88@gmail.com>