### PR TITLE
fix: status.AvailableReplicas does not reflect the current state of statefulset

### DIFF
--- a/pkg/controller/kes.go
+++ b/pkg/controller/kes.go
@@ -181,7 +181,7 @@ func (c *Controller) checkKESCertificatesStatus(ctx context.Context, tenant *min
 	return nil
 }
 
-func (c *Controller) checkKESStatus(ctx context.Context, tenant *miniov2.Tenant, totalReplicas int32, cOpts metav1.CreateOptions, uOpts metav1.UpdateOptions, nsName types.NamespacedName) error {
+func (c *Controller) checkKESStatus(ctx context.Context, tenant *miniov2.Tenant, totalAvailableReplicas int32, cOpts metav1.CreateOptions, uOpts metav1.UpdateOptions, nsName types.NamespacedName) error {
 	if tenant.HasKESEnabled() {
 		if err := c.checkKESCertificatesStatus(ctx, tenant, nsName); err != nil {
 			return err
@@ -261,7 +261,7 @@ func (c *Controller) checkKESStatus(ctx context.Context, tenant *miniov2.Tenant,
 			// if the KES StatefulSet doesn't match the spec
 			if !kesStatefulSetMatchesSpec {
 				ks := statefulsets.NewForKES(tenant, svc.Name)
-				if tenant, err = c.updateTenantStatus(ctx, tenant, StatusUpdatingKES, totalReplicas); err != nil {
+				if tenant, err = c.updateTenantStatus(ctx, tenant, StatusUpdatingKES, totalAvailableReplicas); err != nil {
 					return err
 				}
 				if _, err = c.kubeClientSet.AppsV1().StatefulSets(tenant.Namespace).Update(ctx, ks, uOpts); err != nil {


### PR DESCRIPTION
### Summary
The `tenant.Status.AvailableReplicas` field does not reflect the current pod state of all statefulset.

### Steps to reproduce
#### create tenant with affinity, let pod can not scheduling(that's what we want)
```
[root@localhost /]# kubectl get po test-minioascasac-pool-0-0 -o wide
NAME                         READY   STATUS    RESTARTS   AGE     IP       NODE     NOMINATED NODE   READINESS GATES
test-minioascasac-pool-0-0   0/1     Pending   0          4h15m   <none>   <none>   <none>           <none>
```

### then we can see
The available replicas in cr is 1:
```
[root@localhost /]# kubectl describe tenants.minio.min.io test-minioascasac | grep 'Available Replicas'
  Available Replicas:  1
```

The replicas in statefulset is 1:
```
[root@localhost /]# kubectl describe sts test-minioascasac-pool-0 | grep 'Replicas:'
Replicas:           1 desired | 1 total
```

**The available replicas should be 0 indeed.**