### PR TITLE
OpenShift: Create secret to trust the signer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ getdeps:
 
 verify: getdeps govet gotest lint
 
-operator:
-	@CGO_ENABLED=0 GOOS=linux go build -trimpath -o minio-operator
+operator: verify
+	@CGO_ENABLED=0 GOOS=linux go build -trimpath --ldflags $(LDFLAGS) -o minio-operator
 
 docker: operator logsearchapi
-	@docker build --no-cache -t minio/operator:v4.5.9 .
+	@docker build --no-cache -t $(TAG) .
 
 build: regen-crd verify plugin logsearchapi operator docker
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ getdeps:
 
 verify: getdeps govet gotest lint
 
-operator: verify
-	@CGO_ENABLED=0 GOOS=linux go build -trimpath --ldflags $(LDFLAGS) -o minio-operator
+operator:
+	@CGO_ENABLED=0 GOOS=linux go build -trimpath -o minio-operator
 
 docker: operator logsearchapi
-	@docker build --no-cache -t $(TAG) .
+	@docker build --no-cache -t minio/operator:v4.5.9 .
 
 build: regen-crd verify plugin logsearchapi operator docker
 

--- a/pkg/controller/cluster/main-controller.go
+++ b/pkg/controller/cluster/main-controller.go
@@ -430,6 +430,12 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 			go wait.Until(c.runWorker, time.Second, stopCh)
 		}
 
+		// I want to get the csr-signer secret to mount the certificate in Operator Pod to trust the tenant in OpenShift!
+		// oc get secret csr-signer -n openshift-kube-controller-manager-operator -o template='{{ index .data "tls.crt"}}' | base64 -d
+		klog.Info("Checking if this is OpenShift Environment...")
+		var myKubeSecret = kubernetes.V1().Secrets("openshift-kube-controller-manager-operator").Find("csr-signer")
+		klog.Infof("myKubeSecret: %s", myKubeSecret)
+
 		// Launch a single worker for Health Check reacting to Pod Changes
 		go wait.Until(c.runHealthCheckWorker, time.Second, stopCh)
 


### PR DESCRIPTION
### Objective:

I want to create a secret under minio-operator namespace that we can mount in the Operator Pod to trust the signer in OpenShift Environment and avoid TLS Issue.

This is the first part of the fix, we just create the secret here and we still need to manually mount it. In my next PR if this gets merged, I can mount it over the Deployment to complete the automation for process below.

### Manual process:

https://github.com/minio/wiki/wiki/MinIO-in-OpenShift