### PR TITLE
Fix incorrect quoting of objects in the tenant helm chart template

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -154,8 +154,14 @@ spec:
     kesSecret:
       name: "kes-configuration"
     imagePullPolicy: {{ .kes.imagePullPolicy | quote }}
-    externalCertSecret: {{ .kes.externalCertSecret | quote }}
-    clientCertSecret: {{ .kes.clientCertSecret | quote }}
+    {{- with (dig "kes" "externalCertSecret" (dict) .) }}
+    externalCertSecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with (dig "kes" "clientCertSecret" (dict) .) }}
+    clientCertSecret:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     ## Key name to be created on the KMS, default is "my-minio-key"
     keyName: {{ .kes.keyName | quote }}
     {{- with (dig "resources" (dict) .) }}


### PR DESCRIPTION
In the [Tenant CRD](https://github.com/minio/operator/blob/master/docs/crd.adoc#localcertificatereference) `spec.kes.externalCertSecret` and `spec.kes.clientCertSecret` are objects so quoting them in the helm chart results in error:

```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Tenant.spec.kes.clientCertSecret): invalid type for io.min.minio.v2.Tenant.spec.kes.clientCertSecret: got "string", expected "map"
```