### PR TITLE
fix: release version typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ As an alternative to `krew`, you can download the `kubectl-minio` plugin from th
 For example, the following code downloads the latest stable version of the MinIO Kubernetes Plugin and installs it to the system ``$PATH``. The example assumes a Linux operating system:
 
 ```sh
-wget -qO- https://github.com/minio/operator/releases/latest/download/kubectl-minio_linux_amd64.zip | sudo bsdtar -xvf- -C /usr/local/bin
+wget -qO- https://github.com/minio/operator/releases/latest/download/kubectl-minio_linux_amd64_v1.zip | sudo bsdtar -xvf- -C /usr/local/bin
 sudo chmod +x /usr/local/bin/kubectl-minio
 ```
 


### PR DESCRIPTION
# FIX release version typo
There is an release version typo error about `kubectl-minio_linux_amd64.zip`.

#### Reference Image 1
<img width="864" alt="image" src="https://user-images.githubusercontent.com/68190553/219026878-6e84b562-aafb-4e45-b84a-1211b4116041.png">

#### Reference Image 2
<img width="909" alt="image" src="https://user-images.githubusercontent.com/68190553/219026823-2dcc3876-56db-4bd6-af1a-64b8f48c93e7.png">

---

## BEFORE
```
wget -qO- https://github.com/minio/operator/releases/latest/download/kubectl-minio_linux_amd64_v1.zip | sudo bsdtar -xvf- -C /usr/local/bin
sudo chmod +x /usr/local/bin/kubectl-minio
```

## AFTER
```
wget -qO- https://github.com/minio/operator/releases/latest/download/kubectl-minio_linux_amd64.zip | sudo bsdtar -xvf- -C /usr/local/bin
sudo chmod +x /usr/local/bin/kubectl-minio
```