### PR TITLE
Adding kind configuration for NodePort Testing

### DIFF
--- a/testing/kind-config/kind-config-nodeport.yaml
+++ b/testing/kind-config/kind-config-nodeport.yaml
@@ -1,0 +1,37 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "127.0.0.1"
+  apiServerPort: 6443
+nodes:
+  - role: control-plane
+    extraPortMappings:
+    - containerPort: 30080
+      hostPort: 30080
+      listenAddress: "127.0.0.1"
+      protocol: TCP
+  - role: worker
+    extraPortMappings:
+    - containerPort: 30081
+      hostPort: 30081
+      listenAddress: "127.0.0.1"
+      protocol: TCP
+  - role: worker
+    extraPortMappings:
+    - containerPort: 30082
+      hostPort: 30082
+      listenAddress: "127.0.0.1"
+      protocol: TCP
+  - role: worker
+    extraPortMappings:
+    - containerPort: 30083
+      hostPort: 30083
+      listenAddress: "127.0.0.1"
+      protocol: TCP
+  - role: worker
+    extraPortMappings:
+    - containerPort: 30084
+      hostPort: 30084
+      listenAddress: "127.0.0.1"
+      protocol: TCP
+


### PR DESCRIPTION
### Objective:

To test `NodePort` in our Operator Service, added kind configuration for that.

### Reason:

I have some functions I would like to use with different config:

```sh
     13 function createcluster() {
     14         kind delete cluster
     15         kind create cluster --config ~/operator/testing/kind-config.yaml
     16 }
```