### PR TITLE
Fixed typos in Add Tenant Images screen

### DIFF
--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/Images.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/Images.tsx
@@ -152,7 +152,7 @@ const Images = ({ classes }: IImagesProps) => {
           value: prometheusVolumeSize,
           customValidation:
             prometheusVolumeSize === "" || parseInt(prometheusVolumeSize) <= 0,
-          customValidationMessage: `Volume size must be present and be greatter than 0`,
+          customValidationMessage: `Volume size must be present and be greater than 0`,
         },
       ];
     }
@@ -172,7 +172,7 @@ const Images = ({ classes }: IImagesProps) => {
           value: logSearchVolumeSize,
           customValidation:
             logSearchVolumeSize === "" || parseInt(logSearchVolumeSize) <= 0,
-          customValidationMessage: `Volume size must be present and be greatter than 0`,
+          customValidationMessage: `Volume size must be present and be greater than 0`,
         },
       ];
     }
@@ -308,7 +308,7 @@ const Images = ({ classes }: IImagesProps) => {
       <div className={classes.headerElement}>
         <H3Section>Container Images</H3Section>
         <span className={classes.descriptionText}>
-          Specify the container images used by the Tenant and it's features.
+          Specify the container images used by the Tenant and its features.
         </span>
       </div>
 


### PR DESCRIPTION
Small text fixes on Add Tenants/Images screen
<img width="1202" alt="Screen Shot 2023-03-07 at 11 38 40 AM" src="https://user-images.githubusercontent.com/65002498/223534315-9ac0fb21-3880-4476-ace0-d9d81f3d25f9.png">
