### PR TITLE
move from ioutil to io/os instead

### DIFF
--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -16,8 +16,8 @@
 package resources
 
 import (
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"path"
 	"strings"
@@ -117,7 +117,7 @@ func LoadTenantCRD(decode func(data []byte, defaults *schema.GroupVersionKind, i
 	if err != nil {
 		log.Fatal(err)
 	}
-	contentBytes, err := ioutil.ReadAll(contents)
+	contentBytes, err := io.ReadAll(contents)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func copyFileToMemFS(src, dst string, memFS filesys.FileSystem) error {
 	defer dstFileDesc.Close()
 
 	// Note: I had to read the whole string, for some reason io.Copy was not copying the whole content
-	input, err := ioutil.ReadAll(srcFileDesc)
+	input, err := io.ReadAll(srcFileDesc)
 	if err != nil {
 		return err
 	}

--- a/logsearchapi/server/server.go
+++ b/logsearchapi/server/server.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -153,7 +153,7 @@ func (ls *LogSearch) ingestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		ls.writeErrorResponse(w, 500, "Error reading request body", err)
 		return

--- a/pkg/apis/minio.min.io/v1/helper.go
+++ b/pkg/apis/minio.min.io/v1/helper.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -63,7 +62,7 @@ type hostsTemplateValues struct {
 // GetNSFromFile assumes the operator is running inside a k8s pod and extract the
 // current namespace from the /var/run/secrets/kubernetes.io/serviceaccount/namespace file
 func GetNSFromFile() string {
-	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "minio-operator"
 	}

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -132,7 +131,7 @@ var (
 // GetPodCAFromFile assumes the operator is running inside a k8s pod and extract the
 // current ca certificate from /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 func GetPodCAFromFile() []byte {
-	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	if err != nil {
 		return nil
 	}
@@ -142,7 +141,7 @@ func GetPodCAFromFile() []byte {
 // GetNSFromFile assumes the operator is running inside a k8s pod and extract the
 // current namespace from the /var/run/secrets/kubernetes.io/serviceaccount/namespace file
 func GetNSFromFile() string {
-	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "minio-operator"
 	}

--- a/pkg/controller/cluster/csr.go
+++ b/pkg/controller/cluster/csr.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -268,7 +267,7 @@ func (c *Controller) createSecret(ctx context.Context, tenant *miniov2.Tenant, l
 }
 
 func parseCertificate(r io.Reader) (*x509.Certificate, error) {
-	certPEMBlock, err := ioutil.ReadAll(r)
+	certPEMBlock, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/cluster/monitoring.go
+++ b/pkg/controller/cluster/monitoring.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -334,7 +333,7 @@ func drainBody(respBody io.ReadCloser) {
 		// the same connection for future uses.
 		//  - http://stackoverflow.com/a/17961593/4465767
 		defer respBody.Close()
-		io.Copy(ioutil.Discard, respBody)
+		io.Copy(io.Discard, respBody)
 	}
 }
 

--- a/pkg/controller/cluster/operator.go
+++ b/pkg/controller/cluster/operator.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -112,7 +111,7 @@ func (c *Controller) generateTLSCert() (*string, *string) {
 				privateKeyKey = "tls.key"
 			}
 			if val, ok := operatorTLSCert.Data[publicCertKey]; ok {
-				err := ioutil.WriteFile(publicCertPath, val, 0o644)
+				err := os.WriteFile(publicCertPath, val, 0o644)
 				if err != nil {
 					panic(err)
 				}
@@ -120,7 +119,7 @@ func (c *Controller) generateTLSCert() (*string, *string) {
 				panic(fmt.Errorf("missing '%s' in %s/%s", publicCertKey, operatorTLSCert.Namespace, operatorTLSCert.Name))
 			}
 			if val, ok := operatorTLSCert.Data[privateKeyKey]; ok {
-				err := ioutil.WriteFile(publicKeyPath, val, 0o644)
+				err := os.WriteFile(publicKeyPath, val, 0o644)
 				if err != nil {
 					panic(err)
 				}
@@ -474,11 +473,11 @@ var serverCertsManager *xcerts.Manager
 // from the provided paths. The private key may be encrypted and is
 // decrypted using the ENV_VAR: OPERATOR_CERT_PASSWD.
 func LoadX509KeyPair(certFile, keyFile string) (tls.Certificate, error) {
-	certPEMBlock, err := ioutil.ReadFile(certFile)
+	certPEMBlock, err := os.ReadFile(certFile)
 	if err != nil {
 		return tls.Certificate{}, err
 	}
-	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	keyPEMBlock, err := os.ReadFile(keyFile)
 	if err != nil {
 		return tls.Certificate{}, err
 	}

--- a/subnet/subnet-utils.go
+++ b/subnet/subnet-utils.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -337,7 +336,7 @@ func subnetReqDo(r *http.Request, headers map[string]string) (string, error) {
 	}
 
 	defer resp.Body.Close()
-	respBytes, e := ioutil.ReadAll(io.LimitReader(resp.Body, subnetRespBodyLimit))
+	respBytes, e := io.ReadAll(io.LimitReader(resp.Body, subnetRespBodyLimit))
 	if e != nil {
 		return "", e
 	}


### PR DESCRIPTION
We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil