### PR TITLE
Add containerSecurityContext to helm charts

### DIFF
--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for MinIO Operator
 name: operator
-version: 4.4.28
+version: 4.5.0
 appVersion: v4.4.28
 keywords:
   - storage

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for MinIO Operator
 name: operator
-version: 4.5.0
+version: 4.4.28
 appVersion: v4.4.28
 keywords:
   - storage

--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -59,6 +59,10 @@ spec:
                 {{- end }}
           resources:
           {{- toYaml .Values.console.resources | nindent 12 }}
+          {{- with .Values.console.containerSecurityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}                
           volumeMounts:
           {{- with .Values.console.volumeMounts }}
           {{- toYaml . | nindent 12 }}

--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -49,7 +49,11 @@ spec:
           {{ toYaml . | nindent 10 }}
           {{- end }}
           resources:
-      {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- with .Values.operator.containerSecurityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}      
       {{- with .Values.operator.initContainers }}
       initContainers:
       {{- toYaml . | nindent 8 }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -19,8 +19,18 @@ operator:
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000
-    runAsNonRoot: true
     fsGroup: 1000
+    runAsNonRoot: true    
+  containerSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true  
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+      - ALL    
   nodeSelector: { }
   affinity: { }
   tolerations: [ ]
@@ -46,7 +56,19 @@ console:
   resources: { }
   securityContext:
     runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
     runAsNonRoot: true
+  containerSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    runAsNonRoot: true  
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+      - ALL
   ingress:
     enabled: false
     ingressClassName: ""


### PR DESCRIPTION
Hi guys,

For your consideration, a PR to introduce containerSecurityContexts to the operator/console deployments.

Why?

Some security mitigations can only be applied within the context of the container spec (*such as dropping capabilities, or preventing privileged mode*), and without the ability to configure a container securityContext, validation / security assessment tools such as Kyverno will raise exceptions for operator/console.

Example below:

<img width="740" alt="Policy Reporter UI - Policy Reporter UI 2022-09-05 12-17-25" src="https://user-images.githubusercontent.com/1524686/188339198-2a0c2823-2c33-45c6-89b8-35154eaf2614.png">
