### PR TITLE
bugfix --kubeconfig parameter for `kubectl-minio proxy` command

### DIFF
--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -134,11 +134,9 @@ func (o *deleteCmd) run(writer io.Writer) error {
 
 	path, _ := rootCmd.Flags().GetString(kubeconfig)
 
-	var parameters []string
+	parameters := []string{"delete", "-f", "-"}
 	if path != "" {
-		parameters = append(parameters, "--kubeconfig", path, "delete", "-f", "-")
-	} else {
-		parameters = append(parameters, "delete", "-f", "-")
+		parameters = append([]string{"--kubeconfig", path}, parameters...)
 	}
 
 	// do kubectl apply

--- a/kubectl-minio/cmd/init.go
+++ b/kubectl-minio/cmd/init.go
@@ -295,11 +295,9 @@ func (o *operatorInitCmd) run(writer io.Writer) error {
 
 	path, _ := rootCmd.Flags().GetString(kubeconfig)
 
-	var parameters []string
+	parameters := []string{"apply", "-f", "-"}
 	if path != "" {
-		parameters = append(parameters, "--kubeconfig", path, "apply", "-f", "-")
-	} else {
-		parameters = append(parameters, "apply", "-f", "-")
+		parameters = append([]string{"--kubeconfig", path}, parameters...)
 	}
 	// do kubectl apply
 	cmd := exec.Command("kubectl", parameters...)

--- a/kubectl-minio/cmd/proxy.go
+++ b/kubectl-minio/cmd/proxy.go
@@ -127,8 +127,13 @@ func servicePortForwardPort(ctx context.Context, namespace, service, port string
 		defer close(ch)
 		// service we are going to forward
 		serviceName := fmt.Sprintf("service/%s", service)
+		path, _ := rootCmd.Flags().GetString(kubeconfig)
+		parameters := []string{"port-forward", "--address", "0.0.0.0", "-n", namespace, serviceName, port}
+		if path != "" {
+			parameters = append([]string{"--kubeconfig", path}, parameters...)
+		}
 		// command to run
-		cmd := exec.CommandContext(ctx, "kubectl", "port-forward", "--address", "0.0.0.0", "-n", namespace, serviceName, port)
+		cmd := exec.CommandContext(ctx, "kubectl", parameters...)
 		// prepare to capture the output
 		var errStdout, errStderr error
 		stdoutIn, _ := cmd.StdoutPipe()


### PR DESCRIPTION
* add kubeconfig flag to proxy command, a scond call to kubectl was missing the parameter
* little refactor to simpify command parameters

Closes https://github.com/minio/operator/issues/1364