### PR TITLE
Replace hard code namespace with template value

### DIFF
--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.7
     meta.helm.sh/release-name: minio-operator
-    meta.helm.sh/release-namespace: minio-operator
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: Helm
   name: tenants.minio.min.io
@@ -15,7 +15,7 @@ spec:
       clientConfig:
         service:
           name: operator
-          namespace: minio-operator
+          namespace: {{ .Release.Namespace }}
           path: /webhook/v1/crd-conversion
           port: 4222
       conversionReviewVersions:


### PR DESCRIPTION
If the deploy namespace is not minio-operator, the conversion url cannot be found and creation of CRD v1 will fail. |

Replace hard code namespace with template value.