### PR TITLE
Use k8s recorder for events

### DIFF
--- a/pkg/controller/cluster/events.go
+++ b/pkg/controller/cluster/events.go
@@ -16,36 +16,11 @@ package cluster
 
 import (
 	"context"
-	"time"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 // RegisterEvent creates an event for a given tenant
 func (c *Controller) RegisterEvent(ctx context.Context, tenant *miniov2.Tenant, eventType, reason, message string) {
-	now := time.Now()
-	_, err := c.kubeClientSet.CoreV1().Events(tenant.Namespace).Create(ctx, &corev1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "tenant-",
-			Namespace:    tenant.Namespace,
-		},
-		InvolvedObject: tenant.ObjectRef(),
-		Reason:         reason,
-		Message:        message,
-		Source: corev1.EventSource{
-			Component: "minio-operator",
-		},
-		FirstTimestamp: metav1.NewTime(now),
-		LastTimestamp:  metav1.NewTime(now),
-
-		Type: eventType,
-
-		ReportingController: "minio-operator",
-	}, metav1.CreateOptions{})
-	if err != nil {
-		klog.Errorf("Error registering event: %s", err)
-	}
+	c.recorder.Event(tenant, eventType, reason, message)
 }


### PR DESCRIPTION
Use k8s recorder implementation to create and update events.

Closes: https://github.com/miniohq/engineering/issues/705

It will better handle the creation of events.

- It will reduce the number of API calls to k8s
- It will increment the count for duplicated messages

First events were created with previous implementation and last line with the change
![Screen Shot 2022-08-16 at 15 54 50](https://user-images.githubusercontent.com/10521119/184983495-799fe6ac-a0aa-4d6a-9063-ee2c8de9f48f.png)

