### PR TITLE
Remove affinity duplicate in the operator chart

### DIFF
--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -54,14 +54,3 @@ spec:
       initContainers:
       {{- toYaml . | nindent 8 }}
       {{- end}}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                      - minio-operator
-              topologyKey: kubernetes.io/hostname
-

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -22,7 +22,16 @@ operator:
     runAsNonRoot: true
     fsGroup: 1000
   nodeSelector: { }
-  affinity: { }
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: name
+                operator: In
+                values:
+                  - minio-operator
+          topologyKey: kubernetes.io/hostname
   tolerations: [ ]
   topologySpreadConstraints: [ ]
   resources:


### PR DESCRIPTION
The PR fixes https://github.com/minio/operator/issues/1271 issue.
It removes affinity duplicate in the operator chart and moves default value to `values.yaml` file.