### PR TITLE
[logsearch] Partition creation fixes

### DIFF
--- a/logsearchapi/server/server.go
+++ b/logsearchapi/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, MinIO, Inc.
+// Copyright (C) 2022, MinIO, Inc.
 //
 // This code is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License, version 3,


### PR DESCRIPTION
- At startup attempt to create partitions regardless of whether parent
table exists.
- At startup create "previous" and "next" partitions around the current
time always
- Use `CREATE IF NOT EXISTS` to avoid checking if the table already
exists