### PR TITLE
Olm webhook

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -64,8 +64,8 @@ for catalog in "${redhatCatalogs[@]}"; do
   # deploymentName has to be minio-operator, the reason is in case/03206318 or redhat support.
   # the deployment name you set is "operator", and in CSV, there are two deployments 'console' and 'minio-operator'
   # but there is no 'operator' option, without this change error is: "calculated deployment install is bad"
-  yq -i '.spec.webhookdefinitions[0].deploymentName = "minio-operator"' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
-  yq -i '.spec.conversion.webhook.clientConfig.service.name = "minio-operator"' bundles/$catalog/$RELEASE/manifests/minio.min.io_tenants.yaml
+  yq -d -i '.spec.webhookdefinitions'
+  yq -i '.spec.conversion.webhook.clientConfig.service.name = "operator"' bundles/$catalog/$RELEASE/manifests/minio.min.io_tenants.yaml
 
   # I get the update from engineering team, typically no user/group specification is made in a container image.
   # Rather, the user spec (if there is one) is placed in the clusterserviceversion.yaml file as a RunAsUser clause.

--- a/olm.sh
+++ b/olm.sh
@@ -64,7 +64,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # deploymentName has to be minio-operator, the reason is in case/03206318 or redhat support.
   # the deployment name you set is "operator", and in CSV, there are two deployments 'console' and 'minio-operator'
   # but there is no 'operator' option, without this change error is: "calculated deployment install is bad"
-  yq -d -i '.spec.webhookdefinitions'
+  yq -i 'del(.spec.webhookdefinitions)' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml 
   yq -i '.spec.conversion.webhook.clientConfig.service.name = "operator"' bundles/$catalog/$RELEASE/manifests/minio.min.io_tenants.yaml
 
   # I get the update from engineering team, typically no user/group specification is made in a container image.


### PR DESCRIPTION
We are removing webhook from the clusterserviceversion.yaml, so that Openshift do not attempt to create an additional service on operator install.

We did this in the last release, but missed to update the CRD with the service that will handle the webhook to `operator` from `minio-operator`, causing the following issue on operator update:

```
error validating existing CRs against new CRD's schema for "tenants.minio.min.io": error listing resources in GroupVersionResource schema.GroupVersionResource{Group:"minio.min.io", Version:"v1", Resource:"tenants"}: conversion webhook for minio.min.io/v2, Kind=Tenant failed: Post "https://minio-operator.openshift-operators.svc:4222/webhook/v1/crd-conversion?timeout=30s": service "minio-operator" not found
```