### PR TITLE
Fix nested values in Tenant Helm template

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -205,15 +205,15 @@ spec:
     initimage: {{ .prometheus.initimage | quote }}
     diskCapacityGB: {{ .prometheus.diskCapacityGB | int }}
     storageClassName: {{ .prometheus.storageClassName }}
-    {{- with (dig "annotations" (dict) .) }}
+    {{- with (dig "prometheus" "annotations" (dict) .) }}
     annotations:
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "labels" (dict) .) }}
+    {{- with (dig "prometheus" "labels" (dict) .) }}
     labels:
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "nodeSelector" (dict) .) }}
+    {{- with (dig "prometheus" "nodeSelector" (dict) .) }}
     nodeSelector:
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -225,7 +225,7 @@ spec:
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with (dig "resources" (dict) .) }}
+    {{- with (dig "prometheus" "resources" (dict) .) }}
     resources:
       {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -245,11 +245,11 @@ spec:
     env:
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "resources" (dict) .) }}
+    {{- with (dig "log" "resources" (dict) .) }}
     resources:
       {{ toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "nodeSelector" (dict) .) }}
+    {{- with (dig "log" "nodeSelector" (dict) .) }}
     nodeSelector:
       {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -261,11 +261,11 @@ spec:
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with (dig "annotations" (dict) .) }}
+    {{- with (dig "log" "annotations" (dict) .) }}
     annotations:
       {{ toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "labels" (dict) .) }}
+    {{- with (dig "log" "labels" (dict) .) }}
     labels:
       {{ toYaml . | nindent 4 }}
     {{- end }}
@@ -282,7 +282,7 @@ spec:
       {{- end }}
       initimage: {{ .log.db.initimage | quote }}
       volumeClaimTemplate:
-        {{- with (dig "metadata" (dict) .) }}
+        {{- with (dig "log" "db" "volumeClaimTemplate" "metadata" (dict) .) }}
         metadata:
           {{ toYaml . | nindent 4 }}
         {{- end }}
@@ -293,11 +293,11 @@ spec:
           resources:
             requests:
               storage: {{ .log.db.volumeClaimTemplate.spec.resources.requests.storage | quote }}
-      {{- with (dig "resources" (dict) .) }}
+      {{- with (dig "log" "db" "resources" (dict) .) }}
       resources:
         {{ toYaml . | nindent 4 }}
       {{- end }}
-      {{- with (dig "nodeSelector" (dict) .) }}
+      {{- with (dig "log" "db" "nodeSelector" (dict) .) }}
       nodeSelector:
         {{ toYaml . | nindent 4 }}
       {{- end }}
@@ -309,11 +309,11 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (dig "annotations" (dict) .) }}
+      {{- with (dig "log" "db" "annotations" (dict) .) }}
       annotations:
         {{ toYaml . | nindent 4 }}
       {{- end }}
-      {{- with (dig "labels" (dict) .) }}
+      {{- with (dig "log" "db" "labels" (dict) .) }}
       labels:
         {{ toYaml . | nindent 4 }}
       {{- end }}


### PR DESCRIPTION
I was not able to set log nodeSelector by using values demonstrated in https://github.com/minio/operator/blob/master/helm/tenant/values.yaml  
But log affinity was working properly so I realised some dig functions aren't using nested values.  Maybe there is a reason for that but it doesn't match values.yaml so I'm thinking it might be a mistake.