### PR TITLE
Add runtimeClassName to helm for console and operator

### DIFF
--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -70,4 +70,8 @@ spec:
       {{- with .Values.console.initContainers }}
       initContainers:
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.runtimeClassName }}
+      runtimeClassName: 
+      {{- toYaml . | nindent 8 }}
   {{- end}}

--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -54,3 +54,7 @@ spec:
       initContainers:
       {{- toYaml . | nindent 8 }}
       {{- end}}
+      {{- with .Values.operator.runtimeClassName }}
+      runtimeClassName: 
+      {{- toYaml . | nindent 8 }}
+  {{- end }}

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -99,6 +99,16 @@ func minioEnvironmentVars(t *miniov2.Tenant, skipEnvVars map[string][]byte, opVe
 			Value: t.PrometheusConfigJobName(),
 		},
 	}
+	// Specific case of bug in runtimeClass crun where $HOME is not set
+	for _, pool := range t.Spec.Pools {
+		if *pool.RuntimeClassName == "runc" {
+			// Set HOME to /
+			envVarsMap["HOME"] = corev1.EnvVar{
+				Name:  "HOME",
+				Value: "/",
+			}
+		}
+	}
 
 	var domains []string
 	// Enable Bucket DNS only if asked for by default turned off

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -101,7 +101,7 @@ func minioEnvironmentVars(t *miniov2.Tenant, skipEnvVars map[string][]byte, opVe
 	}
 	// Specific case of bug in runtimeClass crun where $HOME is not set
 	for _, pool := range t.Spec.Pools {
-		if *pool.RuntimeClassName == "runc" {
+		if pool.RuntimeClassName != nil && *pool.RuntimeClassName == "crun" {
 			// Set HOME to /
 			envVarsMap["HOME"] = corev1.EnvVar{
 				Name:  "HOME",


### PR DESCRIPTION
# Fixes 
https://github.com/minio/operator/issues/1337

- The helm charts for operator/console do not yet contain runtimeClassName. This is added in this PR.
- User $HOME is set to ```/``` if runtimeClassName is ```crun```

# Pending
Review of UI aspect of the issue

# Tests
See https://github.com/allanrogerr/operator/wiki/%5Bbug%5D-ensure-non-empty-$HOME-in-deployments-%231337#steps-add-helm-for-console-and-operator

Fixes https://github.com/minio/operator/issues/1337