### PR TITLE
To delete audit log config when disabled

### DIFF
--- a/pkg/controller/cluster/log-search.go
+++ b/pkg/controller/cluster/log-search.go
@@ -107,7 +107,10 @@ func logSearchAPIDeploymentMatchesSpec(tenant *miniov2.Tenant, actualDeployment 
 	return true, nil
 }
 
-func (c *Controller) deleteLogHeadlessService(ctx context.Context, tenant *miniov2.Tenant) error {
+func (c *Controller) deleteLogHeadlessService(ctx context.Context, tenant *miniov2.Tenant, adminClnt *madmin.AdminClient) error {
+	if _, err := adminClnt.DelConfigKV(ctx, fmt.Sprintf("audit_webhook:%s", tenant.LogSearchAPIDeploymentName())); err != nil {
+		return err
+	}
 	_, err := c.serviceLister.Services(tenant.Namespace).Get(tenant.LogHLServiceName())
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -1176,7 +1176,7 @@ func (c *Controller) syncHandler(key string) error {
 			return err
 		}
 	} else {
-		err := c.deleteLogHeadlessService(ctx, tenant)
+		err := c.deleteLogHeadlessService(ctx, tenant, adminClnt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR is to fix issue observed in: https://subnet.min.io/issues/6214
Basically we need to delete audit log configuration when it is disabled.