### PR TITLE
remove v1 reference in Marketplace templates

### DIFF
--- a/resources/templates/olm-template.yaml
+++ b/resources/templates/olm-template.yaml
@@ -15,9 +15,6 @@ spec:
     owned:
       - kind: Tenant
         name: tenants.minio.min.io
-        version: v1
-      - kind: Tenant
-        name: tenants.minio.min.io
         version: v2
   keywords:
     - S3


### PR DESCRIPTION
Tenant v1 [was removed](https://github.com/minio/operator/pull/1428) along with webhook, the olm template is missing to reflect that