### PR TITLE
refactor goroutines handling

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,8 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Set up swagger
         run: |
-          download_url=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | \
-            jq -r '.assets[] | select(.name | contains("'"$(uname | tr '[:upper:]' '[:lower:]')"'_amd64")) | .browser_download_url')
+          download_url="https://github.com/go-swagger/go-swagger/releases/download/v0.30.4/swagger_linux_amd64"
           curl -o /usr/local/bin/swagger -L'#' "$download_url"
           chmod +x /usr/local/bin/swagger
       - name: Run GoReleaser

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ minio.yaml
 nancy
 examples/.DS_Store
 testing/openshift/bundle/*
+examples/**/obj/

--- a/helm/operator/templates/operator-service.yaml
+++ b/helm/operator/templates/operator-service.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 4222
-      name: https
+    - port: 4221
+      name: http
   selector:
     operator: leader
     {{- include "minio-operator.selectorLabels" . | nindent 4 }}
@@ -22,7 +22,7 @@ metadata:
   labels:
     {{- include "minio-operator.labels" . | nindent 4 }}
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 4223
       name: https

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -19,6 +19,7 @@ package common
 // Constants for the webhook endpoints
 const (
 	WebhookAPIVersion       = "/webhook/v1"
+	UpgradeServerPort       = "4221"
 	WebhookDefaultPort      = "4222"
 	WebhookAPIBucketService = WebhookAPIVersion + "/bucketsrv"
 )

--- a/pkg/controller/cluster/webhook.go
+++ b/pkg/controller/cluster/webhook.go
@@ -34,27 +34,7 @@ func configureHTTPUpgradeServer() *http.Server {
 	router.NotFoundHandler = http.NotFoundHandler()
 
 	s := &http.Server{
-		Addr:           ":4221",
-		Handler:        router,
-		ReadTimeout:    time.Minute,
-		WriteTimeout:   time.Minute,
-		MaxHeaderBytes: 1 << 20,
-	}
-
-	return s
-}
-
-func configureWebhookServer() *http.Server {
-	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
-
-	router.Methods(http.MethodGet).
-		PathPrefix(miniov2.WebhookAPIUpdate).
-		Handler(http.StripPrefix(miniov2.WebhookAPIUpdate, http.FileServer(http.Dir(updatePath))))
-
-	router.NotFoundHandler = http.NotFoundHandler()
-
-	s := &http.Server{
-		Addr:           ":" + common.WebhookDefaultPort,
+		Addr:           ":" + common.UpgradeServerPort,
 		Handler:        router,
 		ReadTimeout:    time.Minute,
 		WriteTimeout:   time.Minute,

--- a/resources/base/service.yaml
+++ b/resources/base/service.yaml
@@ -13,8 +13,6 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 4222
-      name: https
     - port: 4221
       name: http
   selector:


### PR DESCRIPTION
## Motivation

1) MinIO Operator was not validating the webservers (~~webhook~~, upgrade and sts) state after they start, if for some reason a webserver go routine stoped, we would not notice it.

2) The web servers were not exiting gracefully on SIGTERM

3) the `leaderelection.RunOrDie` were not exiting gracefully, on the `OnStoppedLeading: func()` we had an abrupt os.Exit(0) not allowing the `mainController.Stop()` to be invoked ever.

4) remove webhook server that ran on TLS, no longer needed

also a bit of not related changes:
* adding to .gitignore the files under the `obj/*` dotnet sts example client temporary files
* fixing the issue with swagger: When many builds are running frequently,  calls to the Github API `https://api.github.com/repos/go-swagger/go-swagger/releases/latest` would result in a throttle and a false negative of the check `goreleaser` failing, changing it to be a fixed version instead to workaround that situation.

