### PR TITLE
Allow manual execution by keeping cluster alive

### DIFF
--- a/testing/deploy-tenant.sh
+++ b/testing/deploy-tenant.sh
@@ -31,7 +31,18 @@ function main() {
 
     check_tenant_status tenant-lite storage-lite
 
-    destroy_kind
+    # To allow the execution without killing the cluster at the end of the test
+    # Use below statement to automatically test and kill cluster at the end:
+    # `unset OPERATOR_ENABLE_MANUAL_TESTING`
+    # Use below statement to test and keep cluster alive at the end!:
+    # `export OPERATOR_ENABLE_MANUAL_TESTING="ON"`
+    if [[ -z "${OPERATOR_ENABLE_MANUAL_TESTING}" ]]; then
+        # OPERATOR_ENABLE_MANUAL_TESTING is not defined, hence destroy_kind
+        echo "Cluster will be destroyed for automated testing"
+        destroy_kind
+    else
+        echo "Cluster will remain alive for manual testing"
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
### Objective:

To allow manual testing without killing the cluster at the end of the test. This will save time when we comment out this line every time we test. All we need to use is an environment variable to activate this option.

```sh
unset ENABLE_MANUAL_TESTING <------------ For automated test
export ENABLE_MANUAL_TESTING="ON" <------ For manual test
```

### Story:

Idea comes from https://github.com/minio/operator/pull/1378 where @allanrogerr suggested to use `testing/deploy-tenant.sh` and comment out "destroy_kind". I would rather prefer to have this option set in my ~/.bash_profile in order to test manually every time wihtout killing the cluster