### PR TITLE
Redhat ubi-minimal:8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 ARG TAG
 


### PR DESCRIPTION
AWS Marketplace complains when publishing a new release of enterprise operator with the following error message:

`Provide image with resolved security issue: UnscannableImage.` according to [documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-troubleshooting.html), 

```yaml
You may get an UnsupportedImageError error when attempting to perform a basic scan on an image that was built using an operating system that Amazon ECR doesn't support basic image scanning for. Amazon ECR supports package vulnerability scanning for major versions of Amazon Linux, Amazon Linux 2, Debian, Ubuntu, CentOS, Oracle Linux, Alpine, and RHEL Linux distributions. Once a distribution loses support from its vendor, Amazon ECR may no longer support scanning it for vulnerabilities. Amazon ECR does not support scanning images built from the [Docker scratch](https://hub.docker.com/_/scratch) image.
```

Probably the [Redhat ubi 8.6](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?tag=8.6-994&push_date=1666894348000&container-tabs=security) is no longer being supported by AWS ECR scanner.

Triggering this build to initiate test using ubi 8.7