### PR TITLE
Add container security context to tenant crd and helm chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -330,4 +330,8 @@ spec:
       runAsNonRoot: true
       fsGroup: {{ .log.securityContext.fsGroup | int }}
   {{- end }}
+  {{- with (dig "securityContext" (dict) .) }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -362,6 +362,10 @@ type TenantSpec struct {
 	// The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
 	// +optional
 	Configuration *corev1.LocalObjectReference `json:"configuration,omitempty"`
+	// *Optional* +
+	//
+	// Specify container security context for tenant
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 }
 
 // Logging describes Logging for MinIO tenants.

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -344,6 +344,7 @@ func poolMinioServerContainer(t *miniov2.Tenant, wsSecret *v1.Secret, skipEnvVar
 		LivenessProbe:   t.Spec.Liveness,
 		ReadinessProbe:  t.Spec.Readiness,
 		StartupProbe:    t.Spec.Startup,
+		SecurityContext: t.Spec.SecurityContext,
 	}
 }
 


### PR DESCRIPTION
Hi folks! With this PR I'm trying to address the issue described in here https://github.com/minio/operator/issues/1267 & https://github.com/minio/operator/issues/1310

Currently there is no way to pass full container level security context when deploying a tenant. This feature would be similar to the one pending for the operator and the console https://github.com/minio/operator/pull/1278

This is my first trying contributing here, so any pointers on what I'm missing here are more than welcome.