### PR TITLE
Add a startup probe

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -303,6 +303,25 @@ func volumeMounts(t *miniov2.Tenant, pool *miniov2.Pool, operatorTLS bool, certV
 	return mounts
 }
 
+// Build the startup probe for MinIO container.
+func startupProbe(t *miniov2.Tenant) *corev1.Probe {
+	scheme := corev1.URISchemeHTTP
+	if t.TLS() {
+		scheme = corev1.URISchemeHTTPS
+	}
+	return &corev1.Probe{
+		ProbeHandler: v1.ProbeHandler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   "/minio/health/live",
+				Port:   intstr.FromInt(miniov2.MinIOPort),
+				Scheme: scheme,
+			},
+		},
+		PeriodSeconds:    1,
+		FailureThreshold: 30,
+	}
+}
+
 // Builds the MinIO container for a Tenant.
 func poolMinioServerContainer(t *miniov2.Tenant, wsSecret *v1.Secret, skipEnvVars map[string][]byte, pool *miniov2.Pool, hostsTemplate string, opVersion string, operatorTLS bool, certVolumeSources []v1.VolumeProjection) v1.Container {
 	consolePort := miniov2.ConsolePort
@@ -343,6 +362,7 @@ func poolMinioServerContainer(t *miniov2.Tenant, wsSecret *v1.Secret, skipEnvVar
 		Resources:       pool.Resources,
 		LivenessProbe:   t.Spec.Liveness,
 		ReadinessProbe:  t.Spec.Readiness,
+		StartupProbe:    startupProbe(t),
 	}
 }
 


### PR DESCRIPTION
This is a proposal to address #600 and #947. The goal is to minimize errors or downtime during a rollout.

With a startup probe, k8s will wait for the server to be up before routing traffic to it and deleting another pod. Hopefully this will speed up the (re)connection to the cluster of fresh servers and avoid having too many servers down at the same time.

A potential issue could be if we want to make a critical change in the config which would require to restart all servers at almost the same time. But because upgrade is managed in-place, I believe a rollout don't require disturbing the cluster.

What do you think ?