### PR TITLE
Add configuration name support to tenant helm chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -25,14 +25,12 @@ spec:
   imagePullSecret:
     name: {{ dig "imagePullSecret" "name" "" . }}
   {{- end }}
-  {{- if dig "secrets" false ($.Values | merge (dict)) }}
-  ## Secret with credentials to be used by MinIO Tenant.
+  ## Secret with default environment variable configurations
   configuration:
-    name: {{ dig "secrets" "name" "" ($.Values | merge (dict)) }}
+    name: {{ .configuration.name }}
   ## Deprecated credsSecret
   credsSecret:
     name: "tenant-secret"
-  {{- end }}
   pools:
   {{- range (dig "pools" (list) .) }}
     - servers: {{ dig "servers" 4 . }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,7 +1,8 @@
-## Secret with credentials to be used by MinIO Tenant
+## Secret with default environment variable configurations to be used by MinIO Tenant.
+## Not recommended for production deployments! Create the secret manually instead.
 secrets:
-  # create a kubernetes configuration secret object with the accessKey and secretKey as defined here.
   name: minio1-env-configuration
+  # MinIO root user and password
   accessKey: minio
   secretKey: minio123
 
@@ -20,6 +21,10 @@ tenant:
   ## If a scheduler is specified here, Tenant pods will be dispatched by specified scheduler.
   ## If not specified, the Tenant pods will be dispatched by default scheduler.
   scheduler: { }
+  ## Secret name that contains additional environment variable configurations.
+  ## The secret is expected to have a key named config.env containing environment variables exports.
+  configuration:
+    name: minio1-env-configuration
   ## Specification for MinIO Pool(s) in this Tenant.
   pools:
     ## Servers specifies the number of MinIO Tenant Pods / Servers in this pool.


### PR DESCRIPTION
The PR adds `tenant.configuration.name` support to tenant helm chart.
It allows to specify user managed secret name and disable chart managed secret for production environment.

It fixes https://github.com/minio/operator/issues/1166 issue and it is the solution alternative to https://github.com/minio/operator/pull/1192 PR.
So the following would work:
```
## tenant-values.yaml
secrets: ""
tenant:
  configuration:
    name: "test"
```
```
## tenant-envs-conf.yaml
apiVersion: v1
kind: Secret
metadata:
  name: test
type: Opaque
stringData:
  config.env: |-
    export MINIO_ROOT_USER=minio
    export MINIO_ROOT_PASSWORD=miniominio
```
`helm install tenant tenant -f tenant-values.yaml`