### PR TITLE
feat: validate bucket name the same as minio-go

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -807,7 +807,7 @@ func (t *Tenant) CreateUsers(madmClnt *madmin.AdminClient, userCredentialSecrets
 // CreateBuckets creates buckets and skips if bucket already present
 func (t *Tenant) CreateBuckets(minioClient *minio.Client, buckets ...Bucket) error {
 	for _, bucket := range buckets {
-		if err := s3utils.CheckValidBucketName(bucket.Name); err != nil {
+		if err := s3utils.CheckValidBucketNameStrict(bucket.Name); err != nil {
 			return err
 		}
 		// create each bucket with a 20 seconds timeout


### PR DESCRIPTION
Change the bucket name validate rule the same as minio-go:

https://github.com/minio/minio-go/blob/d6fbd4980ec84fb532ad7b46ee097e007392780b/api-put-bucket.go#L30-L43

It make the check fail fast as soon as possiable.