### PR TITLE
Add support to define pool name during tenant creation/expansion

### DIFF
--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -58,6 +58,7 @@ func tenantStorage(q resource.Quantity) corev1.ResourceList {
 // Pool returns a Pool object from given values
 func Pool(opts *TenantOptions, volumes int32, q resource.Quantity) miniov2.Pool {
 	p := miniov2.Pool{
+		Name:             opts.PoolName,
 		Servers:          opts.Servers,
 		VolumesPerServer: volumes,
 		VolumeClaimTemplate: &corev1.PersistentVolumeClaim{

--- a/kubectl-minio/cmd/resources/tenant.go
+++ b/kubectl-minio/cmd/resources/tenant.go
@@ -30,6 +30,7 @@ import (
 // TenantOptions encapsulates the CLI options for a MinIO Tenant
 type TenantOptions struct {
 	Name                    string
+	PoolName                string
 	ConfigurationSecretName string
 	Servers                 int32
 	Volumes                 int32

--- a/kubectl-minio/cmd/tenant-create.go
+++ b/kubectl-minio/cmd/tenant-create.go
@@ -55,7 +55,7 @@ func newTenantCreateCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	c := &createCmd{out: out, errOut: errOut}
 
 	cmd := &cobra.Command{
-		Use:     "create <TENANTNAME> --servers <NSERVERS> --volumes <NVOLUMES> --capacity <SIZE> --namespace <TENANTNS>",
+		Use:     "create <TENANTNAME> --pool <POOLNAME> --servers <NSERVERS> --volumes <NVOLUMES> --capacity <SIZE> --namespace <TENANTNS>",
 		Short:   "Create a MinIO tenant",
 		Long:    createDesc,
 		Example: createExample,
@@ -77,6 +77,7 @@ func newTenantCreateCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	}
 	cmd = helpers.DisableHelp(cmd)
 	f := cmd.Flags()
+	f.StringVarP(&c.tenantOpts.PoolName, "pool", "p", "", "name for this pool")
 	f.Int32Var(&c.tenantOpts.Servers, "servers", 0, "total number of pods in MinIO tenant")
 	f.Int32Var(&c.tenantOpts.Volumes, "volumes", 0, "total number of volumes in the MinIO tenant")
 	f.StringVar(&c.tenantOpts.Capacity, "capacity", "", "total raw capacity of MinIO tenant in this pool, e.g. 16Ti")

--- a/kubectl-minio/cmd/tenant-expand.go
+++ b/kubectl-minio/cmd/tenant-expand.go
@@ -51,7 +51,7 @@ func newTenantExpandCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	v := &expandCmd{out: out, errOut: errOut}
 
 	cmd := &cobra.Command{
-		Use:     "expand <TENANTNAME> --servers <NSERVERS> --volumes <NVOLUMES> --capacity <SIZE>",
+		Use:     "expand <TENANTNAME> --pool <POOLNAME> --servers <NSERVERS> --volumes <NVOLUMES> --capacity <SIZE> --namespace <TENANTNS>",
 		Short:   "Add capacity to existing tenant",
 		Long:    expandDesc,
 		Example: expandExample,
@@ -70,6 +70,7 @@ func newTenantExpandCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd = helpers.DisableHelp(cmd)
 	f := cmd.Flags()
 	f.StringVarP(&v.tenantOpts.NS, "namespace", "n", "", "k8s namespace for this MinIO tenant")
+	f.StringVarP(&v.tenantOpts.PoolName, "pool", "p", "", "name for this pool expansion")
 	f.Int32Var(&v.tenantOpts.Servers, "servers", 0, "total number of pods to add to tenant")
 	f.Int32Var(&v.tenantOpts.Volumes, "volumes", 0, "total number of volumes to add to tenant")
 	f.StringVar(&v.tenantOpts.Capacity, "capacity", "", "total raw capacity to add to tenant, e.g. 16Ti")


### PR DESCRIPTION
```
./kubectl-minio tenant create <TENANTNAME> --pool <POOLNAME> --servers <NSERVERS> --volumes <NVOLUMES> --capacity <SIZE> --namespace <TENANTNS>"
```

and

```
./kubectl-minio tenant expand <TENANTNAME> --pool <POOLNAME> --servers <NSERVERS> --volumes <NVOLUMES> --capacity <SIZE> --namespace <TENANTNS>
```

Signed-off-by: Lenin Alevski <alevsk.8772@gmail.com>