### PR TITLE
Adding support for multiple client certificates

### DIFF
--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -112,6 +112,37 @@ spec:
   ## Create secrets as explained here:
   ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
   # externalClientCertSecret: {}
+  ##
+  ## Use this field to provide additional client certificate for the MinIO Tenant
+  ## Certificate secret files will be mounted under /tmp/certs folder, supported types:
+  ## Opaque | kubernetes.io/tls | cert-manager.io/v1alpha2 | cert-manager.io/v1
+  ##
+  ## mount path inside container:
+  ##
+  ##	certs
+  ##		|
+  ##		+ client-0
+  ##		|			+ client.crt
+  ##		|			+ client.key
+  ##		+ client-1
+  ##		|			+ client.crt
+  ##		|			+ client.key
+  ##		+ client-2
+  ##		|			+ client.crt
+  ##		|			+ client.key
+  ## ie:
+  ##
+  ##    externalClientCertSecrets:
+  ##      - name: client-certificate-1
+  ##        type: kubernetes.io/tls
+  ##      - name: client-certificate-2
+  ##        type: kubernetes.io/tls
+  ##      - name:client-certificate-3
+  ##        type: kubernetes.io/tls
+  ##
+  ## Create secrets as explained here:
+  ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
+  externalClientCertSecrets: [ ]
   ## Registry location and Tag to download MinIO Server image
   image: quay.io/minio/minio:RELEASE.2022-08-02T23-59-16Z
   imagePullSecret: { }

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -179,6 +179,17 @@ spec:
                 required:
                 - name
                 type: object
+              externalClientCertSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:
@@ -4541,6 +4552,17 @@ spec:
                 required:
                 - name
                 type: object
+              externalClientCertSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               features:
                 properties:
                   bucketDNS:

--- a/pkg/apis/minio.min.io/v1/conversion.go
+++ b/pkg/apis/minio.min.io/v1/conversion.go
@@ -76,6 +76,7 @@ func (src *Tenant) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ExternalCertSecret = src.Spec.ExternalCertSecret
 	dst.Spec.ExternalCaCertSecret = src.Spec.ExternalCaCertSecret
 	dst.Spec.ExternalClientCertSecret = src.Spec.ExternalClientCertSecret
+	dst.Spec.ExternalClientCertSecrets = src.Spec.ExternalClientCertSecrets
 	dst.Spec.Mountpath = src.Spec.Mountpath
 	dst.Spec.Subpath = src.Spec.Subpath
 	dst.Spec.RequestAutoCert = src.Spec.RequestAutoCert
