### PR TITLE
Deprecating audit logs from kustomization examples

### DIFF
--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -228,53 +228,54 @@ spec:
   # prometheusOperator:
   #   labels:
   #     app: minio-sm
+  ## Audit Logs will be deprecated soon, commenting out for now!.
   ## LogSearch API setup for MinIO Tenant.
-  log:
-    image: "" # defaults to minio/operator:v4.5.8
-    env: [ ]
-    resources: { }
-    nodeSelector: { }
-    affinity:
-      nodeAffinity: { }
-      podAffinity: { }
-      podAntiAffinity: { }
-    tolerations: [ ]
-    annotations: { }
-    labels: { }
-    audit:
-      diskCapacityGB: 1
-    ## Postgres setup for LogSearch API
-    db:
-      image: "" # defaults to library/postgres
-      env: [ ]
-      initimage: "" # defaults to busybox:1.33.1
-      volumeClaimTemplate:
-        metadata: { }
-        spec:
-          storageClassName: standard
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 1Gi
-      resources: { }
-      nodeSelector: { }
-      affinity:
-        nodeAffinity: { }
-        podAffinity: { }
-        podAntiAffinity: { }
-      tolerations: [ ]
-      annotations: { }
-      labels: { }
-      serviceAccountName: ""
-      securityContext:
-        runAsUser: 999
-        runAsGroup: 999
-        runAsNonRoot: true
-        fsGroup: 999
-    serviceAccountName: ""
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 1000
-      runAsNonRoot: true
-      fsGroup: 1000
+  # log:
+  #   image: "" # defaults to minio/operator:v4.5.8
+  #   env: [ ]
+  #   resources: { }
+  #   nodeSelector: { }
+  #   affinity:
+  #     nodeAffinity: { }
+  #     podAffinity: { }
+  #     podAntiAffinity: { }
+  #   tolerations: [ ]
+  #   annotations: { }
+  #   labels: { }
+  #   audit:
+  #     diskCapacityGB: 1
+  #   ## Postgres setup for LogSearch API
+  #   db:
+  #     image: "" # defaults to library/postgres
+  #     env: [ ]
+  #     initimage: "" # defaults to busybox:1.33.1
+  #     volumeClaimTemplate:
+  #       metadata: { }
+  #       spec:
+  #         storageClassName: standard
+  #         accessModes:
+  #           - ReadWriteOnce
+  #         resources:
+  #           requests:
+  #             storage: 1Gi
+  #     resources: { }
+  #     nodeSelector: { }
+  #     affinity:
+  #       nodeAffinity: { }
+  #       podAffinity: { }
+  #       podAntiAffinity: { }
+  #     tolerations: [ ]
+  #     annotations: { }
+  #     labels: { }
+  #     serviceAccountName: ""
+  #     securityContext:
+  #       runAsUser: 999
+  #       runAsGroup: 999
+  #       runAsNonRoot: true
+  #       fsGroup: 999
+  #   serviceAccountName: ""
+  #   securityContext:
+  #     runAsUser: 1000
+  #     runAsGroup: 1000
+  #     runAsNonRoot: true
+  #     fsGroup: 1000


### PR DESCRIPTION
### Objective:

To deprecate Audit Logs from Kustomization examples as we no longer offer a UI for the edition of these logs:

<img width="1840" alt="Screenshot 2023-01-31 at 11 02 29 AM" src="https://user-images.githubusercontent.com/6667358/215813435-213c778f-928e-4524-9fe0-38b8b69764bf.png">

As per the message:

```
Current Audit logs functionality will be deprecated soon, please refer to the[ documentation ](https://min.io/docs/minio/kubernetes/upstream/operations/monitoring/minio-logging.html)in order to setup an external service for logs
```