### PR TITLE
update .goreleaser.yml for go mod hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ before:
   hooks:
     - make clean
     - go generate ./...
-    - go mod tidy -compat=1.17
+    - go mod tidy -compat=1.18
     - go mod download
 
 builds:


### PR DESCRIPTION
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/12080746/198800845-bb807734-7f51-4f1e-8d1e-7d6e057ce2af.png">

I update go mod tidy -compat=1.17
According url: https://go.dev/ref/mod#go-mod-tidy
By default, go mod tidy will check that the [selected versions](https://go.dev/ref/mod#glos-selected-version) of modules do not change when the module graph is loaded by the Go version immediately preceding the version indicated in the go directive. The versioned checked for compatibility can also be specified explicitly via the -compat flag.