### PR TITLE
OpenShift: Trust Signer by mounting a secret

### DIFF
--- a/pkg/openshift/.gitignore
+++ b/pkg/openshift/.gitignore
@@ -1,0 +1,1 @@
+create-secret

--- a/pkg/openshift/Dockerfile
+++ b/pkg/openshift/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+
+ARG TAG
+
+RUN \
+    microdnf update --nodocs && \
+    microdnf install curl ca-certificates shadow-utils --nodocs
+
+COPY create-secret /create-secret
+
+CMD ["/create-secret"]

--- a/pkg/openshift/Makefile
+++ b/pkg/openshift/Makefile
@@ -1,0 +1,20 @@
+GOARCH := $(shell go env GOARCH)
+GOOS := $(shell go env GOOS)
+
+operator-job-linux-amd64:
+	@echo "operator-job-linux-amd64"
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build create-secret.go
+
+operator-job-linux-arm64:
+	@echo "operator-job-linux-amd64"
+	@CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build create-secret.go
+
+docker-mac:
+	@docker build -t minio/operator-job:v4.5.9 .
+	@docker tag docker.io/minio/operator-job:v4.5.9 quay.io/cniackz4/operator-job:v4.5.9
+	@docker push quay.io/cniackz4/operator-job:v4.5.9
+
+docker-linux-amd64:
+	@docker buildx build --platform linux/amd64 --tag minio/operator-job:v4.5.9 .
+	@docker tag docker.io/minio/operator-job:v4.5.9 quay.io/cniackz4/operator-job:v4.5.9
+	@docker push quay.io/cniackz4/operator-job:v4.5.9

--- a/pkg/openshift/create-secret.go
+++ b/pkg/openshift/create-secret.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+var (
+	masterURL  string
+	kubeconfig string
+)
+
+// GetNSFromFile assumes the operator is running inside a k8s pod and extract the
+// current namespace from the /var/run/secrets/kubernetes.io/serviceaccount/namespace file
+func GetNSFromFile() string {
+	namespace, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "minio-operator"
+	}
+	return string(namespace)
+}
+
+func init() {
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "path to a kubeconfig. Only required if out-of-cluster")
+}
+
+func main() {
+	fmt.Println("Look for incluster config by default")
+	cfg, err := rest.InClusterConfig()
+	// If config is passed as a flag use that instead
+	if kubeconfig != "" {
+		cfg, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("Error building Kubernetes clientset: %s", err.Error())
+	}
+
+	ctx := context.TODO()
+	secret, err := kubeClient.CoreV1().Secrets("openshift-kube-controller-manager-operator").Get(
+		ctx, "csr-signer", metav1.GetOptions{})
+	klog.Info("Checking if this is OpenShift Environment...")
+	if err != nil {
+		klog.Errorf("failed to get secret: %#v", err)
+		if k8serrors.IsNotFound(err) {
+			// Do nothing special, because this is maybe k8s vanilla
+			klog.Info("This is NOT OpenShift because csr-signer secret was NOT found")
+		}
+	} else {
+		// Do something special, create the secret to trust the tenant spec.
+		klog.Info("This is OpenShift because csr-signer secret was found")
+		cpData := *&secret.Data
+		var tlsCrt []byte
+		for k, v := range cpData {
+			if k == "tls.crt" {
+				tlsCrt = v
+			}
+		}
+		// To get minio-operator namespace without hardcoding the value in case
+		// it comes from OperatorHub I think...
+		namespace := GetNSFromFile()
+		newSecret := &corev1.Secret{
+			Type: "Opaque",
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "minio-operator-openshift-signer",
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"tls.crt": tlsCrt,
+			},
+		}
+		_, err := kubeClient.CoreV1().Secrets(namespace).Create(
+			ctx, newSecret, metav1.CreateOptions{})
+		if err != nil {
+			klog.Errorf("failed to create secret: %#v", err)
+		}
+	}
+}

--- a/resources/base/cluster-role-binding.yaml
+++ b/resources/base/cluster-role-binding.yaml
@@ -10,3 +10,16 @@ subjects:
   - kind: ServiceAccount
     name: minio-operator
     namespace: default
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: role-binding-cesar-5
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccount:minio-operator:default'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/resources/base/job.yaml
+++ b/resources/base/job.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openshift-secret
+  namespace: minio-operator
+spec:
+  selector: {}
+  template:
+    metadata:
+      name: openshift-secret
+    spec:
+      containers:
+        - name: openshift-secret
+          image: quay.io/cniackz4/operator-job:v4.5.9
+          imagePullPolicy: Always
+      restartPolicy: Never

--- a/resources/kustomization.yaml
+++ b/resources/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - base/service.yaml
   - base/deployment.yaml
   - base/console-ui.yaml
+  - base/job.yaml


### PR DESCRIPTION
### Objective:

Have a Kubernetes Job that will create the Secret to Trust the Signer in OpenShift.

### Tested locally:

1. Got the Operator Yamls `kustomize build ~/operator/ > minio-operator-v4-5-8.yaml`
2. Deployed Operator on Top of OpenShift Cluster
3. Verified Job created secret: `minio-operator-openshift-signer`

<img width="1796" alt="Screenshot 2023-02-15 at 1 36 36 PM" src="https://user-images.githubusercontent.com/6667358/219121609-c410b515-1616-46d2-9e40-75131e47fac3.png">


