### PR TITLE
Parse .spec.features.domains.minio array elements

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -1139,22 +1139,36 @@ func (t *Tenant) HasConsoleDomains() bool {
 func (t *Tenant) ValidateDomains() error {
 	if t.HasMinIODomains() {
 		domains := t.Spec.Features.Domains.Minio
+		var globalDomains []string
 		if len(domains) != 0 {
-			for _, domainName := range domains {
-				_, err := url.Parse(domainName)
+			for _, domain := range domains {
+				// Infer schema from tenant TLS, if not explicit
+				if !strings.HasPrefix(domain, "http") {
+					useSchema := "http"
+					if t.TLS() {
+						useSchema = "https"
+					}
+					domain = fmt.Sprintf("%s://%s", useSchema, domain)
+				}
+
+				u, err := url.Parse(domain)
 				if err != nil {
 					return err
 				}
 
-				if _, ok := dns.IsDomainName(domainName); !ok {
-					return fmt.Errorf("invalid domain `%s`", domainName)
+				if _, ok := dns.IsDomainName(domain); !ok {
+					return fmt.Errorf("invalid domain `%s`", domain)
 				}
+
+				// Remove ports if any
+				domain := strings.Split(u.Host, ":")[0]
+				globalDomains = append(globalDomains, domain)
 			}
-			sort.Strings(domains)
-			lcpSuf := lcpSuffix(domains)
-			for _, domainName := range domains {
-				if domainName == lcpSuf && len(domains) > 1 {
-					return fmt.Errorf("overlapping domains `%s` not allowed", domainName)
+			sort.Strings(globalDomains)
+			lcpSuf := lcpSuffix(globalDomains)
+			for _, domain := range globalDomains {
+				if domain == lcpSuf && len(globalDomains) > 1 {
+					return fmt.Errorf("overlapping domains `%s` not allowed", domain)
 				}
 			}
 		}
@@ -1167,14 +1181,28 @@ func (t *Tenant) GetDomainHosts() []string {
 	if t.HasMinIODomains() {
 		domains := t.Spec.Features.Domains.Minio
 		var hosts []string
-		for _, d := range domains {
-			u, err := url.Parse(d)
+		for _, domain := range domains {
+			// Infer schema from tenant TLS, if not explicit
+			if !strings.HasPrefix(domain, "http") {
+				useSchema := "http"
+				if t.TLS() {
+					useSchema = "https"
+				}
+				domain = fmt.Sprintf("%s://%s", useSchema, domain)
+			}
+
+			if _, ok := dns.IsDomainName(domain); !ok {
+				continue
+			}
+
+			u, err := url.Parse(domain)
 			if err != nil {
 				continue
 			}
-			// remove ports if any
-			hostParts := strings.Split(u.Host, ":")
-			hosts = append(hosts, hostParts[0])
+
+			// Remove ports if any
+			host := strings.Split(u.Host, ":")[0]
+			hosts = append(hosts, host)
 		}
 		return hosts
 	}

--- a/pkg/apis/minio.min.io/v2/helper_test.go
+++ b/pkg/apis/minio.min.io/v2/helper_test.go
@@ -338,8 +338,8 @@ func TestTenant_GetDomainHosts(t1 *testing.T) {
 					Features: &Features{
 						Domains: &TenantDomains{
 							Minio: []string{
-								"https://domain1.com:8080",
-								"http://domain2.com",
+								"domain1.com:8080",
+								"domain2.com",
 							},
 						},
 					},
@@ -460,8 +460,10 @@ func TestTenant_ValidateDomains(t1 *testing.T) {
 					Features: &Features{
 						Domains: &TenantDomains{
 							Minio: []string{
-								"https://domain1.com:8080",
-								"http://domain2.com",
+								"domain1.com:8080",
+								"domain2.com",
+								"http://domain3.com:8080",
+								"https://domain4.com",
 							},
 						},
 					},
@@ -478,6 +480,8 @@ func TestTenant_ValidateDomains(t1 *testing.T) {
 							Minio: []string{
 								"http s://domain1.com:8080",
 								"http://domain2.com",
+								"httx://domain3.com",
+								":8080",
 							},
 						},
 					},
@@ -492,8 +496,8 @@ func TestTenant_ValidateDomains(t1 *testing.T) {
 					Features: &Features{
 						Domains: &TenantDomains{
 							Minio: []string{
-								"http://domain2.com",
-								"http://domain2.com",
+								"domain2.com",
+								"other.domain2.com:8080",
 							},
 						},
 					},


### PR DESCRIPTION
# Issues
[features domain broken on Tenant helm chart · Issue #1354 · minio/operator](https://github.com/minio/operator/issues/1354) 

# Steps
## Reproduce using operator 4.5.8
1a. Clone https://github.com/allanrogerr/operator.git
Checkout `parse-tenant-domain` and build
Comment out "destroy_kind" from testing/deploy-tenant.sh
Run `testing/deploy-tenant.sh`
Once running, add to minio-operator deployment at `.spec.template.spec.containers.image`:
```
k -n minio-operator edit deployment/minio-operator
```

```
image: minio/operator:v4.5.8 
```

<img width="406" alt="image" src="https://user-images.githubusercontent.com/16472240/213320056-01249de0-2837-45d1-86e1-cfbcf9b44bd6.png">


b. Edit tenant under .spec.features
```
  features:
    domains:
      console: https://localhost:9443
      minio:
      - http://minio.default.svc.cluster.local
      - minio1.default.svc.cluster.local
      - https://test.default.svc.cluster.local
      - old.default.svc.cluster.local:9090
      - minio.default.svc.cluster.local
      - rbitrary.default.svc.cluster.local
      - default.svc.cluster.local
```

c. Run testing/deploy-tenant.sh

d. Observe
* no overlapping domains are reported. default.svc.cluster.local should cause an overlap
* strings with prefix https? are missing
Tenant
```
  features:
    domains:
      console: https://localhost:9443
      minio:
      - http://minio.default.svc.cluster.local
      - minio1.default.svc.cluster.local
      - https://test.default.svc.cluster.local
      - old.default.svc.cluster.local:9090
      - minio.default.svc.cluster.local
      - rbitrary.default.svc.cluster.local
      - default.svc.cluster.local

```
Statefulset
```
        - name: MINIO_BROWSER_REDIRECT_URL
          value: https://localhost:9443
        - name: MINIO_DOMAIN
          value: ',minio.default.svc.cluster.local,test.default.svc.cluster.local,,,,'
        - name: MINIO_SERVER_URL
          value: default.svc.cluster.local
```
e. Observe pods do not start:
```
➜  operator git:(parse-tenant-domain) ✗ k -n tenant-lite get pods                            
NAME                                           READY   STATUS             RESTARTS       AGE
storage-lite-log-0                             1/1     Running            0              40m
storage-lite-log-search-api-5685f95857-xx9t5   1/1     Running            4 (39m ago)    40m
storage-lite-pool-0-0                          1/1     Running            0              15m
storage-lite-pool-0-1                          1/1     Running            0              15m
storage-lite-pool-0-2                          0/1     CrashLoopBackOff   5 (106s ago)   4m47s
storage-lite-pool-0-3                          0/1     CrashLoopBackOff   5 (2m6s ago)   4m51s
storage-lite-prometheus-0                      2/2     Running            0              38m
➜  operator git:(parse-tenant-domain) ✗ k -n tenant-lite logs pod/storage-lite-pool-0-2
ERROR Invalid MINIO_SERVER_URL value in environment variable: unexpected scheme found 
```

f. Remove minio domain modification. Observe pods start. Observe console accessible on reported urls:
```
API: https://minio.tenant-lite.svc.cluster.local 
Console: https://localhost:9443 
```
<img width="714" alt="image" src="https://user-images.githubusercontent.com/16472240/213324310-698644f6-c349-43ab-b2a3-4394fc64fc39.png">
```
➜  operator git:(parse-tenant-domain) ✗ k -n tenant-lite get pods                            
NAME                                           READY   STATUS    RESTARTS      AGE
storage-lite-log-0                             1/1     Running   0             55m
storage-lite-log-search-api-5685f95857-xx9t5   1/1     Running   4 (55m ago)   55m
storage-lite-pool-0-0                          1/1     Running   0             2m42s
storage-lite-pool-0-1                          1/1     Running   0             2m45s
storage-lite-pool-0-2                          1/1     Running   0             2m48s
storage-lite-pool-0-3                          1/1     Running   0             2m51s
storage-lite-prometheus-0                      2/2     Running   0             53m
```
##Fix
## Fix using operator https://github.com/allanrogerr/operator/tree/parse-tenant-domain
1a. Edit minio-operator deployment at `.spec.template.spec.containers.image`:
```
k -n minio-operator edit deployment/minio-operator
```

```
image: minio/operator:noop
```
<img width="412" alt="image" src="https://user-images.githubusercontent.com/16472240/213322196-720c5624-e488-4032-8611-d86f0060a19e.png">


b. Edit tenant under .spec.features
```
  features:
    domains:
      console: localhost:9443
      minio:
      - http://minio.default.svc.cluster.local
      - minio1.default.svc.cluster.local
      - https://test.default.svc.cluster.local
      - old.default.svc.cluster.local:9090
      - minio.default.svc.cluster.local
      - rbitrary.default.svc.cluster.local
      - default.svc.cluster.local
```


c. Observe
* overlapping domains are reported. default.svc.cluster.local caused an overlap. This entry was then removed.
<img width="414" alt="image" src="https://user-images.githubusercontent.com/16472240/213325038-c2847e27-aac4-4dce-9a94-ad901b2414ae.png">

* strings with prefix https? are available without their prefixes
Tenant
```
  features:
    domains:
      console: localhost:9443
      minio:
      - http://minio.default.svc.cluster.local
      - minio1.default.svc.cluster.local
      - https://test.default.svc.cluster.local
      - old.default.svc.cluster.local:9090
      - minio.default.svc.cluster.local
      - rbitrary.default.svc.cluster.local
```
Statefulset
```
        - name: MINIO_BROWSER_REDIRECT_URL
          value: https://localhost:9443
        - name: MINIO_DOMAIN
          value: minio.default.svc.cluster.local,minio1.default.svc.cluster.local,test.default.svc.cluster.local,old.default.svc.cluster.local,minio.default.svc.cluster.local,rbitrary.default.svc.cluster.local
        - name: MINIO_SERVER_URL
          value: https://minio.tenant-lite.svc.cluster.local:443
```
d. Observe pods start:
```
➜  operator git:(parse-tenant-domain) ✗ k -n tenant-lite get pods  
NAME                                           READY   STATUS    RESTARTS      AGE
storage-lite-log-0                             1/1     Running   0             73m
storage-lite-log-search-api-5685f95857-xx9t5   1/1     Running   4 (72m ago)   73m
storage-lite-pool-0-0                          1/1     Running   0             5m45s
storage-lite-pool-0-1                          1/1     Running   0             5m48s
storage-lite-pool-0-2                          1/1     Running   0             5m52s
storage-lite-pool-0-3                          1/1     Running   0             5m56s
storage-lite-prometheus-0                      2/2     Running   0             71m
```

e. Validate that the urls are accessible with
```
k -n tenant-lite exec -it storage-lite-pool-0-0 -- /bin/sh
curl https://localhost:9443
curl https://minio.tenant-lite.svc.cluster.local:443
```
<img width="704" alt="image" src="https://user-images.githubusercontent.com/16472240/213326615-e8625f1a-adfe-4ca6-8c8f-686bc5894e86.png">


f. Validate tenant console accessible
```
k port-forward service/storage-lite-console -n tenant-lite 9443 
```
Navigate to https://localhost:9443
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/16472240/213326842-eb1b1f2c-b396-4c0a-9074-38ed97d0ce50.png">
