### PR TITLE
Fix configuration name set in tenant helm chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -27,7 +27,7 @@ spec:
   {{- end }}
   ## Secret with default environment variable configurations
   configuration:
-    name: {{ dig "secrets" "name" "" ($.Values | merge (dict)) }}
+    name: {{ .configuration.name }}
   pools:
   {{- range (dig "pools" (list) .) }}
     - servers: {{ dig "servers" 4 . }}


### PR DESCRIPTION
The PR fixes https://github.com/minio/operator/issues/1269 issue.
Actually this change was introduced in PR https://github.com/minio/operator/pull/1232 but accidentally overwritten by PR https://github.com/minio/operator/pull/1009 during the conflicts resolution.