### PR TITLE
Fixing the secret reference for root configuration

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -27,7 +27,7 @@ spec:
   {{- end }}
   ## Secret with default environment variable configurations
   configuration:
-    name: {{ .configuration.name }}
+    name: {{ .Values.configuration.name }}
   pools:
   {{- range (dig "pools" (list) .) }}
     - servers: {{ dig "servers" 4 . }}


### PR DESCRIPTION
## Secret with default environment variable configurations from .Values

Detailed description in Issue
https://github.com/minio/operator/issues/1342 