### PR TITLE
Fixed wrong key names in the helm values for a tenant

### DIFF
--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -229,7 +229,7 @@ tenant:
   ## Prometheus setup for MinIO Tenant.
   prometheus:
     # When set to true disables the creation of prometheus deployment
-    disabled: false
+    disable: false
     image: "" # defaults to quay.io/prometheus/prometheus:latest
     env: [ ]
     sidecarimage: "" # defaults to alpine
@@ -254,7 +254,7 @@ tenant:
   ## LogSearch API setup for MinIO Tenant.
   log:
     # When set to true disables the creation of logsearch api deployment
-    disabled: false
+    disable: false
     image: "" # defaults to minio/operator:v4.4.17
     env: [ ]
     resources: { }


### PR DESCRIPTION
The tenant helm chart have feature toggles for Prometheus([ref](https://github.com/minio/operator/blob/master/helm/tenant/templates/tenant.yaml#L204)) and LogSearch API([ref](https://github.com/minio/operator/blob/master/helm/tenant/templates/tenant.yaml#L248)) as key name `disable`.
However, current values defines wrong key name `disabled`, thus this PR fixes it to `disable`.