### PR TITLE
Single node stateful-kes integration

### DIFF
--- a/examples/kustomization/tenant-stateful-kes-encryption/init-kes-configuration-secret.yaml
+++ b/examples/kustomization/tenant-stateful-kes-encryption/init-kes-configuration-secret.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: init-kes-configuration
+  namespace: minio-tenant
+type: Opaque
+stringData:
+  init-config.yaml: |-
+    version: "v1"
+    address: 0.0.0.0:7373
+    tls:
+      key: /tmp/stateful-kes/server.key
+      cert: /tmp/stateful-kes/server.crt
+      client:
+        verify_cert: false
+
+    system:
+      admin:
+        identity: ${MINIO_STATEFUL_KES_SYS_ADMIN_IDENTITY}
+
+    unseal:
+      environment:
+        name: KES_UNSEAL_KEY
+
+    enclave:
+      default:
+        admin:
+          identity: ${MINIO_STATEFUL_KES_ENCLAVE_ADMIN_IDENTITY}
+        policy:
+          minio:
+            allow:
+            - /v1/api
+            - /v1/log/audit
+            - /v1/log/error
+            - /v1/key/create/*
+            - /v1/key/generate/*
+            - /v1/key/decrypt/*
+            identities:
+            - ${MINIO_STATEFUL_KES_IDENTITY}

--- a/examples/kustomization/tenant-stateful-kes-encryption/kustomization.yaml
+++ b/examples/kustomization/tenant-stateful-kes-encryption/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - init-kes-configuration-secret.yaml
+namespace: minio-tenant
+patchesStrategicMerge:
+  - tenant.yaml
+patchesJson6902:
+  - target:
+      group: minio.min.io
+      version: v2
+      kind: Tenant
+      name: storage
+    path: tenantNamePatch.yaml

--- a/examples/kustomization/tenant-stateful-kes-encryption/tenant.yaml
+++ b/examples/kustomization/tenant-stateful-kes-encryption/tenant.yaml
@@ -1,0 +1,95 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: storage
+  namespace: minio-tenant
+spec:
+  ## Specification for MinIO Pool(s) in this Tenant.
+  pools:
+    ## Servers specifies the number of MinIO Tenant Pods / Servers in this pool.
+    ## For standalone mode, supply 1. For distributed mode, supply 4 or more.
+    ## Note that the operator does not support upgrading from standalone to distributed mode.
+    - servers: 1
+      ## custom pool name
+      name: pool-0
+      ## volumesPerServer specifies the number of volumes attached per MinIO Tenant Pod / Server.
+      volumesPerServer: 4
+      ## This VolumeClaimTemplate is used across all the volumes provisioned for MinIO Tenant in this
+      ## Pool.
+      volumeClaimTemplate:
+        metadata:
+          name: data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 100Mi
+          storageClassName: directpv-min-io
+  ## Define configuration for Stateful-KES
+  ## Refer https://github.com/minio/kes
+  ##
+  ## [PLEASE NOTE THAT STATEFUL-KES IS STRICTLY EXPERIMENTAL AND NOT RECOMMENDED FOR PRODUCTION USECASES]
+  ##
+  stateful-kes:
+    image: "minio/kes:v0.22.3" # minio/kes:v0.18.0
+    env:
+    - name: KES_UNSEAL_KEY
+      value: "UP9GnCU93v8dh5+4YE77e5StU5mtopns1N/wqJGcscA="
+    replicas: 1
+    kesSecret:
+      name: init-kes-configuration
+    imagePullPolicy: "IfNotPresent"
+    ## Use this field to provide external certificates for the StatefulKES server. TLS for StatefulKES pods will be configured
+    ## by mounting a Kubernetes secret under /tmp/stateful-kes folder, supported types:
+    ## Opaque | kubernetes.io/tls | cert-manager.io/v1alpha2 | cert-manager.io/v1
+    ##
+    ## ie:
+    ##
+    ##  externalCertSecret:
+    ##    name: tls-certificates-for-kes
+    ##    type: kubernetes.io/tls
+    ##
+    ## Create secrets as explained here:
+    ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+    # externalCertSecret: null
+    ## Use this field to provide client certificates for StatefulKES. This can be used to configure
+    ## mTLS for StatefulKES and your KMS. Files will be mounted under /tmp/stateful-kes folder, supported types:
+    ## Opaque | kubernetes.io/tls | cert-manager.io/v1alpha2 | cert-manager.io/v1
+    ##
+    ## ie:
+    ##
+    ##  clientCertSecret:
+    ##    name: mtls-certificates-for-kms
+    ##    type: Opaque
+    ##
+    ## Create secrets as explained here:
+    ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+    clientCertSecret: null
+    ## Key name to be created on the KMS, default is "my-minio-key"
+    keyName: "minio-key"
+    volumeClaimTemplate:
+        metadata:
+          name: stateful-kes-data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 200Mi
+          storageClassName: directpv-min-io
+    resources: { }
+    nodeSelector: { }
+    affinity:
+      nodeAffinity: { }
+      podAffinity: { }
+      podAntiAffinity: { }
+    tolerations: [ ]
+    annotations: { }
+    labels: { }
+    serviceAccountName: ""
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      fsGroup: 1000

--- a/examples/kustomization/tenant-stateful-kes-encryption/tenantNamePatch.yaml
+++ b/examples/kustomization/tenant-stateful-kes-encryption/tenantNamePatch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: storage

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -5335,6 +5335,796 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              stateful-kes:
+                properties:
+                  affinity:
+                    properties:
+                      nodeAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                preference:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              nodeSelectorTerms:
+                                items:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  clientCertSecret:
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  env:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  externalCertSecret:
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    type: string
+                  kesSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  keyName:
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    type: integer
+                  resources:
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  securityContext:
+                    properties:
+                      fsGroup:
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        type: string
+                      runAsGroup:
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        properties:
+                          level:
+                            type: string
+                          role:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          hostProcess:
+                            type: boolean
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    type: string
+                  tolerations:
+                    items:
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      properties:
+                        labelSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          format: int32
+                          type: integer
+                        minDomains:
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          type: string
+                        nodeTaintsPolicy:
+                          type: string
+                        topologyKey:
+                          type: string
+                        whenUnsatisfiable:
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                  volumeClaimTemplate:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                      status:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          allocatedResources:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          conditions:
+                            items:
+                              properties:
+                                lastProbeTime:
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  type: string
+                                reason:
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          phase:
+                            type: string
+                          resizeStatus:
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - kesSecret
+                - volumeClaimTemplate
+                type: object
               subPath:
                 type: string
               users:

--- a/kubectl-minio/cmd/helpers/constants.go
+++ b/kubectl-minio/cmd/helpers/constants.go
@@ -42,7 +42,7 @@ const (
 	DefaultTenantImage = "minio/minio:RELEASE.2023-01-12T02-06-16Z"
 
 	// DefaultKESImage is the default KES image used while creating tenant
-	DefaultKESImage = "minio/kes:v0.18.0"
+	DefaultKESImage = "minio/kes:v0.22.3"
 )
 
 // KESReplicas is the number of replicas for MinIO KES

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -224,16 +224,26 @@ const LogSearchDiskCapacityGB = "LOGSEARCH_DISK_CAPACITY_GB"
 // KES Related Constants
 
 // DefaultKESImage specifies the latest KES Docker hub image
-const DefaultKESImage = "minio/kes:v0.18.0"
+const DefaultKESImage = "minio/kes:v0.22.3"
 
 // KESInstanceLabel is applied to the KES pods of a Tenant cluster
 const KESInstanceLabel = "v1.min.io/kes"
 
+// StatefulKESInstanceLabel is applied to the stateful KES pods of a Tenant cluster
+const StatefulKESInstanceLabel = "v1.min.io/stateful-kes"
+
 // KESPort specifies the default KES Service's port number.
 const KESPort = 7373
 
+// StatefulKESPort specifies the default Stateful KES Service's port number.
+// Same port as either one of them will be enabled on not both
+const StatefulKESPort = 7373
+
 // KESServicePortName specifies the default KES Service's port name.
 const KESServicePortName = "http-kes"
+
+// StatefulKESServicePortName specifies the default Stateful KES Service's port name.
+const StatefulKESServicePortName = "http-stateful-kes"
 
 // KESMinIOKey is the name of key that KES creates on the KMS backend
 const KESMinIOKey = "my-minio-key"
@@ -244,15 +254,29 @@ const KESJobRestartPolicy = corev1.RestartPolicyOnFailure
 // KESHLSvcNameSuffix specifies the suffix added to Tenant name to create a headless service for KES
 const KESHLSvcNameSuffix = "-kes-hl-svc"
 
+// StatefulKESHLSvcNameSuffix specifies the suffix added to Tenant name to create a headless service for StatefulKES
+const StatefulKESHLSvcNameSuffix = "-stateful-kes-hl-svc"
+
 // KESName specifies the default container name for KES
 const KESName = "-kes"
+
+// StatefulKESName specifies the default container name for Stateful KES
+const StatefulKESName = "-stateful-kes"
 
 // KESConfigMountPath specifies the path where KES config file and all secrets are mounted
 // We keep this to /tmp so it doesn't require any special permissions
 const KESConfigMountPath = "/tmp/kes"
 
+// StatefulKESConfigMountPath specifies the path where stateful KES init config file and all secrets are mounted
+// We keep this to /tmp so it doesn't require any special permissions
+const StatefulKESConfigMountPath = "/tmp/stateful-kes"
+
 // DefaultKESReplicas specifies the default number of KES pods to be created if not specified
 const DefaultKESReplicas = 2
+
+// DefaultStatefulKESReplicas specifies the default number of StatefulKES pods to be created if not specified
+// Note: the replica count should be 1 as multi-node is not yet supported
+const DefaultStatefulKESReplicas = 1
 
 // Auto TLS related constants
 
@@ -312,3 +336,9 @@ const PrometheusAddlScrapeConfigSecret = "minio-prom-additional-scrape-config"
 
 // PrometheusAddlScrapeConfigKey is the key in secret data
 const PrometheusAddlScrapeConfigKey = "prometheus-additional.yaml"
+
+// SysAdminConfigSuffix is the suffix applied to StatefulKES sysadmin creds
+const SysAdminConfigSuffix = "-sys-admin-config"
+
+// EnclaveAdminConfigSuffix is the suffix applied to StatefulKES enclave admin creds
+const EnclaveAdminConfigSuffix = "-enclave-admin-config"

--- a/pkg/apis/minio.min.io/v2/helper_test.go
+++ b/pkg/apis/minio.min.io/v2/helper_test.go
@@ -145,6 +145,50 @@ func TestTenant_KESServiceEndpoint(t1 *testing.T) {
 	}
 }
 
+func TestTenant_StatefulKESServiceEndpoint(t1 *testing.T) {
+	type fields struct {
+		TypeMeta   metav1.TypeMeta
+		ObjectMeta metav1.ObjectMeta
+		Scheduler  TenantScheduler
+		Spec       TenantSpec
+		Status     TenantStatus
+	}
+	autoCertEnabled := true
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "Success",
+			fields: fields{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stateful-kes",
+					Namespace: "namespace",
+				},
+				Spec: TenantSpec{
+					RequestAutoCert: &autoCertEnabled,
+				},
+			},
+			want: "https://stateful-kes" + StatefulKESHLSvcNameSuffix + ".namespace.svc.cluster.local:7373",
+		},
+	}
+	for _, tt := range tests {
+		t1.Run(tt.name, func(t1 *testing.T) {
+			t := &Tenant{
+				TypeMeta:   tt.fields.TypeMeta,
+				ObjectMeta: tt.fields.ObjectMeta,
+				Scheduler:  tt.fields.Scheduler,
+				Spec:       tt.fields.Spec,
+				Status:     tt.fields.Status,
+			}
+			if got := t.StatefulKESServiceEndpoint(); got != tt.want {
+				t1.Errorf("StatefulKESServiceEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCompareEnvs(t *testing.T) {
 	type args struct {
 		old map[string]string

--- a/pkg/apis/minio.min.io/v2/labels.go
+++ b/pkg/apis/minio.min.io/v2/labels.go
@@ -28,6 +28,13 @@ func (t *Tenant) KESPodLabels() map[string]string {
 	return m
 }
 
+// StatefulKESPodLabels returns the default labels for Stateful KES Pod
+func (t *Tenant) StatefulKESPodLabels() map[string]string {
+	m := make(map[string]string, 1)
+	m[StatefulKESInstanceLabel] = t.StatefulKESStatefulSetName()
+	return m
+}
+
 // LogPgPodLabels returns the default labels for Log Postgres server pods
 func (t *Tenant) LogPgPodLabels() map[string]string {
 	m := make(map[string]string, 1)

--- a/pkg/apis/minio.min.io/v2/names.go
+++ b/pkg/apis/minio.min.io/v2/names.go
@@ -31,6 +31,12 @@ const MinIOVolumeInitContainer = "minio-vol-wait"
 // KESContainerName specifies the default container name for KES
 const KESContainerName = "kes"
 
+// StatefulKESContainerName specifies the default container name for stateful KES
+const StatefulKESContainerName = "stateful-kes"
+
+// StatefulKESInitContainerName specifies the default init container name for stateful KES
+const StatefulKESInitContainerName = "init-stateful-kes"
+
 // ConsoleContainerName specifies the default container name for Console
 const ConsoleContainerName = "console"
 
@@ -139,15 +145,31 @@ func (t *Tenant) KESStatefulSetName() string {
 	return t.Name + KESName
 }
 
+// StatefulKESStatefulSetName returns the name for stateful KES StatefulSet
+func (t *Tenant) StatefulKESStatefulSetName() string {
+	return t.Name + StatefulKESName
+}
+
 // KESHLServiceName returns the name of headless service that is created to manage the
 // StatefulSet of this Tenant
 func (t *Tenant) KESHLServiceName() string {
 	return t.Name + KESHLSvcNameSuffix
 }
 
+// StatefulKESHLServiceName returns the name of headless service that is created to manage the
+// stateful KES deployment of this Tenant
+func (t *Tenant) StatefulKESHLServiceName() string {
+	return t.Name + StatefulKESHLSvcNameSuffix
+}
+
 // KESVolMountName returns the name of Secret that has TLS related Info (Cert & Private Key)
 func (t *Tenant) KESVolMountName() string {
 	return t.Name + KESName
+}
+
+// StatefulKESVolMountName returns the name of Secret that has TLS related Info (Cert & Private Key)
+func (t *Tenant) StatefulKESVolMountName() string {
+	return t.Name + StatefulKESName
 }
 
 // KESWildCardName returns the wild card name managed by headless service created for
@@ -156,9 +178,30 @@ func (t *Tenant) KESWildCardName() string {
 	return fmt.Sprintf("*.%s.%s.svc.%s", t.KESHLServiceName(), t.Namespace, GetClusterDomain())
 }
 
+// StatefulKESWildCardName returns the wild card name managed by headless service created for
+// stateful KES StatefulSet in current Tenant
+func (t *Tenant) StatefulKESWildCardName() string {
+	return fmt.Sprintf("*.%s.%s.svc.%s", t.StatefulKESHLServiceName(), t.Namespace, GetClusterDomain())
+}
+
 // KESTLSSecretName returns the name of Secret that has KES TLS related Info (Cert & Private Key)
 func (t *Tenant) KESTLSSecretName() string {
 	return t.KESStatefulSetName() + TLSSecretSuffix
+}
+
+// StatefulKESTLSSecretName returns the name of Secret that has KES TLS related Info (Cert & Private Key)
+func (t *Tenant) StatefulKESTLSSecretName() string {
+	return t.StatefulKESStatefulSetName() + TLSSecretSuffix
+}
+
+// StatefulKESSysAdminSecretName is the name of the secret for sysadmin creds in statefulKES
+func (t *Tenant) StatefulKESSysAdminSecretName() string {
+	return t.StatefulKESStatefulSetName() + SysAdminConfigSuffix
+}
+
+// StatefulKESEnclaveAdminSecretName is the name of the secret for enclave creds in statefulKES
+func (t *Tenant) StatefulKESEnclaveAdminSecretName() string {
+	return t.StatefulKESStatefulSetName() + EnclaveAdminConfigSuffix
 }
 
 // KESCSRName returns the name of CSR that generated if AutoTLS is enabled for KES
@@ -166,6 +209,13 @@ func (t *Tenant) KESTLSSecretName() string {
 // since CSR is not a namespaced resource
 func (t *Tenant) KESCSRName() string {
 	return t.KESStatefulSetName() + "-" + t.Namespace + CSRNameSuffix
+}
+
+// StatefulKESCSRName returns the name of CSR that generated if AutoTLS is enabled for Stateful KES
+// Namespace adds uniqueness to the CSR name (single stateful KES tenant per namsepace)
+// since CSR is not a namespaced resource
+func (t *Tenant) StatefulKESCSRName() string {
+	return t.StatefulKESStatefulSetName() + "-" + t.Namespace + CSRNameSuffix
 }
 
 // Console Related Names

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -117,6 +117,9 @@ const (
 	StatusInconsistentMinIOVersions          = "Different versions across MinIO Pools"
 	StatusRestartingMinIO                    = "Restarting MinIO"
 	StatusDecommissioningNotAllowed          = "Pool Decommissioning Not Allowed"
+	StatusUpdatingStatefulKES                = "Updating stateful KES"
+	StatusWaitingStatefulKESCert             = "Waiting for stateful KES TLS Certificate"
+	StatusProvisioningStatefulKESStatefulSet = "Provisioning stateful KES StatefulSet"
 )
 
 // ErrMinIONotReady is the error returned when MinIO is not Ready
@@ -856,6 +859,11 @@ func (c *Controller) syncHandler(key string) error {
 		return err
 	}
 
+	err = c.checkStatefulKESStatus(ctx, tenant, totalReplicas, cOpts, uOpts, nsName)
+	if err != nil {
+		klog.V(2).Infof("Error checking stateful KES state %v", err)
+		return err
+	}
 	// check if operator-tls has to be updated or re-created in the tenant namespace
 	err = c.checkOperatorCertForTenant(ctx, tenant)
 	if err != nil {

--- a/pkg/controller/cluster/stateful-kes.go
+++ b/pkg/controller/cluster/stateful-kes.go
@@ -1,0 +1,422 @@
+// Copyright (C) 2022 MinIO, Inc.
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License, version 3,
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package cluster
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
+	"github.com/minio/operator/pkg/controller/cluster/certificates"
+	"github.com/minio/operator/pkg/resources/services"
+	"github.com/minio/operator/pkg/resources/statefulsets"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+func generateStatefulKESCryptoData(tenant *miniov2.Tenant) ([]byte, []byte, error) {
+	privateKey, err := newPrivateKey(miniov2.DefaultEllipticCurve)
+	if err != nil {
+		klog.Errorf("Unexpected error during the ECDSA Key generation: %v", err)
+		return nil, nil, err
+	}
+
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		klog.Errorf("Unexpected error during encoding the ECDSA Private Key: %v", err)
+		return nil, nil, err
+	}
+
+	var csrExtensions []pkix.Extension
+	statefulkesHosts := tenant.StatefulKESHosts()
+	for _, host := range statefulkesHosts {
+		csrExtensions = append(csrExtensions, pkix.Extension{
+			Id:       nil,
+			Critical: false,
+			Value:    []byte(host),
+		})
+	}
+
+	csrTemplate := x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("system:node:%s", tenant.StatefulKESWildCardName()),
+			Organization: tenant.Spec.CertConfig.OrganizationName,
+		},
+		SignatureAlgorithm: x509.ECDSAWithSHA512,
+		DNSNames:           tenant.StatefulKESHosts(),
+		Extensions:         csrExtensions,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, privateKey)
+	if err != nil {
+		klog.Errorf("Unexpected error during creating the CSR: %v", err)
+		return nil, nil, err
+	}
+	return privKeyBytes, csrBytes, nil
+}
+
+// createStatefulKESCSR handles all the steps required to create the CSR: from creation of keys, submitting CSR and
+// finally creating a secret that stateful KES Statefulset will use to mount private key and certificate for TLS
+// This Method Blocks till the CSR Request is approved via kubectl approve
+func (c *Controller) createStatefulKESCSR(ctx context.Context, tenant *miniov2.Tenant) error {
+	privKeysBytes, csrBytes, err := generateStatefulKESCryptoData(tenant)
+	if err != nil {
+		klog.Errorf("Private Key and CSR generation failed with error: %v", err)
+		return err
+	}
+
+	err = c.createCertificateSigningRequest(ctx, tenant.StatefulKESPodLabels(), tenant.StatefulKESCSRName(), tenant.Namespace, csrBytes)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.StatefulKESCSRName(), err)
+		return err
+	}
+	c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "CSRCreated", "Stateful KES CSR Created")
+
+	// fetch certificate from CSR
+	certbytes, err := c.fetchCertificate(ctx, tenant.StatefulKESCSRName())
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the csr/%s: %v", tenant.StatefulKESCSRName(), err)
+		c.RegisterEvent(ctx, tenant, corev1.EventTypeWarning, "CSRFailed", fmt.Sprintf("Stateful KES CSR Failed to create: %s", err))
+		return err
+	}
+
+	// PEM encode private ECDSA key
+	encodedPrivKey := pem.EncodeToMemory(&pem.Block{Type: privateKeyType, Bytes: privKeysBytes})
+
+	// Create secret for stateful KES Statefulset to use
+	err = c.createSecret(ctx, tenant, tenant.StatefulKESPodLabels(), tenant.StatefulKESTLSSecretName(), encodedPrivKey, certbytes)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", tenant.StatefulKESTLSSecretName(), err)
+		return err
+	}
+
+	return nil
+}
+
+// statefulKESStatefulSetMatchesSpec checks if the StatefulSet for stateful KES matches what is expected and described from the Tenant
+func statefulKESStatefulSetMatchesSpec(tenant *miniov2.Tenant, existingStatefulSet *appsv1.StatefulSet) (bool, error) {
+	if existingStatefulSet == nil {
+		return false, errors.New("cannot process an empty stateful kes StatefulSet")
+	}
+	if tenant == nil {
+		return false, errors.New("cannot process an empty tenant")
+	}
+	// compare image directly
+	if !tenant.Spec.StatefulKES.EqualImage(existingStatefulSet.Spec.Template.Spec.Containers[0].Image) {
+		klog.V(2).Infof("Tenant %s KES version %s doesn't match: %s", tenant.Name,
+			tenant.Spec.StatefulKES.Image, existingStatefulSet.Spec.Template.Spec.Containers[0].Image)
+		return false, nil
+	}
+	// compare any other change from what is specified on the tenant
+	expectedStatefulSet := statefulsets.NewForStatefulKES(tenant, tenant.StatefulKESHLServiceName())
+	// compare containers environment variables
+	if miniov2.IsContainersEnvUpdated(existingStatefulSet.Spec.Template.Spec.Containers, expectedStatefulSet.Spec.Template.Spec.Containers) {
+		return false, nil
+	}
+	if !equality.Semantic.DeepDerivative(expectedStatefulSet.Spec, existingStatefulSet.Spec) {
+		// some field set by the operator has changed
+		return false, nil
+	}
+	return true, nil
+}
+
+func (c *Controller) checkStatefulKESCertificatesStatus(ctx context.Context, tenant *miniov2.Tenant, nsName types.NamespacedName) (err error) {
+	if !tenant.ExternalClientCert() {
+		if err = c.checkAndCreateMinIOClientCertificates(ctx, nsName, tenant); err != nil {
+			return err
+		}
+	}
+	// if KES is enabled and user didn't provide KES server certificates generate them
+	if !tenant.StatefulKESExternalCert() {
+		_, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.StatefulKESTLSSecretName(), metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				if err = c.checkAndCreateStatefulKESCSR(ctx, nsName, tenant); err != nil {
+					return err
+				}
+				// TLS secret not found, delete CSR if exists and start certificate generation process again
+				if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
+					if err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, tenant.StatefulKESCSRName(), metav1.DeleteOptions{}); err != nil {
+						return err
+					}
+				} else {
+					if err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Delete(ctx, tenant.StatefulKESCSRName(), metav1.DeleteOptions{}); err != nil {
+						return err
+					}
+				}
+			} else {
+				return err
+			}
+		}
+	}
+	// Check sys admin creds
+	_, err = c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.StatefulKESSysAdminSecretName(), metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			if err = c.checkAndCreateStatefulKESSysAdminSecret(ctx, nsName, tenant); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	// check enclave admin creds
+	_, err = c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.StatefulKESEnclaveAdminSecretName(), metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			if err = c.checkAndCreateStatefulKESEnclaveAdminSecret(ctx, nsName, tenant); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) checkAndCreateStatefulKESSysAdminSecret(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
+	privateKey, err := newPrivateKey(miniov2.DefaultEllipticCurve)
+	if err != nil {
+		klog.Errorf("Unexpected error during the ECDSA Key generation: %v", err)
+		return err
+	}
+	publicKey := privateKey.Public()
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		klog.Errorf("Unexpected error while creating cert serial number: %v", err)
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "kes-sys-admin",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
+	if err != nil {
+		return err
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return err
+	}
+
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+
+	// Create secret for KES StatefulSet to use
+	err = c.createSecret(ctx, tenant, tenant.StatefulKESPodLabels(), tenant.StatefulKESSysAdminSecretName(), keyPem, certPem)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", tenant.StatefulKESSysAdminSecretName(), err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) checkAndCreateStatefulKESEnclaveAdminSecret(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
+	privateKey, err := newPrivateKey(miniov2.DefaultEllipticCurve)
+	if err != nil {
+		klog.Errorf("Unexpected error during the ECDSA Key generation: %v", err)
+		return err
+	}
+	publicKey := privateKey.Public()
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		klog.Errorf("Unexpected error while creating cert serial number: %v", err)
+		return err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName: "minio-admin",
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
+	if err != nil {
+		return err
+	}
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return err
+	}
+
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+
+	// Create secret for KES StatefulSet to use
+	err = c.createSecret(ctx, tenant, tenant.StatefulKESPodLabels(), tenant.StatefulKESEnclaveAdminSecretName(), keyPem, certPem)
+	if err != nil {
+		klog.Errorf("Unexpected error during the creation of the secret/%s: %v", tenant.MinIOClientTLSSecretName(), err)
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) checkAndCreateStatefulKESCSR(ctx context.Context, nsName types.NamespacedName, tenant *miniov2.Tenant) error {
+	var err error
+	if certificates.GetCertificatesAPIVersion(c.kubeClientSet) == certificates.CSRV1 {
+		_, err = c.kubeClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, tenant.StatefulKESCSRName(), metav1.GetOptions{})
+	} else {
+		_, err = c.kubeClientSet.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, tenant.StatefulKESCSRName(), metav1.GetOptions{})
+	}
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			if tenant, err = c.updateTenantStatus(ctx, tenant, StatusWaitingStatefulKESCert, 0); err != nil {
+				return err
+			}
+			klog.V(2).Infof("Creating a new Certificate Signing Request for stateful KES Server Certs, cluster %q", nsName)
+			if err = c.createStatefulKESCSR(ctx, tenant); err != nil {
+				return err
+			}
+			return errors.New("waiting for stateful kes cert")
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) checkStatefulKESStatus(ctx context.Context, tenant *miniov2.Tenant, totalReplicas int32, cOpts metav1.CreateOptions, uOpts metav1.UpdateOptions, nsName types.NamespacedName) error {
+	if tenant.HasStatefulKESEnabled() {
+		if err := c.checkStatefulKESCertificatesStatus(ctx, tenant, nsName); err != nil {
+			return err
+		}
+		// Calculate sys-admin identity based on auto generated KES client certificate
+		sysAdminIdentity, err := c.getCertIdentity(tenant.Namespace, &miniov2.LocalCertificateReference{Name: tenant.StatefulKESSysAdminSecretName()})
+		if err != nil {
+			return err
+		}
+		if !tenant.HasEnv("MINIO_STATEFUL_KES_SYS_ADMIN_IDENTITY") {
+			tenant.Spec.StatefulKES.Env = append(tenant.Spec.StatefulKES.Env, corev1.EnvVar{
+				Name:  "MINIO_STATEFUL_KES_SYS_ADMIN_IDENTITY",
+				Value: sysAdminIdentity,
+			})
+		}
+		// Calculate enclave-admin identity based on auto generated KES client certificate
+		enclaveAdminIdentity, err := c.getCertIdentity(tenant.Namespace, &miniov2.LocalCertificateReference{Name: tenant.StatefulKESEnclaveAdminSecretName()})
+		if err != nil {
+			return err
+		}
+		if !tenant.HasEnv("MINIO_STATEFUL_KES_ENCLAVE_ADMIN_IDENTITY") {
+			tenant.Spec.StatefulKES.Env = append(tenant.Spec.StatefulKES.Env, corev1.EnvVar{
+				Name:  "MINIO_STATEFUL_KES_ENCLAVE_ADMIN_IDENTITY",
+				Value: enclaveAdminIdentity,
+			})
+		}
+		var tenantIdentity string
+		if tenant.ExternalClientCert() {
+			tenantIdentity, err = c.getCertIdentity(tenant.Namespace, tenant.Spec.ExternalClientCertSecret)
+			if err != nil {
+				return err
+			}
+		} else {
+			tenantIdentity, err = c.getCertIdentity(tenant.Namespace, &miniov2.LocalCertificateReference{Name: tenant.MinIOClientTLSSecretName()})
+			if err != nil {
+				return err
+			}
+		}
+		// pass the identity of the MinIO client certificate
+		if !tenant.HasEnv("MINIO_STATEFUL_KES_IDENTITY") {
+			tenant.Spec.StatefulKES.Env = append(tenant.Spec.StatefulKES.Env, corev1.EnvVar{
+				Name:  "MINIO_STATEFUL_KES_IDENTITY",
+				Value: tenantIdentity,
+			})
+		}
+		svc, err := c.serviceLister.Services(tenant.Namespace).Get(tenant.StatefulKESHLServiceName())
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				klog.V(2).Infof("Creating a new Headless Service for stateful kes %q", nsName)
+				svc = services.NewHeadlessForStatefulKES(tenant)
+				if _, err = c.kubeClientSet.CoreV1().Services(svc.Namespace).Create(ctx, svc, cOpts); err != nil {
+					c.RegisterEvent(ctx, tenant, corev1.EventTypeWarning, "SvcFailed", fmt.Sprintf("Stateful KES Headless Service failed to create: %s", err))
+					return err
+				}
+				c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "SvcCreated", "Stateful KES Headless Service created")
+			} else {
+				return err
+			}
+		}
+
+		// Get the StatefulSet with the name specified in spec
+		if existingStatefulSet, err := c.statefulSetLister.StatefulSets(tenant.Namespace).Get(tenant.StatefulKESStatefulSetName()); err != nil {
+			if k8serrors.IsNotFound(err) {
+				ks := statefulsets.NewForStatefulKES(tenant, svc.Name)
+				if tenant, err = c.updateTenantStatus(ctx, tenant, StatusProvisioningStatefulKESStatefulSet, 0); err != nil {
+					return err
+				}
+				klog.V(2).Infof("Creating a new KES StatefulSet for %q", nsName)
+				if _, err = c.kubeClientSet.AppsV1().StatefulSets(tenant.Namespace).Create(ctx, ks, cOpts); err != nil {
+					klog.V(2).Infof(err.Error())
+					c.RegisterEvent(ctx, tenant, corev1.EventTypeWarning, "StsFailed", fmt.Sprintf("Stateful KES Statefulset failed to create: %s", err))
+					return err
+				}
+				c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "StsCreated", "Stateful KES Statefulset Created")
+			} else {
+				return err
+			}
+		} else {
+			// Verify if this KES StatefulSet matches the spec on the tenant (resources, affinity, sidecars, etc)
+			statefulkesStatefulSetMatchesSpec, err := statefulKESStatefulSetMatchesSpec(tenant, existingStatefulSet)
+			if err != nil {
+				return err
+			}
+
+			// if the KES StatefulSet doesn't match the spec
+			if !statefulkesStatefulSetMatchesSpec {
+				sks := statefulsets.NewForStatefulKES(tenant, svc.Name)
+				if tenant, err = c.updateTenantStatus(ctx, tenant, StatusUpdatingStatefulKES, totalReplicas); err != nil {
+					return err
+				}
+				if _, err = c.kubeClientSet.AppsV1().StatefulSets(tenant.Namespace).Update(ctx, sks, uOpts); err != nil {
+					c.RegisterEvent(ctx, tenant, corev1.EventTypeWarning, "StsFailed", fmt.Sprintf("Stateful KES Statefulset failed to update: %s", err))
+					return err
+				}
+				c.RegisterEvent(ctx, tenant, corev1.EventTypeNormal, "StsUpdated", "Stateful KES Statefulset Updated")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -191,6 +191,27 @@ func NewHeadlessForKES(t *miniov2.Tenant) *corev1.Service {
 	return svc
 }
 
+// NewHeadlessForStatefulKES will return a new headless Kubernetes service for stateful KES
+func NewHeadlessForStatefulKES(t *miniov2.Tenant) *corev1.Service {
+	kesPort := corev1.ServicePort{Port: miniov2.StatefulKESPort, Name: miniov2.StatefulKESServicePortName}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          t.StatefulKESPodLabels(),
+			Name:            t.StatefulKESHLServiceName(),
+			Namespace:       t.Namespace,
+			OwnerReferences: t.OwnerRef(),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:     []corev1.ServicePort{kesPort},
+			Selector:  t.StatefulKESPodLabels(),
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: corev1.ClusterIPNone,
+		},
+	}
+
+	return svc
+}
+
 // NewHeadlessForLog returns a k8s Headless service object for Log
 func NewHeadlessForLog(t *miniov2.Tenant) *corev1.Service {
 	searchPort := corev1.ServicePort{Port: miniov2.LogPgPort, Name: miniov2.LogPgPortName}

--- a/pkg/resources/statefulsets/stateful-kes-statefulset.go
+++ b/pkg/resources/statefulsets/stateful-kes-statefulset.go
@@ -1,0 +1,296 @@
+// Copyright (C) 2022, MinIO, Inc.
+//
+// This code is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License, version 3,
+// along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+package statefulsets
+
+import (
+	"fmt"
+	"sort"
+
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const statefulKESInitMountPath = "/mnt/kes"
+
+// StatefulKESMetadata Returns the stateful KES pods metadata set in configuration.
+// If a user specifies metadata in the spec we return that
+// metadata.
+func StatefulKESMetadata(t *miniov2.Tenant) metav1.ObjectMeta {
+	meta := metav1.ObjectMeta{}
+	meta.Labels = t.Spec.StatefulKES.Labels
+	meta.Annotations = t.Spec.StatefulKES.Annotations
+
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+	for k, v := range t.StatefulKESPodLabels() {
+		meta.Labels[k] = v
+	}
+	return meta
+}
+
+// StatefulKESSelector Returns the stateful KES pods selector set in configuration.
+func StatefulKESSelector(t *miniov2.Tenant) *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: t.StatefulKESPodLabels(),
+	}
+}
+
+// StatefulKESVolumeMounts builds the volume mounts for MinIO stateful-kes container.
+func StatefulKESVolumeMounts(t *miniov2.Tenant) []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      t.StatefulKESVolMountName(),
+			MountPath: miniov2.StatefulKESConfigMountPath,
+		},
+	}
+
+	if t.Spec.StatefulKES.VolumeClaimTemplate != nil {
+		name := t.Spec.StatefulKES.VolumeClaimTemplate.Name
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      name,
+			MountPath: statefulKESInitMountPath,
+		})
+	}
+
+	return volumeMounts
+}
+
+// StatefulKESEnvironmentVars returns the StatefulKES environment variables set in configuration.
+func StatefulKESEnvironmentVars(t *miniov2.Tenant) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+	// Add all the tenant.spec.kes.env environment variables
+	// User defined environment variables will take precedence over default environment variables
+	envVars = append(envVars, t.GetStatefulKESEnvVars()...)
+	// sort the array to produce the same result everytime
+	sort.Slice(envVars, func(i, j int) bool {
+		return envVars[i].Name < envVars[j].Name
+	})
+	return envVars
+}
+
+// - result=$([[ -d /tmp/stateful-kes/data ]]; echo $?); if [ "$result" -eq 1 ]; then /kes init --config=/tmp/stateful-kes/init-config.yaml /mnt/kes/data; fi
+
+// StatefulKESInitContainer returns the KES container for a KES StatefulSet.
+func StatefulKESInitContainer(t *miniov2.Tenant) corev1.Container {
+	var force bool
+
+	kesInitCommand := fmt.Sprintf("/kes init --config=%s/init-config.yaml %s/data", miniov2.StatefulKESConfigMountPath, statefulKESInitMountPath)
+	initCommand := fmt.Sprintf("result=$([[ -d %s/data ]]; echo $?); if [ \"$result\" -eq 1 ]; then %s",
+		statefulKESInitMountPath, kesInitCommand)
+	if force {
+		initCommand = initCommand + fmt.Sprintf(";else %s --force", kesInitCommand)
+	}
+	initCommand = initCommand + "; fi"
+
+	// Args to start KES with config mounted at miniov2.KESConfigMountPath and require but don't verify mTLS authentication
+	args := []string{
+		"-c",
+		initCommand,
+	}
+
+	return corev1.Container{
+		Name:    miniov2.StatefulKESInitContainerName,
+		Image:   t.Spec.StatefulKES.Image,
+		Command: []string{"sh"},
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: miniov2.StatefulKESPort,
+			},
+		},
+		ImagePullPolicy: t.Spec.StatefulKES.ImagePullPolicy,
+		VolumeMounts:    StatefulKESVolumeMounts(t),
+		Args:            args,
+		Env:             StatefulKESEnvironmentVars(t),
+		Resources:       t.Spec.StatefulKES.Resources,
+	}
+}
+
+// StatefulKESServerContainer returns the StatefulKES container for a StatefulKES StatefulSet.
+func StatefulKESServerContainer(t *miniov2.Tenant) corev1.Container {
+	// Args to start KES with config mounted at miniov2.KESConfigMountPath and require but don't verify mTLS authentication
+	args := []string{"server", statefulKESInitMountPath + "/data"}
+
+	return corev1.Container{
+		Name:  miniov2.StatefulKESContainerName,
+		Image: t.Spec.StatefulKES.Image,
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: miniov2.KESPort,
+			},
+		},
+		ImagePullPolicy: t.Spec.StatefulKES.ImagePullPolicy,
+		VolumeMounts:    StatefulKESVolumeMounts(t),
+		Args:            args,
+		Env:             StatefulKESEnvironmentVars(t),
+		Resources:       t.Spec.StatefulKES.Resources,
+	}
+}
+
+// statefulkesSecurityContext builds the security context for stateful KES statefulset pods
+func statefulkesSecurityContext(t *miniov2.Tenant) *corev1.PodSecurityContext {
+	runAsNonRoot := true
+	var runAsUser int64 = 1000
+	var runAsGroup int64 = 1000
+	var fsGroup int64 = 1000
+	fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
+
+	securityContext := corev1.PodSecurityContext{
+		RunAsNonRoot:        &runAsNonRoot,
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: &fsGroupChangePolicy,
+	}
+	if t.HasStatefulKESEnabled() && t.Spec.StatefulKES.SecurityContext != nil {
+		securityContext = *t.Spec.StatefulKES.SecurityContext
+	}
+	return &securityContext
+}
+
+// NewForStatefulKES creates a statefulset for stateful-kes
+func NewForStatefulKES(t *miniov2.Tenant, serviceName string) *appsv1.StatefulSet {
+	replicas := t.StatefulKESReplicas()
+	// certificate files used by the KES server
+	certPath := "server.crt"
+	keyPath := "server.key"
+
+	var volumeProjections []corev1.VolumeProjection
+
+	var serverCertSecret string
+	// clientCertSecret holds certificate files (public.crt, private.key and ca.crt) used by KES
+	// in mTLS with a KMS (eg: authentication with Vault)
+	var clientCertSecret string
+
+	serverCertPaths := []corev1.KeyToPath{
+		{Key: "public.crt", Path: certPath},
+		{Key: "private.key", Path: keyPath},
+	}
+
+	configPath := []corev1.KeyToPath{
+		{Key: "init-config.yaml", Path: "init-config.yaml"},
+	}
+
+	// External certificates will have priority over AutoCert generated certificates
+	if t.StatefulKESExternalCert() {
+		serverCertSecret = t.Spec.StatefulKES.ExternalCertSecret.Name
+		// This covers both secrets of type "kubernetes.io/tls" and
+		// "cert-manager.io/v1alpha2" because of same keys in both.
+		if t.Spec.StatefulKES.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.StatefulKES.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" || t.Spec.StatefulKES.ExternalCertSecret.Type == "cert-manager.io/v1" {
+			serverCertPaths = []corev1.KeyToPath{
+				{Key: "tls.crt", Path: certPath},
+				{Key: "tls.key", Path: keyPath},
+			}
+		}
+	} else {
+		serverCertSecret = t.StatefulKESTLSSecretName()
+	}
+
+	if t.StatefulKESClientCert() {
+		clientCertSecret = t.Spec.StatefulKES.ClientCertSecret.Name
+	}
+
+	if t.Spec.StatefulKES.Configuration.Name != "" {
+		volumeProjections = append(volumeProjections, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: t.Spec.StatefulKES.Configuration.Name,
+				},
+				Items: configPath,
+			},
+		})
+	}
+
+	if serverCertSecret != "" {
+		volumeProjections = append(volumeProjections, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: serverCertSecret,
+				},
+				Items: serverCertPaths,
+			},
+		})
+	}
+
+	if clientCertSecret != "" {
+		volumeProjections = append(volumeProjections, corev1.VolumeProjection{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: clientCertSecret,
+				},
+			},
+		})
+	}
+
+	podVolumes := []corev1.Volume{
+		{
+			Name: t.StatefulKESVolMountName(),
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: volumeProjections,
+				},
+			},
+		},
+	}
+
+	initContainers := []corev1.Container{StatefulKESInitContainer(t)}
+	containers := []corev1.Container{StatefulKESServerContainer(t)}
+
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       t.Namespace,
+			Name:            t.StatefulKESStatefulSetName(),
+			OwnerReferences: t.OwnerRef(),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: miniov2.DefaultUpdateStrategy,
+			},
+			PodManagementPolicy: t.Spec.PodManagementPolicy,
+			// KES is always matched via Tenant Name + KES prefix
+			Selector:    StatefulKESSelector(t),
+			ServiceName: serviceName,
+			Replicas:    &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: StatefulKESMetadata(t),
+				Spec: corev1.PodSpec{
+					ServiceAccountName:        t.Spec.StatefulKES.ServiceAccountName,
+					InitContainers:            initContainers,
+					Containers:                containers,
+					Volumes:                   podVolumes,
+					RestartPolicy:             corev1.RestartPolicyAlways,
+					SchedulerName:             t.Scheduler.Name,
+					NodeSelector:              t.Spec.StatefulKES.NodeSelector,
+					Tolerations:               t.Spec.StatefulKES.Tolerations,
+					Affinity:                  t.Spec.StatefulKES.Affinity,
+					TopologySpreadConstraints: t.Spec.StatefulKES.TopologySpreadConstraints,
+					SecurityContext:           statefulkesSecurityContext(t),
+				},
+			},
+		},
+	}
+	// Address issue https://github.com/kubernetes/kubernetes/issues/85332
+	if t.Spec.ImagePullSecret.Name != "" {
+		ss.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{t.Spec.ImagePullSecret}
+	}
+
+	if t.Spec.StatefulKES.VolumeClaimTemplate != nil {
+		ss.Spec.VolumeClaimTemplates = append(ss.Spec.VolumeClaimTemplates, *t.Spec.StatefulKES.VolumeClaimTemplate)
+	}
+
+	return ss
+}

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -5335,6 +5335,796 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              stateful-kes:
+                properties:
+                  affinity:
+                    properties:
+                      nodeAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                preference:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              nodeSelectorTerms:
+                                items:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaceSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  clientCertSecret:
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  env:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  externalCertSecret:
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    type: string
+                  kesSecret:
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  keyName:
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    type: integer
+                  resources:
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  securityContext:
+                    properties:
+                      fsGroup:
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        type: string
+                      runAsGroup:
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        properties:
+                          level:
+                            type: string
+                          role:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          hostProcess:
+                            type: boolean
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    type: string
+                  tolerations:
+                    items:
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      properties:
+                        labelSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          format: int32
+                          type: integer
+                        minDomains:
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          type: string
+                        nodeTaintsPolicy:
+                          type: string
+                        topologyKey:
+                          type: string
+                        whenUnsatisfiable:
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                  volumeClaimTemplate:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            properties:
+                              apiGroup:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            type: string
+                          volumeMode:
+                            type: string
+                          volumeName:
+                            type: string
+                        type: object
+                      status:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          allocatedResources:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          conditions:
+                            items:
+                              properties:
+                                lastProbeTime:
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  format: date-time
+                                  type: string
+                                message:
+                                  type: string
+                                reason:
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          phase:
+                            type: string
+                          resizeStatus:
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - kesSecret
+                - volumeClaimTemplate
+                type: object
               subPath:
                 type: string
               users:


### PR DESCRIPTION
Steps to test :-

STEP 1: Install operator with the dev image
```sh
./kubectl-minio init --image minio/operator:v4.4.21-60-gb0ad327 --default-kes-image minio/kes:v0.20.0
```

STEP 2: Generate a unseal key for kes

```sh
cat /dev/urandom | head -c 32 | base64
```

and set it in `examples/kustomization/tenant-stateful-kes-encryption/tenant.yaml`

STEP 3: Configure volumeClaimTemplate section in "stateful-kes". Use directpv storage class if directpv is configured

STEP 4: Create the tenant

```sh
kustomize build examples/kustomization/tenant-stateful-kes-encryption | kubectl apply -f -
```

STEP 5: Once the pods are up, get the enclave-admin.key and enclave-admin.crt from the secrets

```sh
kubectl get secret storage-stateful-kes-enclave-admin-config -n minio-tenant -o yaml
```
(NOTE: base64 decode the private.key and public.crt and place it in respective files enclave-admin.key and enclave-admin.crt)

STEP 6: Check if the key is created

```sh
export KES_SERVER=<KES_POD_ENDPOINT>
export KES_CLIENT_KEY=enclave-admin.key
export KES_CLIENT_CERT=enclave-admin.crt

kes key ls -k
```
