### PR TITLE
Include vulncheck in make

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.18, 1.19 ]
+        go-version: [ 1.19 ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -10,8 +10,19 @@ jobs:
   vulncheck:
     name: Analysis
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 1.18, 1.19 ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-    - name: Check for vulnerabilities
-      uses: kmulvey/govulncheck-action@v1.0.0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+        check-latest: true
+    - name: Get govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      shell: bash
+    - name: Run govulncheck
+      run: govulncheck ./...
+      shell: bash

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ all: build
 getdeps:
 	@echo "Checking dependencies"
 	@mkdir -p ${GOPATH}/bin
-	@echo "Installing golangci-lint" && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+	@echo "Installing golangci-lint" && \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0 && \
+		echo "Installing govulncheck" && \
+		go install golang.org/x/vuln/cmd/govulncheck@latest
 
 verify: getdeps govet gotest lint
 
@@ -50,6 +53,9 @@ govet:
 
 gotest:
 	@go test -race ./...
+
+vulncheck:
+	@${GOPATH}/bin/govulncheck ./...
 
 clean:
 	@echo "Cleaning up all the generated files"


### PR DESCRIPTION
Vulnerability test also available in the Makefile.

One caveat is that currently there is a "vulnerability" in "net/url" package whose [fix is in 1.18.6 and 1.19.1](https://golangtutorial.dev/news/go-1.19.1-and-go-1.18.6-versions-released/), however the DB only lists the fix in 1.19.1, 

Already requested to include 1.18.6 as fixed verison
https://github.com/golang/vulndb/issues/994