### PR TITLE
Updating doc URLs for new site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MinIO Kubernetes Operator supports deploying MinIO Tenants onto private and publ
 cloud infrastructures ("Hybrid" Cloud).
 
 This README provides a high level description of the MinIO Operator and 
-quickstart instructions. See https://docs.min.io/minio/k8s/ for 
+quickstart instructions. See https://min.io/docs/minio/kubernetes/upstream/index.html for 
 complete documentation on the MinIO Operator.
 
 ## Table of Contents
@@ -307,10 +307,10 @@ Use of MinIO Operator is governed by the GNU AGPLv3 or later, found in the [LICE
 
 # Explore Further
 
-[MinIO Hybrid Cloud Storage Documentation](https://docs.min.io/minio/k8s/index.html)
-- [Deploy MinIO Operator on Kubernetes](https://docs.min.io/minio/k8s/deployment/deploy-minio-operator.html)
-- [Deploy a MinIO Tenant using the MinIO Plugin](https://docs.min.io/minio/k8s/tenant-management/deploy-minio-tenant.html)
-- [Configure TLS/SSL for MinIO Tenants](https://docs.min.io/minio/k8s/tutorials/transport-layer-security.html)
+[MinIO Hybrid Cloud Storage Documentation](https://min.io/docs/minio/kubernetes/upstream/index.html)
+- [Deploy MinIO Operator on Kubernetes](https://min.io/docs/minio/kubernetes/upstream/operations/installation.html)
+- [Deploy a MinIO Tenant using the MinIO Plugin](https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html)
+- [Configure TLS/SSL for MinIO Tenants](https://min.io/docs/minio/kubernetes/upstream/operations/network-encryption.html)
 
 [Github Resources](https://github.com/minio/operator/blob/master/docs/)
 - [Examples for MinIO Tenant Settings](https://github.com/minio/operator/blob/master/docs/examples.md)

--- a/docs/DECOMISSION.md
+++ b/docs/DECOMISSION.md
@@ -12,7 +12,7 @@ Then monitor the status of the decommissioned pool
 mc admin decom status myminio/
 ```
 
-More details documentation available [here](https://docs.min.io/minio/baremetal/installation/decommission-pool.html#minio-decommissioning)
+More details documentation available [here](https://min.io/docs/minio/linux/operations/install-deploy-manage/decommission-server-pool.html)
 
 ### Update `tenant.yaml`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -167,4 +167,4 @@ kustomize build examples/kustomization/tenant-nodeport  | kubectl apply -f -
 
 ### Additional Examples
 
-For additional examples on how to deploy a tenant with [LDAP](https://docs.min.io/minio/baremetal/security/ad-ldap-external-identity-management/configure-ad-ldap-external-identity-management.html) or [OIDC](https://docs.min.io/minio/baremetal/security/openid-external-identity-management/configure-openid-external-identity-management.html) you can look at the [examples directory](https://github.com/minio/operator/tree/master/examples/kustomization)
+For additional examples on how to deploy a tenant with [LDAP](https://min.io/docs/minio/kubernetes/upstream/operations/external-iam/configure-ad-ldap-external-identity-management.html) or [OIDC](https://min.io/docs/minio/kubernetes/upstream/operations/external-iam/configure-openid-external-identity-management.html) you can look at the [examples directory](https://github.com/minio/operator/tree/master/examples/kustomization)

--- a/docs/nginx-ingress.md
+++ b/docs/nginx-ingress.md
@@ -6,13 +6,13 @@ Ingress exposes HTTP and HTTPS routes from outside the cluster to services withi
 
 ### Prerequisites
 
-- MinIO Operator up and running as explained in the [document here](https://docs.min.io/minio/k8s/deployment/deploy-minio-operator.html).
+- MinIO Operator up and running as explained in the [document here](https://min.io/docs/minio/kubernetes/upstream/operations/installation.html).
 - Nginx Ingress Controller installed and running as explained [here](https://kubernetes.github.io/ingress-nginx/deploy/).
 - Network routing rules that enable external client access to Kubernetes worker nodes. For example, this tutorial assumes `minio.example.com` and `console.minio.example.com` as an externally resolvable URL.
 
 ### Create MinIO Tenant
 
-Use the `kubectl minio` plugin to create the MinIO tenant if one does not already exist. See [Deploy a MinIO Tenant using the MinIO Plugin](https://docs.min.io/minio/k8s/tenant-management/deploy-minio-tenant.html) for more complete documentation. 
+Use the `kubectl minio` plugin to create the MinIO tenant if one does not already exist. See [Deploy a MinIO Tenant using the MinIO Plugin](https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html) or [`kubectl minio tenant create`](https://min.io/docs/minio/kubernetes/upstream/reference/kubectl-minio-plugin/kubectl-minio-tenant-create.html#command-kubectl.minio.tenant.create)for more complete documentation. 
 
 The following example deploys a MinIO Tenant with 4 servers and 16 volumes in total and a total capacity of 16 Terabytes into the `tenant1-ns` namespace using the default Kubernetes storage class. Change these values as appropriate for your requirements.
 

--- a/pkg/apis/minio.min.io/v2/doc.go
+++ b/pkg/apis/minio.min.io/v2/doc.go
@@ -15,7 +15,7 @@
 // +k8s:deepcopy-gen=package,register
 // go:generate controller-gen crd:trivialVersions=true paths=. output:dir=.
 
-// Package v2 - This page provides a quick automatically generated reference for the MinIO Operator `minio.min.io/v2` CRD. For more complete documentation on the MinIO Operator CRD, see https://docs.min.io/minio/k8s/reference/minio-operator-reference[MinIO Kubernetes Documentation]. +
+// Package v2 - This page provides a quick automatically generated reference for the MinIO Operator `minio.min.io/v2` CRD. For more complete documentation on the MinIO Operator CRD, see https://min.io/docs/minio/kubernetes/upstream/index.html[MinIO Kubernetes Documentation]. +
 //
 // The `minio.min.io/v2` API was released with the v4.0.0 MinIO Operator. The MinIO Operator automatically converts existing tenants using the `/v1` API to `/v2`. +
 //

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -99,7 +99,7 @@ type Features struct {
 //
 // The following parameters are specific to the `minio.min.io/v2` MinIO CRD API `spec` definition added as part of the MinIO Operator v4.0.0. +
 //
-// For more complete documentation on this object, see the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#minio-operator-yaml-reference[MinIO Kubernetes Documentation]. +
+// For more complete documentation on this object, see the https://min.io/docs/minio/kubernetes/upstream/operations/installation.html[MinIO Kubernetes Documentation]. +
 type TenantSpec struct {
 	// *Required* +
 	//
@@ -107,7 +107,7 @@ type TenantSpec struct {
 	//
 	// The MinIO Tenant `spec` *must have* at least *one* element in the `pools` array. +
 	//
-	// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
+	// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
 	Pools []Pool `json:"pools"`
 	// *Optional* +
 	//
@@ -153,7 +153,7 @@ type TenantSpec struct {
 	//
 	// * - `type` - Specify `kubernetes.io/tls` +
 	//
-	// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+	// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 	// +optional
 	ExternalCertSecret []*LocalCertificateReference `json:"externalCertSecret,omitempty"`
 	// *Optional* +
@@ -168,7 +168,7 @@ type TenantSpec struct {
 	//
 	// * - `type` - Specify `kubernetes.io/tls`. +
 	//
-	// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+	// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 	// +optional
 	ExternalCaCertSecret []*LocalCertificateReference `json:"externalCaCertSecret,omitempty"`
 	// *Optional* +
@@ -185,7 +185,7 @@ type TenantSpec struct {
 	//
 	// If deploying KES with the MinIO Operator, include the hash of the certificate as part of the <<k8s-api-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig,`kes`>> object specification. +
 	//
-	// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+	// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 	//
 	// +optional
 	ExternalClientCertSecret *LocalCertificateReference `json:"externalClientCertSecret,omitempty"`
@@ -234,7 +234,7 @@ type TenantSpec struct {
 	//
 	// If `requestAutoCert` is set to `false` *and* `externalCertSecret` is omitted, the MinIO Tenant deploys *without* TLS enabled.
 	//
-	// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+	// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 	// +optional
 	RequestAutoCert *bool `json:"requestAutoCert,omitempty"`
 
@@ -559,7 +559,7 @@ type CertificateConfig struct {
 
 // Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
 //
-// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#server-pools[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
+// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
 type Pool struct {
 	// *Optional* +
 	//
@@ -1011,7 +1011,7 @@ type KESConfig struct {
 	//
 	// * - `type` - Specify `kubernetes.io/tls` +
 	//
-	// See the https://docs.min.io/minio/k8s/reference/minio-operator-reference.html#transport-layer-encryption-tls[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+	// See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 	// +optional
 	ExternalCertSecret *LocalCertificateReference `json:"externalCertSecret,omitempty"`
 	// *Optional* +


### PR DESCRIPTION
With the new doc site deployed, URLs have changed for all documentation links.
This PR updates the links in the repo to the new doc site.