### PR TITLE
fix:error should be handled

### DIFF
--- a/pkg/controller/cluster/monitoring.go
+++ b/pkg/controller/cluster/monitoring.go
@@ -408,7 +408,7 @@ func (c *Controller) syncHealthCheckHandler(key string) error {
 			runtime.HandleError(fmt.Errorf("Tenant '%s' in work queue no longer exists", key))
 			return nil
 		}
-		return nil
+		return err
 	}
 
 	tenant.EnsureDefaults()


### PR DESCRIPTION
If it is a network error, nil should not be returned here.
```diff
tenant, err := c.minioClientSet.MinioV2().Tenants(namespace).Get(context.Background(), tenantName, metav1.GetOptions{})
	if err != nil {
		// The Tenant resource may no longer exist, in which case we stop processing.
		if k8serrors.IsNotFound(err) {
 			runtime.HandleError(fmt.Errorf("Tenant '%s' in work queue no longer exists", key))
 			return nil
 		}
- 		return nil
+		return err
 	}
```