### PR TITLE
fix: Added missing ClusterRole permission

### DIFF
--- a/helm/operator/templates/cluster-role.yaml
+++ b/helm/operator/templates/cluster-role.yaml
@@ -92,6 +92,7 @@ rules:
       - create
       - get
       - delete
+      - list
   - apiGroups:
       - certificates.k8s.io
     resourceNames:

--- a/helm/operator/templates/console-ui.yaml
+++ b/helm/operator/templates/console-ui.yaml
@@ -111,6 +111,8 @@ rules:
       - update
       - create
       - get
+      - delete
+      - list
   - apiGroups:
       - minio.min.io
     resources:

--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -92,6 +92,7 @@ rules:
       - create
       - get
       - delete
+      - list
   - apiGroups:
       - certificates.k8s.io
     resourceNames:

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -111,6 +111,8 @@ rules:
       - update
       - create
       - get
+      - delete
+      - list
   - apiGroups:
       - minio.min.io
     resources:


### PR DESCRIPTION
Certificate Requests page in Operator Console page was displaying an
error because of the missing `list` permission on `console-sa` service
account for `certificates.k8s.io` resource

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>