### PR TITLE
add delete secret permission to console-sa-role

### DIFF
--- a/helm/operator/templates/console-ui.yaml
+++ b/helm/operator/templates/console-ui.yaml
@@ -29,6 +29,7 @@ rules:
       - list
       - patch
       - update
+      - delete
       - deletecollection
   - apiGroups:
       - ""

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -29,6 +29,7 @@ rules:
       - list
       - patch
       - update
+      - delete
       - deletecollection
   - apiGroups:
       - ""


### PR DESCRIPTION
Console will delete and recreate the tenant -env-configuration secret when OpenID/LDAP credentials are set from the UI.