### PR TITLE
Skip checking public.crt mount in volumes with no sources

### DIFF
--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -865,6 +865,9 @@ func (c *Controller) syncHandler(key string) error {
 		// check if operator-tls public.crt is mounted on MinIO pods
 		if !operatorTLSCertIsMounted {
 			for _, volume := range ss.Spec.Template.Spec.Volumes {
+				if volume.Projected == nil || volume.Projected.Sources == nil {
+					continue
+				}
 				for _, vp := range volume.Projected.Sources {
 					if vp.Secret.Name == OperatorTLSSecretName {
 						operatorTLSCertIsMounted = true


### PR DESCRIPTION
Follows https://github.com/minio/operator/issues/1178