### PR TITLE
Not able to disable log and prometheus deployments because of typo

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -201,7 +201,7 @@ spec:
       fsGroup: {{ .kes.securityContext.fsGroup | int }}
   {{- end }}
 
-  {{- if ne (dig "prometheus" "disable" false .) true}}
+  {{- if ne (dig "prometheus" "disabled" false .) true}}
   ## Prometheus setup for MinIO Tenant.
   prometheus:
     image: {{ .prometheus.image | quote }}
@@ -245,7 +245,7 @@ spec:
       fsGroup: {{ .prometheus.securityContext.fsGroup | int }}
   {{- end }}
 
-  {{- if ne (dig "log" "disable" false .) true}}
+  {{- if ne (dig "log" "disabled" false .) true}}
   ## LogSearch API setup for MinIO Tenant.
   log:
     image: {{ .log.image | quote }}


### PR DESCRIPTION
Not able to disable log and prometheus deployments because of typo. Tested.