### PR TITLE
To fix tls issue in OpenShift

### DIFF
--- a/resources/base/service.yaml
+++ b/resources/base/service.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     name: minio-operator
   namespace: minio-operator
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: operator-tls # To solve "remote error: tls: bad certificate"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Fixes: https://github.com/minio/operator/issues/1234

The idea is to allow Service to use Secret in annotations for tls issue to get solved when installing Operator in OpenShift.
Tested in Openshift version 4.11.0 but user reported issue in 4.10.0 as well.
This change is ignored when not in Openshift cluster. 

<img width="1696" alt="Screen Shot 2022-08-22 at 5 07 08 PM" src="https://user-images.githubusercontent.com/6667358/186019220-3381b2af-dc95-433b-b146-8f37d1016dae.png">

>

`2022/08/10 14:30:03 http: TLS handshake error from 10.128.0.1:54964: remote error: tls: bad certificate` is gone

### Documentation: 

* https://docs.openshift.com/container-platform/3.9/dev_guide/secrets.html#service-serving-certificate-secrets