### PR TITLE
Various LDAP fixes

### DIFF
--- a/examples/kustomization/tenant-external-idp-ldap/openldap.yaml
+++ b/examples/kustomization/tenant-external-idp-ldap/openldap.yaml
@@ -1,44 +1,4 @@
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: billy-ldif
-data:
-  billy.ldif: |
-    # LDIF fragment to create group branch under root
-    dn: uid=billy,dc=example,dc=org
-    uid: billy
-    cn: billy
-    sn: 3
-    objectClass: top
-    objectClass: posixAccount
-    objectClass: inetOrgPerson
-    loginShell: /bin/bash
-    homeDirectory: /home/billy
-    uidNumber: 14583102
-    gidNumber: 14564100
-    userPassword: billy123
-    mail: billy@example.org
-    gecos: Billy User
-
-    # Create base group
-    dn: ou=groups,dc=example,dc=org
-    objectclass:organizationalunit
-    ou: groups
-    description: generic groups branch
-
-    # create consoleAdmin group (this already exists on minio and have a policy of s3::*)
-    dn: cn=consoleAdmin,ou=groups,dc=example,dc=org
-    objectClass: top
-    objectClass: posixGroup
-    gidNumber: 678
-
-    # Assing group to new user
-    dn: cn=consoleAdmin,ou=groups,dc=example,dc=org
-    changetype: modify
-    add: memberuid
-    memberuid: billy
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,23 +13,22 @@ spec:
       labels:
         app: openldap
     spec:
-      volumes:
-        - name: billy-configuration
-          configMap:
-            name: billy-ldif
       containers:
         - name: openldap
-          image: osixia/openldap:1.3.0
+          image: quay.io/minio/openldap:latest
+          env:
+            - name: LDAP_ORGANIZATION
+              value: "MinIO Inc."
+            - name: LDAP_DOMAIN
+              value: "min.io"
+            - name: LDAP_ADMIN_PASSWORD
+              value: "admin"
           imagePullPolicy: "IfNotPresent"
           ports:
             - containerPort: 389
               name: tcp-ldap
             - containerPort: 636
               name: tcp-ldap2
-          volumeMounts:
-            - name: billy-configuration
-              mountPath: /tmp/billy.ldif
-              subPath: billy.ldif
 ---
 apiVersion: v1
 kind: Service

--- a/examples/kustomization/tenant-external-idp-ldap/storage-user.yaml
+++ b/examples/kustomization/tenant-external-idp-ldap/storage-user.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  CONSOLE_ACCESS_KEY: dWlkPWJpbGx5LGRjPWV4YW1wbGUsZGM9b3Jn # "uid=billy,dc=example,dc=org"
+  CONSOLE_ACCESS_KEY: dWlkPWRpbGxvbixvdT1wZW9wbGUsb3U9c3dlbmdnLGRjPW1pbixkYz1pbw== # "uid=dillon,ou=people,ou=swengg,dc=min,dc=io"
   CONSOLE_SECRET_KEY: ""
 kind: Secret
 metadata:

--- a/examples/kustomization/tenant-external-idp-ldap/tenant.yaml
+++ b/examples/kustomization/tenant-external-idp-ldap/tenant.yaml
@@ -10,11 +10,17 @@ spec:
   env:
     - name: MINIO_IDENTITY_LDAP_SERVER_ADDR
       value: "openldap.tenant-external-idp-ldap.svc.cluster.local:389"
-    - name: MINIO_IDENTITY_LDAP_USERNAME_FORMAT
-      value: "uid=%s,dc=example,dc=org"
-    - name: MINIO_IDENTITY_LDAP_USERNAME_SEARCH_FILTER
-      value: "(|(objectclass=posixAccount)(uid=%s))"
-    - name: MINIO_IDENTITY_LDAP_TLS_SKIP_VERIFY
-      value: "on"
+    - name: MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN
+      value: "cn=admin,dc=min,dc=io"
+    - name: MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD
+      value: "admin"
+    - name: MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN
+      value: "dc=min,dc=io"
+    - name: MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER
+      value: "(uid=%s)"
+    - name: MINIO_IDENTITY_LDAP_GROUP_SEARCH_BASE_DN
+      value: "ou=swengg,dc=min,dc=io"
+    - name: MINIO_IDENTITY_LDAP_GROUP_SEARCH_FILTER
+      value: "(&(objectclass=groupOfNames)(member=%d))"
     - name: MINIO_IDENTITY_LDAP_SERVER_INSECURE
       value: "on"

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -1222,7 +1222,7 @@ func (c *Controller) syncHandler(key string) error {
 		c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "UsersCreated", "Users created")
 	}
 
-	// Ensure we are only creating the bucket once using the console user
+	// Ensure we are only creating the bucket
 	if !tenant.Status.ProvisionedBuckets && len(tenant.Spec.Buckets) > 0 {
 		if err := c.createBuckets(ctx, tenant, tenantConfiguration); err != nil {
 			klog.V(2).Infof("Unable to create MinIO buckets: %v", err)


### PR DESCRIPTION
- update: `examples/kustomization/tenant-external-idp-ldap` deployment
  example to use LDAP Lookup-Bind mode
- fix: create buckets during tenant creation when LDAP is enabled
- fix: tenant stuck in provisioning users during tenant creation when
  LDAP is enabled and tenant configuration is readed from configuration
  file

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>