### PR TITLE
Openshift test - install Minio Operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ logsearchapi-bin
 minio.yaml
 nancy
 examples/.DS_Store
-
+testing/openshift/bundle/*

--- a/testing/deploy-openshift-4.sh
+++ b/testing/deploy-openshift-4.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, MinIO, Inc.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+# This script requires: kubectl, kind
+
+SCRIPT_DIR=$(dirname "$0")
+export SCRIPT_DIR
+
+source "${SCRIPT_DIR}/openshift-common.sh"
+
+function main() {
+    
+    install_binaries
+
+    setup_crc
+
+    create_marketplace_catalog
+
+    install_operator
+
+    # install_operator
+    # install_tenant
+    # check_tenant_status tenant-lite storage-lite
+
+    # To allow the execution without killing the cluster at the end of the test
+    # Use below statement to automatically test and kill cluster at the end:
+    # `unset OPERATOR_ENABLE_MANUAL_TESTING`
+    # Use below statement to test and keep cluster alive at the end!:
+    # `export OPERATOR_ENABLE_MANUAL_TESTING="ON"`
+    if [[ -z "${OPERATOR_ENABLE_MANUAL_TESTING}" ]]; then
+        # OPERATOR_ENABLE_MANUAL_TESTING is not defined, hence destroy_kind
+        echo "Cluster will be destroyed for automated testing"
+        destoy_crc
+    else
+        echo -e "\e[33mCluster will remain alive for manual testing\e[0m"
+    fi
+}
+
+main "$@"

--- a/testing/deploy-openshift-4.sh
+++ b/testing/deploy-openshift-4.sh
@@ -26,26 +26,13 @@ function main() {
 
     setup_crc
 
-    create_marketplace_catalog
-
-    install_operator
+    install_operator "certified-operators" # "community-operators", "redhat-marketplace"
 
     # install_operator
     # install_tenant
     # check_tenant_status tenant-lite storage-lite
-
-    # To allow the execution without killing the cluster at the end of the test
-    # Use below statement to automatically test and kill cluster at the end:
-    # `unset OPERATOR_ENABLE_MANUAL_TESTING`
-    # Use below statement to test and keep cluster alive at the end!:
-    # `export OPERATOR_ENABLE_MANUAL_TESTING="ON"`
-    if [[ -z "${OPERATOR_ENABLE_MANUAL_TESTING}" ]]; then
-        # OPERATOR_ENABLE_MANUAL_TESTING is not defined, hence destroy_kind
-        echo "Cluster will be destroyed for automated testing"
-        destoy_crc
-    else
-        echo -e "\e[33mCluster will remain alive for manual testing\e[0m"
-    fi
+    
+    destoy_crc
 }
 
 main "$@"

--- a/testing/deploy-openshift-4.sh
+++ b/testing/deploy-openshift-4.sh
@@ -32,7 +32,7 @@ function main() {
     # install_tenant
     # check_tenant_status tenant-lite storage-lite
     
-    destoy_crc
+    destroy_crc
 }
 
 main "$@"

--- a/testing/deploy-openshift-4.sh
+++ b/testing/deploy-openshift-4.sh
@@ -26,6 +26,8 @@ function main() {
 
     setup_crc
 
+    create_marketplace_catalog "certified-operators"
+
     install_operator "certified-operators" # "community-operators", "redhat-marketplace"
 
     # install_operator

--- a/testing/deploy-openshift-4.sh
+++ b/testing/deploy-openshift-4.sh
@@ -37,4 +37,4 @@ function main() {
     destroy_crc
 }
 
-main "$@"
+time main "$@"

--- a/testing/openshift-common.sh
+++ b/testing/openshift-common.sh
@@ -78,63 +78,104 @@ function setup_crc() {
   crc config set consent-telemetry no
   crc config set skip-check-root-user true
   crc config set kubeadmin-password "crclocal"
-  crc config set cpus 8
   crc setup
   eval $(crc oc-env)
-  eval $(crc oc-podman)
-  crc start -m 20480
-  echo "crc is ready"
+  eval $(crc podman-env)
+  # this creates a symlink "podman" from the "podman-remote", as a hack to solve the a issue with opm: 
+  # opm has hardcoded the command name "podman" causing the index creation to fail
+  # https://github.com/operator-framework/operator-registry/blob/67e6777b5f5f9d337b94da98b8c550c231a8b47c/pkg/containertools/factory_podman.go#L32 
+  ocpath=$(dirname $(which podman-remote))
+  ln -sf $ocpath/podman-remote $ocpath/podman
+  crc start -c 8 -m 20480
   try crc version
 }
 
 function destoy_crc() {
   echo -e "\e[34mdestroy_crc\e[0m"
   setup_path
-  #crc stop
-  #crc delete -f
-  remove_temp_binaries
+
+  # To allow the execution without killing the cluster at the end of the test
+  # Use below statement to automatically test and kill cluster at the end:
+  # `unset OPERATOR_ENABLE_MANUAL_TESTING`
+  # Use below statement to test and keep cluster alive at the end!:
+  # `export OPERATOR_ENABLE_MANUAL_TESTING="ON"`
+  if [[ -z "${OPERATOR_ENABLE_MANUAL_TESTING}" ]]; then
+      # OPERATOR_ENABLE_MANUAL_TESTING is not defined, hence destroy_kind
+      echo "Cluster will be destroyed for automated testing"
+      #crc stop
+      #crc delete -f
+      remove_temp_binaries
+  else
+      echo -e "\e[33mCluster will remain alive for manual testing\e[0m"
+      echo "PATH=$PATH"
+  fi
 }
 
 function create_marketplace_catalog(){
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/openshift-deployment
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
-  echo -e "\e[34mCreate Marketplace catalog\e[0m"
+  # https://operatorhub.io/preview
+  echo "Create Marketplace for catalog '$catalog'"
   setup_path
+  eval $(crc oc-env)
+  eval $(crc podman-env)
+
+  # Obtain catalog
+  catalog="$1"
+  if [ -z "$catalog" ]
+  then
+    die "missing catalog to install"
+  fi
+
+  registry="default-route-openshift-image-registry.apps-crc.testing"
+  operatorNamespace="openshift-operators"
+  marketplaceNamespace="openshift-marketplace"
+  operatorContainerImage="$registry/$operatorNamespace/operator:noop"
+  bundleContainerImage="$registry/$marketplaceNamespace/operator-bundle:noop"
+  indexContainerImage="$registry/$marketplaceNamespace/minio-operator-index:noop"
+  package="minio-operator"
+  if [[ "$catalog" == "redhat-marketplace" ]]
+  then
+    package=minio-operator-rhmp
+  fi
+
   # To compile current branch
-  echo "Compiling Current Branch Operator"
-  (cd "${SCRIPT_DIR}/.." && make operator && make logsearchapi && podman build --quiet --no-cache -t quay.io/minio/operator:noop .)
-  echo "Compiling operator bundle"
-  (cd "${SCRIPT_DIR}/.." && podman build --quiet --no-cache -t quay.io/minio/operator-bundle:noop -f bundle.Dockerfile .)
+  (cd "${SCRIPT_DIR}/.." && make operator && make logsearchapi && podman build --quiet --no-cache -t $operatorContainerImage .)
+  echo "push operator image to crc registry"
+  podman login -u `oc whoami` -p `oc whoami --show-token` $registry/$operatorNamespace --tls-verify=false
+  podman push $operatorContainerImage --tls-verify=false
+  try oc get is -n $operatorNamespace operator
+  oc set image-lookup operator -n $operatorNamespace
+
+  echo "Compiling operator bundle for $catalog"
+  cp -r "${SCRIPT_DIR}/../$catalog/." ${SCRIPT_DIR}/openshift/bundle
+  yq -i ".metadata.annotations.containerImage |= (\"${operatorContainerImage}\")" ${SCRIPT_DIR}/openshift/bundle/manifests/$package.clusterserviceversion.yaml
+  (cd "${SCRIPT_DIR}/.." && podman build --quiet --no-cache -t $bundleContainerImage -f ${SCRIPT_DIR}/openshift/bundle.Dockerfile ${SCRIPT_DIR}/openshift)
 
   echo "login in crc registry"
-  podman login -u `oc whoami` -p `oc whoami --show-token` default-route-openshift-image-registry.apps-crc.testing --tls-verify=false
+  podman login -u `oc whoami` -p `oc whoami --show-token` $registry --tls-verify=false
   
   echo "push bundle to crc registry"
-  podman tag quay.io/minio/operator-index:noop default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop
-  podman push default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop --tls-verify=false
-  oc get is -n openshift-marketplace operator-bundle
-  oc set image-lookup -n openshift-marketplace  operator-bundle
-  
-  echo "push operator image to crc registry"
-  podman login -u `oc whoami` -p `oc whoami --show-token` default-route-openshift-image-registry.apps-crc.testing/openshift-operators --tls-verify=false
-  podman tag quay.io/minio/operator:noop default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator:noop
-  podman push default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator:noop --tls-verify=false
-  oc get is -n openshift-operators operator
-  oc set image-lookup operator -n openshift-operators
+  podman push $bundleContainerImage --tls-verify=false
+  try oc get is -n $marketplaceNamespace operator-bundle
+  oc set image-lookup -n $marketplaceNamespace  operator-bundle
   
   echo "create marketplace index"
-  opm index add --bundles default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop \
-    --tag default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:latest \
-    --skip-tls-verify=true
-  podman push default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:latest --tls-verify=false
-  oc set image-lookup minio-operator-index -n openshift-marketplace
+  opm index add --bundles $bundleContainerImage --tag $indexContainerImage --skip-tls-verify=true
+  podman push $indexContainerImage --tls-verify=false
+  try oc get is -n $marketplaceNamespace minio-operator-index
+  oc set image-lookup -n $marketplaceNamespace minio-operator-index 
   
-  #oc registry login --insecure=true
-  #oc image mirror quay.io/minio/operator-index:latest=default-route-openshift-image-registry.apps-crc.testing/openshift-operators/minio/operator-index:latest --insecure=true
-
   echo "create local marketplace catalog"
   oc apply -f ${SCRIPT_DIR}/openshift/test-operator-catalogsource.yaml
-  oc -n openshift-marketplace get catalogsource minio-test-operators
+  try oc get catalogsource -n $marketplaceNamespace minio-test-operators
+
+  echo "Waiting for marketplace index pod to come online (5m timeout)"
+  try oc wait -n $marketplaceNamespace \
+    --for=condition=Ready pod \
+    -l olm.catalogSource=minio-test-operators \
+    --timeout=300s
+  
   # oc -n openshift-marketplace get pods
   # oc get packagemanifests | grep "Test Minio Operators"
   ## Create a operator group is not needed here because the openshift-operators namespace already have one
@@ -143,25 +184,47 @@ function create_marketplace_catalog(){
 }
 
 function install_operator() {
-  echo -e "\e[34mInstalling Operator from bundle\e[0m"
+
+  echo -e "\e[34mInstalling Operator from catalog '$catalog'\e[0m"
   setup_path
+  eval $(crc oc-env)
+  eval $(crc podman-env)
+
+  # Obtain catalog
+  catalog="$1"
+  if [ -z "$catalog" ]
+  then
+    catalog="certified-operators"
+  fi
+
+  create_marketplace_catalog $catalog
 
   oc apply -f ${SCRIPT_DIR}/openshift/test-subscription.yaml
-  oc get sub -n openshift-operators
-  oc get installplan -n openshift-operators
-  oc get csv -n openshift-operators
+  echo "Subscription:"
+  try oc get sub -n openshift-operators
+  echo "Wait subscription to be ready (10m timeout)"
+  oc wait -n openshift-operators \
+    --for=jsonpath='{.status.state}'=AtLatestKnown subscription\
+    --field-selector metadata.name=$(oc get subscription -n openshift-operators -o json | jq -r '.items[0] | .metadata.name') \
+    --timeout=600s
+  echo "Install plan:"
+  try oc get installplan -n openshift-operators
+  echo "Waiting for install plan to be completed (10m timeout)"
+  oc wait -n openshift-operators \
+    --for=jsonpath='{.status.phase}'=Complete installplan \
+    --field-selector metadata.name=$(oc get installplan -n openshift-operators -o json | jq -r '.items[0] | .metadata.name') \
+    --timeout=600s
+#    --for=condition=Installed installplan \
+  #echo "clusterserviceversion:"
+  #try oc get csv -n openshift-operators minio-operator.noop
 
-  echo "key, value for pod selector in kustomize test"
-  key=name
-  value=minio-operator
-
-  oc -n openshift-operators get deployments
-  oc -n openshift-operators get pods
+  echo "Deployment:"
+  try oc -n openshift-operators get deployment minio-operator
 
   echo "Waiting for Operator Pods to come online (5m timeout)"
   try oc wait -n openshift-operators \
     --for=condition=ready pod \
-    --selector $key=$value \
+    --selector name=minio-operator \
     --timeout=300s
 
   echo "start - get data to verify proper image is being used"

--- a/testing/openshift-common.sh
+++ b/testing/openshift-common.sh
@@ -13,10 +13,11 @@
 # You should have received a copy of the GNU Affero General Public License, version 3,
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-OPERATOR_SDK_VERSION=v1.22.2
+#OPERATOR_SDK_VERSION=v1.22.2
 ARCH=`{ case "$(uname -m)" in "x86_64") echo -n "amd64";; "aarch64") echo -n "arm64";; *) echo -n "$(uname -m)";; esac; }`
 MACHINE="$(uname -m)"
 OS=$(uname | awk '{print tolower($0)}')
+# shellcheck disable=SC2155
 export TMP_BIN_DIR="$(mktemp -d)"
 
 function install_binaries() {

--- a/testing/openshift-common.sh
+++ b/testing/openshift-common.sh
@@ -94,11 +94,11 @@ function destroy_crc() {
 
   # To allow the execution without killing the cluster at the end of the test
   # Use below statement to automatically test and kill cluster at the end:
-  # `unset OPERATOR_ENABLE_MANUAL_TESTING`
+  # `unset OPERATOR_DEV_TEST`
   # Use below statement to test and keep cluster alive at the end!:
-  # `export OPERATOR_ENABLE_MANUAL_TESTING="ON"`
-  if [[ -z "${OPERATOR_ENABLE_MANUAL_TESTING}" ]]; then
-      # OPERATOR_ENABLE_MANUAL_TESTING is not defined, hence destroy_kind
+  # `export OPERATOR_DEV_TEST="ON"`
+  if [[ -z "${OPERATOR_DEV_TEST}" ]]; then
+      # OPERATOR_DEV_TEST is not defined, hence destroy_kind
       echo "Cluster will be destroyed for automated testing"
       crc stop
       crc delete -f

--- a/testing/openshift-common.sh
+++ b/testing/openshift-common.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Copyright (C) 2023, MinIO, Inc.
+#
+# This code is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License, version 3,
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+OPERATOR_SDK_VERSION=v1.22.2
+ARCH=`{ case "$(uname -m)" in "x86_64") echo -n "amd64";; "aarch64") echo -n "arm64";; *) echo -n "$(uname -m)";; esac; }`
+MACHINE="$(uname -m)"
+OS=$(uname | awk '{print tolower($0)}')
+export TMP_BIN_DIR="$(mktemp -d)"
+
+function install_binaries() {
+
+  echo -e "\e[34mInstalling temporal binaries in $TMP_BIN_DIR\e[0m"
+  
+  echo "kubectl"
+  curl -#L "https://dl.k8s.io/release/v1.23.1/bin/$OS/$ARCH/kubectl" -o $TMP_BIN_DIR/kubectl
+  chmod +x $TMP_BIN_DIR/kubectl
+
+  echo "mc"
+  curl -#L "https://dl.min.io/client/mc/release/${OS}-${ARCH}/mc" -o $TMP_BIN_DIR/mc
+  chmod +x $TMP_BIN_DIR/mc
+
+  echo "yq"
+  curl -#L "https://github.com/mikefarah/yq/releases/latest/download/yq_${OS}_${ARCH}" -o $TMP_BIN_DIR/yq
+  chmod +x $TMP_BIN_DIR/yq
+
+  # latest kubectl and oc
+  # curl -#L "https://mirror.openshift.com/pub/openshift-v4/$MACHINE/clients/ocp/stable/openshift-client-$OS.tar.gz" -o $TMP_BIN_DIR/openshift-client-$OS.tar.gz
+  # tar -zxvf openshift-client-$OS.tar.gz
+
+  echo "opm"
+  curl -#L "https://mirror.openshift.com/pub/openshift-v4/$MACHINE/clients/ocp/stable/opm-$OS.tar.gz" -o $TMP_BIN_DIR/opm-$OS.tar.gz
+  tar -zxf $TMP_BIN_DIR/opm-$OS.tar.gz -C $TMP_BIN_DIR/
+  chmod +x $TMP_BIN_DIR/opm
+
+  echo "crc"
+  curl -#L "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/crc-$OS-$ARCH.tar.xz" -o $TMP_BIN_DIR/crc-$OS-$ARCH.tar.xz
+  tar -xJf $TMP_BIN_DIR/crc-$OS-$ARCH.tar.xz -C $TMP_BIN_DIR/ --strip-components=1
+  chmod +x $TMP_BIN_DIR/crc
+
+  echo "operator-sdk"
+  curl -#L "https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/operator-sdk_${OS}_${ARCH}" -o ${TMP_BIN_DIR}/operator-sdk
+  chmod +x $TMP_BIN_DIR/operator-sdk
+}
+
+function setup_path(){
+  export PATH="$TMP_BIN_DIR:$PATH"
+}
+
+function remove_temp_binaries() {
+  echo -e "\e[34mRemoving temporary binaries in: $TMP_BIN_DIR\e[0m"
+  rm -rf $TMP_BIN_DIR
+}
+
+yell() { echo "$0: $*" >&2; }
+
+die() {
+  yell "$*"
+  destroy_crc && exit 111
+}
+
+try() { "$@" || die "cannot $*"; }
+
+function setup_crc() {
+  echo -e "\e[34mConfiguring crc\e[0m"
+  setup_path
+  crc config set consent-telemetry no
+  crc config set skip-check-root-user true
+  crc config set kubeadmin-password "crclocal"
+  crc config set cpus 8
+  crc setup
+  eval $(crc oc-env)
+  eval $(crc oc-podman)
+  crc start -m 20480
+  echo "crc is ready"
+  try crc version
+}
+
+function destoy_crc() {
+  echo -e "\e[34mdestroy_crc\e[0m"
+  setup_path
+  #crc stop
+  #crc delete -f
+  remove_temp_binaries
+}
+
+function create_marketplace_catalog(){
+
+  echo -e "\e[34mCreate Marketplace catalog\e[0m"
+  # To compile current branch
+  echo "Compiling Current Branch Operator"
+  (cd "${SCRIPT_DIR}/.." && make operator && make logsearchapi && podman build --no-cache -t quay.io/minio/operator:noop .)
+ echo "Compiling operator bundle"
+  # Compile bundle image https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
+  podman build --no-cache -t quay.io/minio/operator-bundle:noop -f openshift/bundle.Dockerfile .
+
+  echo "Installing Current Operator"
+  # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/openshift-deployment
+
+  #login in crc registry
+  podman login -u `oc whoami` -p `oc whoami --show-token` default-route-openshift-image-registry.apps-crc.testing --tls-verify=false
+  
+  # create and push test marketplace listing to crc registry
+  podman tag quay.io/minio/operator-index:noop default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop
+  podman push default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop --tls-verify=false
+  oc set image-lookup operator-bundle -n openshift-marketplace
+  opm index add --bundles default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop \
+    --tag default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:latest \
+    --skip-tls-verify=true
+  podman push default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:latest --tls-verify=false
+  oc set image-lookup minio-operator-index -n openshift-marketplace
+  
+  #push operator image to crc registry
+  podman tag quay.io/minio/operator:noop default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator:noop
+  podman push default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator:noop --tls-verify=false
+  oc get is -n openshift-operators
+  oc set image-lookup operator -n openshift-operators
+  #oc registry login --insecure=true
+  #oc image mirror quay.io/minio/operator-index:latest=default-route-openshift-image-registry.apps-crc.testing/openshift-operators/minio/operator-index:latest --insecure=true
+
+  #create local marketplace listing
+  oc apply -f ./openshift/test-operator-catalogsource.yaml
+  # oc -n openshift-marketplace get catalogsource minio-test-operators
+  # oc -n openshift-marketplace get pods
+  # oc get packagemanifests | grep "Test Minio Operators"
+  ## Create a operator group is not needed here because the openshift-operators namespace already have one
+  # oc create -f ./openshift/test-operatorgroup.yaml
+  # oc get og -n openshift-operators
+}
+
+function install_operator() {
+  echo -e "\e[34mInstalling Operator from bundle\e[0m"
+
+  oc apply -f ./openshift/test-subscription.yaml
+  oc get sub -n openshift-operators
+  oc get installplan -n openshift-operators
+  oc get csv -n openshift-operators
+
+  echo "key, value for pod selector in kustomize test"
+  key=name
+  value=minio-operator
+
+  oc -n openshift-operators get deployments
+  oc -n openshift-operators get pods
+
+  echo "Waiting for Operator Pods to come online (5m timeout)"
+  try oc wait -n openshift-operators \
+    --for=condition=ready pod \
+    --selector $key=$value \
+    --timeout=300s
+
+  echo "start - get data to verify proper image is being used"
+  oc get pods --namespace openshift-operators
+  oc describe pods -n openshift-operators | grep Image
+  echo "end - get data to verify proper image is being used"
+}

--- a/testing/openshift/bundle.Dockerfile
+++ b/testing/openshift/bundle.Dockerfile
@@ -1,5 +1,7 @@
 FROM scratch
 
+ARG CATALOG
+
 # Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -8,5 +10,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=minio-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 
 # Copy files to locations specified by labels.
-COPY ../../community-operators/manifests /manifests/
-COPY ../../community-operators/metadata /metadata/
+COPY bundles/${CATALOG}/manifests /manifests/
+COPY bundles/${CATALOG}/metadata /metadata/

--- a/testing/openshift/bundle.Dockerfile
+++ b/testing/openshift/bundle.Dockerfile
@@ -10,5 +10,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=minio-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 
 # Copy files to locations specified by labels.
-COPY bundles/${CATALOG}/manifests /manifests/
-COPY bundles/${CATALOG}/metadata /metadata/
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/

--- a/testing/openshift/bundle.Dockerfile
+++ b/testing/openshift/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=minio-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+
+# Copy files to locations specified by labels.
+COPY ../../community-operators/manifests /manifests/
+COPY ../../community-operators/metadata /metadata/

--- a/testing/openshift/bundle.Dockerfile
+++ b/testing/openshift/bundle.Dockerfile
@@ -6,7 +6,7 @@ ARG CATALOG
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=minio-operator
+LABEL operators.operatorframework.io.bundle.package.v1=minio-operator-noop
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 
 # Copy files to locations specified by labels.

--- a/testing/openshift/tenant/kustomization.yaml
+++ b/testing/openshift/tenant/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../examples/kustomization/tenant-lite
+
+patchesStrategicMerge:
+  - tenant.yaml
+

--- a/testing/openshift/tenant/tenant.yaml
+++ b/testing/openshift/tenant/tenant.yaml
@@ -1,0 +1,8 @@
+apiVersion: minio.min.io/v2
+kind: Tenant
+metadata:
+  name: storage
+  namespace: minio-tenant
+spec:
+  log:
+    image: quay.io/minio/operator:noop

--- a/testing/openshift/test-operator-catalogsource.yaml
+++ b/testing/openshift/test-operator-catalogsource.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: minio-test-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:latest
+  displayName: Test Minio Operators
+  publisher: MinIO
+  updateStrategy:
+    registryPoll:
+      interval: 5m

--- a/testing/openshift/test-operator-catalogsource.yaml
+++ b/testing/openshift/test-operator-catalogsource.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:latest
+  image: default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:noop
   displayName: Test Minio Operators
   publisher: MinIO
   updateStrategy:

--- a/testing/openshift/test-operatorgroup.yaml
+++ b/testing/openshift/test-operatorgroup.yaml
@@ -1,8 +1,0 @@
-apiVersion: operators.coreos.com/v1alpha2
-kind: OperatorGroup
-metadata:
-  name: minio-group
-  namespace: openshift-operators
-spec:
-  targetNamespaces:
-    - openshift-operators

--- a/testing/openshift/test-operatorgroup.yaml
+++ b/testing/openshift/test-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: minio-group
+  namespace: openshift-operators
+spec:
+  targetNamespaces:
+    - openshift-operators

--- a/testing/openshift/test-subscription.yaml
+++ b/testing/openshift/test-subscription.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   channel: stable
   installPlanApproval: Automatic
-  name: minio-operator
+  name: minio-operator-noop
   source: minio-test-operators
   sourceNamespace: openshift-marketplace

--- a/testing/openshift/test-subscription.yaml
+++ b/testing/openshift/test-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: test-subscription
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: minio-operator
+  source: minio-test-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
### Objective:

To test the install of `Minio Operator` in Openshift.
This first iteration tests "community-operators" catalog, expecting to extend it to the other 2 catalogs (redhat-marketplace, certified-operators)

### Reason:

We need to ensure that introduced changes to Operator do not break the Openshift deployment installs, at least fresh clean installs should be flawless.

### Environment:

This test is by far not going to be able to be ran in a github action as to run `crc` expectos 20gb of ram and 12 cores.
The test run expects that no install of `crc` or `podman` are present in the running host.

## !!WARNING:

* The test  downloads the binaries and creates a symlink of the `podman` command, if the running host already has a `podman` binary in $PATH, it could be overwrited by the symlink  

* The test considers the boot and delete of the crc virtual machine, make sure of backup your `~/.crc/cache` dir, OR setup the environment variable `export OPERATOR_ENABLE_MANUAL_TESTING=ON` to prevent the virtual machine deletion.

* The test breaks if  `catalogsource` or `subscription` resources used by the test exists in the Openshift cluster, make sure to either delete them or backup your `crc` vm and start with a fresh`crc` vm on each test (*prefered*).  
  
### How It looks:
```sh
> ./testing/deploy-openshift-4.sh 
Installing temporal binaries in /tmp/tmp.oCqAM0Iztd
yq
#################################################################################################################################################################################### 100.0%
opm
#################################################################################################################################################################################### 100.0%
crc
#################################################################################################################################################################################### 100.0%
Configuring crc
Successfully configured consent-telemetry to no
Successfully configured skip-check-root-user to true
Successfully configured kubeadmin-password to #######
INFO Using bundle path /home/pedro/.crc/cache/crc_libvirt_4.12.0_amd64.crcbundle 
INFO Checking if running as non-root              
WARN Skipping above check...                      
INFO Checking if running inside WSL2              
INFO Checking if crc-admin-helper executable is cached 
INFO Checking for obsolete admin-helper executable 
INFO Checking if running on a supported CPU architecture 
INFO Checking minimum RAM requirements            
INFO Checking if crc executable symlink exists    
INFO Creating symlink for crc executable          
INFO Checking if Virtualization is enabled        
INFO Checking if KVM is enabled                   
INFO Checking if libvirt is installed             
INFO Checking if user is part of libvirt group    
INFO Checking if active user/process is currently part of the libvirt group 
INFO Checking if libvirt daemon is running        
INFO Checking if a supported libvirt version is installed 
INFO Checking if crc-driver-libvirt is installed  
INFO Checking crc daemon systemd service          
INFO Checking crc daemon systemd socket units     
INFO Checking if AppArmor is configured           
INFO Checking if systemd-networkd is running      
INFO Checking if NetworkManager is installed      
INFO Checking if NetworkManager service is running 
INFO Checking if dnsmasq configurations file exist for NetworkManager 
INFO Checking if the systemd-resolved service is running 
INFO Checking if /etc/NetworkManager/dispatcher.d/99-crc.sh exists 
INFO Checking if libvirt 'crc' network is available 
INFO Checking if libvirt 'crc' network is active  
INFO Checking if CRC bundle is extracted in '$HOME/.crc' 
INFO Checking if /home/pedro/.crc/cache/crc_libvirt_4.12.0_amd64.crcbundle exists 
Your system is correctly setup for using CRC. Use 'crc start' to start the instance
INFO Checking if running as non-root              
WARN Skipping above check...                      
INFO Checking if running inside WSL2              
INFO Checking if crc-admin-helper executable is cached 
INFO Checking for obsolete admin-helper executable 
INFO Checking if running on a supported CPU architecture 
INFO Checking minimum RAM requirements            
INFO Checking if crc executable symlink exists    
INFO Checking if Virtualization is enabled        
INFO Checking if KVM is enabled                   
INFO Checking if libvirt is installed             
INFO Checking if user is part of libvirt group    
INFO Checking if active user/process is currently part of the libvirt group 
INFO Checking if libvirt daemon is running        
INFO Checking if a supported libvirt version is installed 
INFO Checking if crc-driver-libvirt is installed  
INFO Checking crc daemon systemd socket units     
INFO Checking if AppArmor is configured           
INFO Checking if systemd-networkd is running      
INFO Checking if NetworkManager is installed      
INFO Checking if NetworkManager service is running 
INFO Checking if dnsmasq configurations file exist for NetworkManager 
INFO Checking if the systemd-resolved service is running 
INFO Checking if /etc/NetworkManager/dispatcher.d/99-crc.sh exists 
INFO Checking if libvirt 'crc' network is available 
INFO Checking if libvirt 'crc' network is active  
INFO Loading bundle: crc_libvirt_4.12.0_amd64...  
INFO Starting CRC VM for openshift 4.12.0...      
INFO CRC instance is running with IP 192.168.130.11 
INFO CRC VM is running                            
INFO Configuring shared directories               
INFO Check internal and public DNS query...       
INFO Check DNS query from host...                 
WARN Wildcard DNS resolution for apps-crc.testing does not appear to be working 
INFO Verifying validity of the kubelet certificates... 
INFO Starting kubelet service                     
INFO Waiting for kube-apiserver availability... [takes around 2min] 
INFO Waiting for user's pull secret part of instance disk... 
INFO Overriding password for kubeadmin user       
INFO Starting openshift instance... [waiting for the cluster to stabilize] 
INFO 8 operators are progressing: dns, image-registry, ingress, kube-storage-version-migrator, network, ... 
INFO 8 operators are progressing: dns, image-registry, ingress, kube-storage-version-migrator, network, ... 
INFO 6 operators are progressing: image-registry, ingress, kube-storage-version-migrator, network, openshift-controller-manager, ... 
INFO 6 operators are progressing: image-registry, ingress, kube-storage-version-migrator, network, openshift-controller-manager, ... 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 5 operators are progressing: image-registry, kube-storage-version-migrator, network, openshift-controller-manager, service-ca 
INFO 4 operators are progressing: image-registry, kube-storage-version-migrator, openshift-controller-manager, service-ca 
INFO Operator image-registry is progressing       
INFO All operators are available. Ensuring stability... 
INFO Operators are stable (2/3)...                
INFO Operators are stable (3/3)...                
INFO Adding crc-admin and crc-developer contexts to kubeconfig... 
Started the OpenShift cluster.

The server is accessible via web console at:
  https://console-openshift-console.apps-crc.testing

Log in as administrator:
  Username: kubeadmin
  Password: #####

Log in as user:
  Username: developer
  Password: developer

Use the 'oc' command line interface:
  $ eval $(crc oc-env)
  $ oc login -u developer https://api.crc.testing:6443
CRC version: 2.13.1+3b466f8
OpenShift version: 4.12.0
Podman version: 4.3.1
Waiting for podman vm come online (5m timeout)
REPOSITORY  TAG         IMAGE ID    CREATED     SIZE
Create Marketplace for catalog 'certified-operators'
Compiling operator in current branch
Checking dependencies
Installing golangci-lint
Installing govulncheck
?   	github.com/minio/operator	[no test files]
?   	github.com/minio/operator/pkg/apis/minio.min.io	[no test files]
?   	github.com/minio/operator/pkg/apis/minio.min.io/v1	[no test files]
ok  	github.com/minio/operator/pkg/apis/minio.min.io/v2	(cached)
?   	github.com/minio/operator/pkg/client/clientset/versioned	[no test files]
?   	github.com/minio/operator/pkg/client/clientset/versioned/fake	[no test files]
?   	github.com/minio/operator/pkg/client/clientset/versioned/scheme	[no test files]
?   	github.com/minio/operator/pkg/client/clientset/versioned/typed/minio.min.io/v2	[no test files]
?   	github.com/minio/operator/pkg/client/clientset/versioned/typed/minio.min.io/v2/fake	[no test files]
?   	github.com/minio/operator/pkg/client/informers/externalversions	[no test files]
?   	github.com/minio/operator/pkg/client/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/minio/operator/pkg/client/informers/externalversions/minio.min.io	[no test files]
?   	github.com/minio/operator/pkg/client/informers/externalversions/minio.min.io/v2	[no test files]
?   	github.com/minio/operator/pkg/client/listers/minio.min.io/v2	[no test files]
ok  	github.com/minio/operator/pkg/controller/cluster	(cached)
?   	github.com/minio/operator/pkg/controller/cluster/certificates	[no test files]
ok  	github.com/minio/operator/pkg/resources/configmaps	(cached)
?   	github.com/minio/operator/pkg/resources/deployments	[no test files]
?   	github.com/minio/operator/pkg/resources/secrets	[no test files]
?   	github.com/minio/operator/pkg/resources/services	[no test files]
ok  	github.com/minio/operator/pkg/resources/statefulsets	(cached)
?   	github.com/minio/operator/resources	[no test files]
?   	github.com/minio/operator/subnet	[no test files]
Running lint check
Checking dependencies
Installing golangci-lint
Installing govulncheck
Building 'logsearchapi' binary
?   	github.com/minio/operator/logsearchapi	[no test files]
ok  	github.com/minio/operator/logsearchapi/server	(cached)
e6d019c454d89908693d9535810e9a2dd07817aa50f0d7b84d7a496f7cd1574e
push operator image to crc registry
Login Succeeded!
Image Stream for operator:
NAME       IMAGE REPOSITORY                                                                       TAGS   UPDATED
operator   default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator   noop   Less than a second ago
imagestream.image.openshift.io/operator image lookup updated
Compiling operator bundle for certified-operators
15e1867cc70d73af37c6ea0fa1ef3904a6d6844b7bc874f7e4519226f7cb8259
Login Succeeded!
push operator-bundle to crc registry
Image Stream for operator-bundle
NAME              IMAGE REPOSITORY                                                                                TAGS   UPDATED
operator-bundle   default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle   noop   Less than a second ago
imagestream.image.openshift.io/operator-bundle image lookup updated
Compiling marketplace index
WARN[0000] DEPRECATION NOTICE:
Sqlite-based catalogs and their related subcommands are deprecated. Support for
them will be removed in a future release. Please migrate your catalog workflows
to the new file-based catalog format. 
INFO[0000] building the index                            bundles="[default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop]"
INFO[0000] Could not find optional dependencies file     file=bundle_tmp724898037/metadata load=annotations with=./bundle_tmp724898037
INFO[0000] Could not find optional properties file       file=bundle_tmp724898037/metadata load=annotations with=./bundle_tmp724898037
INFO[0000] Could not find optional dependencies file     file=bundle_tmp724898037/metadata load=annotations with=./bundle_tmp724898037
INFO[0000] Could not find optional properties file       file=bundle_tmp724898037/metadata load=annotations with=./bundle_tmp724898037
INFO[0000] Generating dockerfile                         bundles="[default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop]"
INFO[0000] writing dockerfile: ./index.Dockerfile2935531590  bundles="[default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop]"
INFO[0000] running podman build                          bundles="[default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop]"
INFO[0000] [podman build --format docker -f ./index.Dockerfile2935531590 -t default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/minio-operator-index:noop .]  bundles="[default-route-openshift-image-registry.apps-crc.testing/openshift-marketplace/operator-bundle:noop]"
push minio-operator-index to crc registry
Image Stream for minio-operator-index
imagestream.image.openshift.io/minio-operator-index image lookup updated
Wait for ImageStream minio-operator-index to be local available
imagestream.image.openshift.io/minio-operator-index condition met
Create 'Test Minio Operators' marketplace catalog source
catalogsource.operators.coreos.com/minio-test-operators created
Catalog Source:
NAME                   DISPLAY                TYPE   PUBLISHER   AGE
minio-test-operators   Test Minio Operators   grpc   MinIO       5s
deleting pod minio-test-operators-gvqds -n openshift-marketplace
pod "minio-test-operators-gvqds" deleted
Waiting for Package manifest to be ready (5m timeout)
.............minio-operator-noop                                Test Minio Operators   20s
Installing Operator from catalog 'certified-operators'
subscription.operators.coreos.com/test-subscription created
Subscription:
NAME                PACKAGE               SOURCE                 CHANNEL
test-subscription   minio-operator-noop   minio-test-operators   stable
Wait subscription to be ready (10m timeout)
subscription.operators.coreos.com/test-subscription condition met
Install plan:
NAME            CSV                     APPROVAL    APPROVED
install-krz6s   minio-operator.v4.5.8   Automatic   true
Waiting for install plan to be completed (10m timeout)
installplan.operators.coreos.com/install-krz6s condition met
Deployment:
NAME             READY   UP-TO-DATE   AVAILABLE   AGE
minio-operator   0/2     2            0           1s
Waiting for Operator Deployment to come online (5m timeout)
deployment.apps/minio-operator condition met
start - get data to verify proper image is being used
Pods:
NAME                              READY   STATUS    RESTARTS   AGE
console-5b47cd945f-nxpq5          1/1     Running   0          20s
minio-operator-5df7b8b7c9-hnrbm   1/1     Running   0          20s
Images:
                  containerImage: default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator:noop
    Image:         quay.io/minio/console@sha256:9827b3b7c89d5b809aa8b90233fd6802711e664aeba87288488255a012ba9d28
    Image ID:      quay.io/minio/console@sha256:7a985a1b8d2b8eb33c8e1fac3ebb736f54f0f68d7d34c0650ed0aad41ffbe698
                  containerImage: default-route-openshift-image-registry.apps-crc.testing/openshift-operators/operator:noop
    Image:          quay.io/minio/operator:v4.5.8
    Image ID:       quay.io/minio/operator@sha256:104e88ec29994c4cc59763e55c41def855ad852f76afb2edffa7758e5791ba6b
destroy_crc
Cluster will be destroyed for automated testing
INFO Stopping kubelet and all containers...       
INFO Stopping the instance, this may take a few minutes... 
Stopped the instance
Deleted the instance
Removing temporary binaries in: /tmp/tmp.oCqAM0Iztd

real	11m12.584s
user	1m49.586s
sys	0m11.620s
```