### PR TITLE
Fix console pod is not starting in tests

### DIFF
--- a/testing/dev/console-deployment.yaml
+++ b/testing/dev/console-deployment.yaml
@@ -1,0 +1,12 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console
+  namespace: minio-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: console
+          image: minio/operator:noop

--- a/testing/dev/kustomization.yaml
+++ b/testing/dev/kustomization.yaml
@@ -5,4 +5,5 @@ bases:
   - ../../resources
 
 patchesStrategicMerge:
+  - console-deployment.yaml
   - deployment.yaml


### PR DESCRIPTION
In the operator tests under `/testing/` the console pod do not start, that is because is trying to use the latest operator release v4.5.8
https://github.com/minio/operator/blob/f6c9c8bad7ca7f9d4c0f228e2bfe79abd23c0ccd/resources/base/console-ui.yaml#L315
This is to use the local built operator docker image for console instead of latest released operator container