### PR TITLE
Consider RuntimeClassName as a string

### DIFF
--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -658,7 +658,7 @@ type Pool struct {
 	//
 	// If provided, each pod on the Statefulset will run with the specified RuntimeClassName, for more info https://kubernetes.io/docs/concepts/containers/runtime-class/
 	// +optional
-	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+	RuntimeClassName string `json:"runtimeClassName,omitempty"`
 }
 
 // EqualImage returns true if image specified in `LogConfig` is equal to `image`

--- a/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
@@ -470,11 +470,6 @@ func (in *Pool) DeepCopyInto(out *Pool) {
 			(*out)[key] = val
 		}
 	}
-	if in.RuntimeClassName != nil {
-		in, out := &in.RuntimeClassName, &out.RuntimeClassName
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -101,7 +101,7 @@ func minioEnvironmentVars(t *miniov2.Tenant, skipEnvVars map[string][]byte, opVe
 	}
 	// Specific case of bug in runtimeClass crun where $HOME is not set
 	for _, pool := range t.Spec.Pools {
-		if pool.RuntimeClassName != nil && *pool.RuntimeClassName == "crun" {
+		if pool.RuntimeClassName == "crun" {
 			// Set HOME to /
 			envVarsMap["HOME"] = corev1.EnvVar{
 				Name:  "HOME",
@@ -848,8 +848,8 @@ func NewPool(t *miniov2.Tenant, wsSecret *v1.Secret, skipEnvVars map[string][]by
 	}
 
 	// pass on RuntimeClassName
-	if pool.RuntimeClassName != nil && *pool.RuntimeClassName != "" {
-		ss.Spec.Template.Spec.RuntimeClassName = pool.RuntimeClassName
+	if pool.RuntimeClassName != "" {
+		ss.Spec.Template.Spec.RuntimeClassName = &pool.RuntimeClassName
 	}
 
 	return ss


### PR DESCRIPTION
## What does this do?
This defines the runtimeClassName of a tenant in the UI, as a string. Currently, runtimeClassName is defined as a *string, making downstream code clumsy.  

## How is it used?
See the user UI request here: https://github.com/minio/operator/issues/1337#issuecomment-1370135627

## How is it tested?
See the steps here: https://github.com/allanrogerr/operator/wiki/Consider-RuntimeClassName-as-a-string