### PR TITLE
delete redundance matrix go version

### DIFF
--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -112,7 +112,7 @@ jobs:
       - operator
     strategy:
       matrix:
-        go-version: [ 1.19.x, 1.19.x ]
+        go-version: [ 1.19.x ]
         os: [ ubuntu-latest ]
 
     steps:


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

```
   strategy:
      matrix:
        go-version: [ 1.19.x, 1.19.x ]
        os: [ ubuntu-latest ]
``` 
may redundance version , delete the same ones.