### PR TITLE
No need to scale down

### DIFF
--- a/testing/common.sh
+++ b/testing/common.sh
@@ -88,9 +88,6 @@ function install_operator() {
     value=minio-operator
   fi
 
-  echo "Scaling down MinIO Operator Deployment"
-  try kubectl -n minio-operator scale deployment minio-operator --replicas=1
-
   # Reusing the wait for both, Kustomize and Helm
   echo "Waiting for k8s api"
   sleep 10


### PR DESCRIPTION
### Objective:

To make our test more reliable!.

### Story:

build-floor test is getting stuck after the scale down since pod is not terminated in 2 min, we either help with the termination of the pod, wait for longer, deploy just one pod since the beginning or just avoid scaling down but test is not stable and is prone to failures:

```sh
Scaling down MinIO Operator Deployment
deployment.apps/minio-operator scaled
Waiting for k8s api
NAME                 STATUS   AGE
default              Active   9m47s
kube-node-lease      Active   9m49s
kube-public          Active   9m49s
kube-system          Active   9m49s
local-path-storage   Active   9m44s
minio-operator       Active   11s
NAME             READY   UP-TO-DATE   AVAILABLE   AGE
console          1/1     1            1           11s
minio-operator   1/1     1            1           11s
NAME                              READY   STATUS        RESTARTS   AGE
console-77c9fbb7dd-jm5sl          1/1     Running       0          10s
minio-operator-5f499f98df-pvsvs   1/1     Running       0          10s
minio-operator-5f499f98df-zx5xr   0/1     Terminating   0          10s
Waiting for Operator Pods to come online (2m timeout)
pod/console-77c9fbb7dd-jm5sl condition met
pod/minio-operator-5f499f98df-pvsvs condition met
error: timed out waiting for the condition on pods/minio-operator-5f499f98df-zx5xr
/home/runner/work/operator/operator/testing/check-helm.sh: cannot kubectl wait --namespace minio-operator --for=condition=ready pod --selector app.kubernetes.io/name=operator --timeout=120s
Deleting cluster "kind" ...
Error: Process completed with exit code 111.
##[debug]Finishing: Deploy a MinIO Tenant on Kind
```