### PR TITLE
PodSecurityPolicies examples

### DIFF
--- a/examples/kustomization/tenant-PodSecurityPolicies/auditlog-sa.yaml
+++ b/examples/kustomization/tenant-PodSecurityPolicies/auditlog-sa.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-log-db-sa
+  namespace: minio-tenant
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: minio-tenant-log-db-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'CHOWN'
+    - 'DAC_OVERRIDE'
+    - 'FSETID'
+    - 'FOWNER'
+    - 'MKNOD'
+    - 'SETGID'
+    - 'SETUID'
+    - 'SETFCAP'
+    - 'SETPCAP'
+    - 'NET_BIND_SERVICE'
+    - 'SYS_CHROOT'
+    - 'KILL'
+    - 'AUDIT_WRITE'
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'projected'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    # The PSP SELinux API cannot express the SELinux Pod Security Standards,
+    # so if using SELinux, you must choose a more restrictive default.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-tenant-log-db-cluster-role
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - minio-tenant-log-db-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minio-tenant-log-db-role-binding
+  namespace: minio-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-tenant-log-db-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: tenant-log-db-sa
+    namespace: tenant-psp

--- a/examples/kustomization/tenant-PodSecurityPolicies/kustomization.yaml
+++ b/examples/kustomization/tenant-PodSecurityPolicies/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - auditlog-sa.yaml
+  - prometheus-sa.yaml
+  - minio-sa.yaml
+  - ../base
+namespace: tenant-psp
+patchesStrategicMerge:
+  - tenant.yaml
+patchesJson6902:
+  - target:
+      group: minio.min.io
+      version: v2
+      kind: Tenant
+      name: storage
+    path: tenantNamePatch.yaml

--- a/examples/kustomization/tenant-PodSecurityPolicies/minio-sa.yaml
+++ b/examples/kustomization/tenant-PodSecurityPolicies/minio-sa.yaml
@@ -1,0 +1,81 @@
+---
+# This is an example of a restrictive policy that requires users to run as an
+# unprivileged user, blocks possible escalations to root, and requires use of
+# several security mechanisms.
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: minio-tenant-psp
+  # annotations:
+  #   # docker/default identifies a profile for seccomp, but it is not particularly tied to the Docker runtime
+  #   seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+  #   apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+  #   apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: false
+  # Required to prevent escalations to root.
+  requiredDropCapabilities:
+    - ALL
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'projected'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-tenant-cluster-role
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - minio-tenant-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minio-tenant-role-binding
+  namespace: minio-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-tenant-cluster-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:tenant-psp

--- a/examples/kustomization/tenant-PodSecurityPolicies/prometheus-sa.yaml
+++ b/examples/kustomization/tenant-PodSecurityPolicies/prometheus-sa.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tenant-prometheus-sa
+  namespace: minio-tenant
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: minio-tenant-prometheus-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'CHOWN'
+    - 'DAC_OVERRIDE'
+    - 'FSETID'
+    - 'FOWNER'
+    - 'MKNOD'
+    - 'SETGID'
+    - 'SETUID'
+    - 'SETFCAP'
+    - 'SETPCAP'
+    - 'NET_BIND_SERVICE'
+    - 'SYS_CHROOT'
+    - 'KILL'
+    - 'AUDIT_WRITE'
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'projected'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    # The PSP SELinux API cannot express the SELinux Pod Security Standards,
+    # so if using SELinux, you must choose a more restrictive default.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-tenant-prometheus-cluster-role
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - minio-tenant-prometheus-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minio-tenant-prometheus-role-binding
+  namespace: minio-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-tenant-prometheus-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: tenant-prometheus-sa
+    namespace: tenant-psp

--- a/examples/kustomization/tenant-PodSecurityPolicies/tenant.yaml
+++ b/examples/kustomization/tenant-PodSecurityPolicies/tenant.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: storage
+  namespace: minio-tenant
+spec:
+  log:
+    db:
+      serviceAccountName: tenant-log-db-sa
+  prometheus:
+    serviceAccountName: tenant-prometheus-sa

--- a/examples/kustomization/tenant-PodSecurityPolicies/tenantNamePatch.yaml
+++ b/examples/kustomization/tenant-PodSecurityPolicies/tenantNamePatch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: storage-psp

--- a/minio-operator-PodSecurityPolicy.yaml
+++ b/minio-operator-PodSecurityPolicy.yaml
@@ -1,0 +1,72 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: minio-operator-psp
+  # annotations:
+  #   # docker/default identifies a profile for seccomp, but it is not particularly tied to the Docker runtime
+  #   seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+  #   apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+  #   apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-operator-cluster-role
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - minio-operator-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: minio-operator-role-binding
+  namespace: minio-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-operator-cluster-role
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:minio-operator


### PR DESCRIPTION
- Adding examples for PodSecurityPolicies tenant deployment for minio,
  postgres and prometheus services
- Adding PodSecurityPolicy deployment example for `minio-operator`

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>