### PR TITLE
Helm chart: Add priorityClass support for operator

### DIFF
--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       topologySpreadConstraints:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.operator.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -28,6 +28,7 @@ operator:
     runAsGroup: 1000
     runAsNonRoot: true
   nodeSelector: { }
+  priorityClassName: ""
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
With the following change I am enabled the ability for the operator to be scheduled before minio clusters (if desired)

In case of restarts and or cases where required a full restart. We need operator to be scheduled before minio pods.
This way Pods can find the operator and startup properly.

priorityClass allows this more (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
