### PR TITLE
fix: set resource namespaces as minio-operator

### DIFF
--- a/resources/base/cluster-role-binding.yaml
+++ b/resources/base/cluster-role-binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: minio-operator
-    namespace: default
+    namespace: minio-operator

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: console-sa
-  namespace: default
+  namespace: minio-operator
 ---
 apiVersion: v1
 kind: Secret
@@ -261,7 +261,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: console-sa
-    namespace: default
+    namespace: minio-operator
 ---
 apiVersion: v1
 data:

--- a/resources/base/service-account.yaml
+++ b/resources/base/service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minio-operator
-  namespace: default
+  namespace: minio-operator


### PR DESCRIPTION
I encountered the following error when installing the operator by `kubectl apply -f resources/base`

![image](https://user-images.githubusercontent.com/30427474/201257590-ed148378-864a-4952-abce-47afe8d077e8.png)

should all resources be placed under the same namespace