@@ -150,6 +151,7 @@ func (dst *Tenant) ConvertFrom(srcRaw conversion.Hub) error { //nolint
 	dst.Spec.ExternalCertSecret = src.Spec.ExternalCertSecret
 	dst.Spec.ExternalCaCertSecret = src.Spec.ExternalCaCertSecret
 	dst.Spec.ExternalClientCertSecret = src.Spec.ExternalClientCertSecret
+	dst.Spec.ExternalClientCertSecrets = src.Spec.ExternalClientCertSecrets
 	dst.Spec.Mountpath = src.Spec.Mountpath
 	dst.Spec.Subpath = src.Spec.Subpath
 	dst.Spec.RequestAutoCert = src.Spec.RequestAutoCert

--- a/pkg/apis/minio.min.io/v1/types.go
+++ b/pkg/apis/minio.min.io/v1/types.go
@@ -68,10 +68,14 @@ type TenantSpec struct {
 	// used for enabling TLS with SNI support on MinIO Pods.
 	// +optional
 	ExternalCertSecret []*miniov2.LocalCertificateReference `json:"externalCertSecret,omitempty"`
-	// ExternalClientCertSecret allows a user to specify custom CA client certificate, and private key. This is
+	// ExternalClientCertSecret allows a user to specify custom client certificate, and private key. This is
 	// used for adding client certificates on MinIO Pods --> used for KES authentication.
 	// +optional
 	ExternalClientCertSecret *miniov2.LocalCertificateReference `json:"externalClientCertSecret,omitempty"`
+	// ExternalClientCertSecrets allows a user to specify additional client certificates, and private keys. This is
+	// used for adding client certificates on MinIO Pods and perform mTLS with external services.
+	// +optional
+	ExternalClientCertSecrets []*miniov2.LocalCertificateReference `json:"externalClientCertSecrets,omitempty"`
 	// ExternalCaCertSecret allows a user to provide additional CA certificates. This is
 	// used for Console to verify TLS connections with other applications.
 	// +optional

--- a/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v1/zz_generated.deepcopy.go
@@ -139,6 +139,17 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 		*out = new(v2.LocalCertificateReference)
 		**out = **in
 	}
+	if in.ExternalClientCertSecrets != nil {
+		in, out := &in.ExternalClientCertSecrets, &out.ExternalClientCertSecrets
+		*out = make([]*v2.LocalCertificateReference, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(v2.LocalCertificateReference)
+				**out = **in
+			}
+		}
+	}
 	if in.ExternalCaCertSecret != nil {
 		in, out := &in.ExternalCaCertSecret, &out.ExternalCaCertSecret
 		*out = make([]*v2.LocalCertificateReference, len(*in))

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -178,6 +178,11 @@ func (t *Tenant) ExternalClientCert() bool {
 	return t.Spec.ExternalClientCertSecret != nil && t.Spec.ExternalClientCertSecret.Name != ""
 }
 
+// ExternalClientCerts returns true is the user has provided additional client certificates
+func (t *Tenant) ExternalClientCerts() bool {
+	return len(t.Spec.ExternalClientCertSecrets) > 0
+}
+
 // KESExternalCert returns true is the user has provided a secret
 // that contains CA cert, server cert and server key for KES pods
 func (t *Tenant) KESExternalCert() bool {

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -196,6 +196,31 @@ type TenantSpec struct {
 	ExternalClientCertSecret *LocalCertificateReference `json:"externalClientCertSecret,omitempty"`
 	// *Optional* +
 	//
+	// Provide support for mounting additional client certificate into MinIO Tenant pods
+	// Multiple client certificates will be mounted using the following folder structure:
+	//
+	//	certs
+	//		|
+	//		+ client-0
+	//		|			+ client.crt
+	//		|			+ client.key
+	//		+ client-1
+	//		|			+ client.crt
+	//		|			+ client.key
+	//		+ client-2
+	//		|			+ client.crt
+	//		|			+ client.key
+	//
+	// Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant that later can be referenced using environment variables. The secret *must* contain the following fields: +
+	//
+	// * `name` - The name of the Kubernetes secret containing the TLS certificate. +
+	//
+	// * `type` - Specify `kubernetes.io/tls` +
+	//
+	// +optional
+	ExternalClientCertSecrets []*LocalCertificateReference `json:"externalClientCertSecrets,omitempty"`
+	// *Optional* +
+	//
 	// Mount path for MinIO volume (PV). Defaults to `/export`
 	// +optional
 	Mountpath string `json:"mountPath,omitempty"`

--- a/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
@@ -822,6 +822,17 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 		*out = new(LocalCertificateReference)
 		**out = **in
 	}
+	if in.ExternalClientCertSecrets != nil {
+		in, out := &in.ExternalClientCertSecrets, &out.ExternalClientCertSecrets
+		*out = make([]*LocalCertificateReference, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(LocalCertificateReference)
+				**out = **in
+			}
+		}
+	}
 	if in.RequestAutoCert != nil {
 		in, out := &in.RequestAutoCert, &out.RequestAutoCert
 		*out = new(bool)

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -179,6 +179,17 @@ spec:
                 required:
                 - name
                 type: object
+              externalClientCertSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               image:
                 type: string
               imagePullPolicy:
@@ -4541,6 +4552,17 @@ spec:
                 required:
                 - name
                 type: object
+              externalClientCertSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
               features:
                 properties:
                   bucketDNS:


### PR DESCRIPTION
Add support for passing multiple client certificates via the
`tenant.spec.externalClientCertSecrets` field

Multiple client certificates will be mounted using the following folder
structure:

```
certs
  |
  + client-0
  |     + client.crt
  |     + client.key
  + client-1
  |     + client.crt
  |     + client.key
  + client-2
  |     + client.crt
  |     + client.key
```

Iterate over all provided client TLS certificates
and store them on the list of Volumes that will be
mounted to the Pod

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>