### PR TITLE
update .golangci.yaml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,11 @@
 linters-settings:
   golint:
     min-confidence: 0
-
   misspell:
     locale: US
+
+run:
+  go: '1.18'
 
 linters:
   disable-all: true
@@ -15,13 +17,9 @@ linters:
     - revive
     - ineffassign
     - gosimple
-    - deadcode
-    - structcheck
     - gomodguard
     - unused
-    - structcheck
     - unconvert
-    - varcheck
     - gofumpt
 
 issues:


### PR DESCRIPTION
When i static check the operator code in golangci-lint , i found the WARN message..
![image](https://user-images.githubusercontent.com/12080746/198761429-79eb3169-3bff-4075-977f-19e10f4bfcba.png)

Because the go.mod use go version is 1.18 , So update the .golangci.yaml to match that version  , test result is ok, as below info.
![image](https://user-images.githubusercontent.com/12080746/198761652-4b612359-8126-4cac-ad0f-0c69728a1853.png)

