### PR TITLE
wrap_all_error

### DIFF
--- a/pkg/controller/cluster/decomission.go
+++ b/pkg/controller/cluster/decomission.go
@@ -43,7 +43,7 @@ func (c *Controller) checkForPoolDecommission(ctx context.Context, key string, t
 		}
 		if noDecom {
 			klog.Warningf("%s Detected we are removing a pool but spec.Pool[].Name is empty - disallowing removal", key)
-			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusDecommissioningNotAllowed, 0); err != nil {
+			if _, err = c.updateTenantStatus(ctx, tenant, StatusDecommissioningNotAllowed, 0); err != nil {
 				return nil, err
 			}
 			return nil, errors.New("removing pool not allowed")

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -559,7 +559,7 @@ func (c *Controller) processNextWorkItem() bool {
 		if err := c.syncHandler(key); err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			c.workqueue.AddRateLimited(key)
-			return fmt.Errorf("error syncing '%s': %s", key, err.Error())
+			return fmt.Errorf("error syncing '%s': %w", key, err)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
@@ -995,7 +995,7 @@ func (c *Controller) syncHandler(key string) error {
 		if err != nil {
 			_ = c.removeArtifacts()
 
-			err = fmt.Errorf("Unable to get canonical update URL for Tenant '%s', failed with %v", tenantName, err)
+			err = fmt.Errorf("Unable to get canonical update URL for Tenant '%s', failed with %w", tenantName, err)
 			if _, terr := c.updateTenantStatus(ctx, tenant, err.Error(), totalReplicas); terr != nil {
 				return terr
 			}

--- a/pkg/controller/cluster/monitoring.go
+++ b/pkg/controller/cluster/monitoring.go
@@ -442,7 +442,7 @@ func (c *Controller) processNextHealthCheckItem() bool {
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Tenant resource to be synced.
 		if err := c.syncHealthCheckHandler(key); err != nil {
-			return fmt.Errorf("error checking health check '%s': %s", key, err.Error())
+			return fmt.Errorf("error checking health check '%s': %w", key, err)
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.


### PR DESCRIPTION
The go.mod file shows that the dependency is 1.17.
In golang 1.17, it supports wrap on errors.
So we can use 'errors.Is' to determine the error afterwards, which is much easier. Before that, we need to wrap the error, so I mention this PR.