### PR TITLE
update the .golangci.yml for go1.18 build and check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,11 @@
 linters-settings:
   golint:
     min-confidence: 0
-
   misspell:
     locale: US
+
+run:
+  go: '1.18'
 
 linters:
   disable-all: true
@@ -14,12 +16,8 @@ linters:
     - govet
     - revive
     - ineffassign
-    - gosimple
     - deadcode
-    - structcheck
     - gomodguard
-    - unused
-    - structcheck
     - unconvert
     - varcheck
     - gofumpt


### PR DESCRIPTION
According the https://github.com/golangci/golangci-lint/issues/2649 and go.mod is go 1.18 , so we should change the golint for go1.18
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/12080746/198755927-094882e2-4602-4afc-8f27-835be4c40b32.png">
