### PR TITLE
fix: some error of bucket creation be ignored

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -820,6 +820,8 @@ func (t *Tenant) CreateBuckets(minioClient *minio.Client, buckets ...Bucket) err
 			case "BucketAlreadyOwnedByYou", "BucketAlreadyExists":
 				klog.Infof(err.Error())
 				continue
+			default:
+				return err
 			}
 		}
 		klog.Infof("Successfully created bucket %s", bucket.Name)


### PR DESCRIPTION
Create tenant with bucket named `mcamel3`, the logs seem to create successful:
<img width="1913" alt="截屏2023-01-05 13 57 06" src="https://user-images.githubusercontent.com/32033618/210711875-90034dd9-dd31-456a-81b0-f977b4df3cf4.png">

But the bucket dose not exist in tenant after checking.

The related log is:
```
I0105 05:01:42.707669       1 monitoring.go:130] 'default/test-minio-3' Failed to get cluster health: Get "http://minio.default.svc.cluster.local/minio/health/cluster": dial tcp 100.66.252.175:80: connect: connection refused
```

The pod is not ready at that time.
