### PR TITLE
update example to use non-legacy KES config

### DIFF
--- a/examples/kustomization/tenant-kes-encryption/kes-configuration-secret.yaml
+++ b/examples/kustomization/tenant-kes-encryption/kes-configuration-secret.yaml
@@ -6,7 +6,8 @@ type: Opaque
 stringData:
   server-config.yaml: |-
     address: :7373
-    root: _ # Effectively disabled since no root identity necessary.
+    admin:
+      identity: _ # Effectively disabled since no root identity necessary.
     tls:
       key: /tmp/kes/server.key   # Path to the TLS private key
       cert: /tmp/kes/server.crt # Path to the TLS certificate
@@ -17,9 +18,11 @@ stringData:
     policy:
       my-policy:
         paths:
+        - /v1/api
         - /v1/key/create/*
         - /v1/key/generate/*
         - /v1/key/decrypt/*
+        - /v1/key/bulk/decrypt/*
         identities:
         - ${MINIO_KES_IDENTITY}
     cache:
@@ -29,7 +32,7 @@ stringData:
     log:
       error: on
       audit: off
-    keys:
+    keystore:
       ## KES configured with fs (File System mode) doesnt work in Kubernetes environments and it's not recommended
       ## use a real KMS
       # fs:


### PR DESCRIPTION
This commit updates the KES example to contain
non-legacy config fields.