### PR TITLE
Using container image digests from RedHat Registry

### DIFF
--- a/olm-post-script.sh
+++ b/olm-post-script.sh
@@ -39,7 +39,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # Console Image in Digested form: sha256:xxxx
   consoleImage=$(yq '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml)
   echo "consoleImage: ${consoleImage}"
-  consoleImageDigest=$(docker pull $consoleImage | grep Digest | awk -F ' ' '{print $2}')
+  consoleImageDigest=$(docker pull "quay.io/"${consoleImage} | grep Digest | awk -F ' ' '{print $2}')
   echo "consoleImageDigest: ${consoleImageDigest}"
   consoleImageDigest="quay.io/minio/console@${consoleImageDigest}"
   yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= (\"${consoleImageDigest}\")" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml

--- a/olm.sh
+++ b/olm.sh
@@ -91,7 +91,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # Console Image in Digested form: sha256:xxxx
   consoleImage=$(yq '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml)
   echo "consoleImage: ${consoleImage}"
-  consoleImageDigest=$(docker pull $consoleImage | grep Digest | awk -F ' ' '{print $2}')
+  consoleImageDigest=$(docker pull "quay.io/"${consoleImage} | grep Digest | awk -F ' ' '{print $2}')
   echo "consoleImageDigest: ${consoleImageDigest}"
   consoleImageDigest="quay.io/minio/console@${consoleImageDigest}"
   yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= (\"${consoleImageDigest}\")" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml


### PR DESCRIPTION
The reason for this PR, it is to properly get the digests from Console Image, as with current option, there will be no match and hence updating the catalogs will continue to fail:

```sh
$ docker pull minio/console:v0.19.4
v0.19.4: Pulling from minio/console
Digest: sha256:930dc08dac5bad399e3e2af17d72e1e9c4ec1e8c8d6dedc83c4f685a47adaeb3 <--- Different than we need to update RedHat Catalogs.
Status: Image is up to date for minio/console:v0.19.4
docker.io/minio/console:v0.19.4

$ docker pull quay.io/minio/console:v0.19.4
v0.19.4: Pulling from minio/console
Digest: sha256:148331d40fd34a6b96a5f70acfd71e1d870b588a7b3ff6b646a0056d55ad5e9b <--- The one we need to update RedHat Catalogs.
Status: Downloaded newer image for quay.io/minio/console:v0.19.4
quay.io/minio/console:v0.19.4
```

Notice we introduced these lines specifically for RedHat repositories:

1. https://github.com/redhat-openshift-ecosystem/certified-operators
2. https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators

So `quay.io` registry is a must in those repositories for OLM to deploy our Operator while in the verification process.