### PR TITLE
fix: --kubeconfig parameter was being ignored in init and delete commands

### DIFF
--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -132,8 +132,17 @@ func (o *deleteCmd) run(writer io.Writer) error {
 		return err
 	}
 
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+
+	var parameters []string
+	if path != "" {
+		parameters = append(parameters, "--kubeconfig", path, "delete", "-f", "-")
+	} else {
+		parameters = append(parameters, "delete", "-f", "-")
+	}
+
 	// do kubectl apply
-	cmd := exec.Command("kubectl", "delete", "-f", "-")
+	cmd := exec.Command("kubectl", parameters...)
 
 	cmd.Stdin = strings.NewReader(string(yml))
 

--- a/kubectl-minio/cmd/init.go
+++ b/kubectl-minio/cmd/init.go
@@ -293,8 +293,16 @@ func (o *operatorInitCmd) run(writer io.Writer) error {
 		return err
 	}
 
+	path, _ := rootCmd.Flags().GetString(kubeconfig)
+
+	var parameters []string
+	if path != "" {
+		parameters = append(parameters, "--kubeconfig", path, "apply", "-f", "-")
+	} else {
+		parameters = append(parameters, "apply", "-f", "-")
+	}
 	// do kubectl apply
-	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd := exec.Command("kubectl", parameters...)
 
 	cmd.Stdin = strings.NewReader(string(yml))
 


### PR DESCRIPTION
This PR closes https://github.com/minio/operator/issues/1361