### PR TITLE
[DO NOT MERGE] add creationTimestamp property to VolumeClaimTemplate

### DIFF
--- a/timestampPatch/ct-patch.yaml
+++ b/timestampPatch/ct-patch.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/pools/items/properties/volumeClaimTemplate/properties/metadata/properties/creationTimestamp
+  value:
+    type: string
+- op: add
+  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/log/properties/db/properties/volumeClaimTemplate/properties/metadata/properties/creationTimestamp
+  value:
+    type: string
+- op: add
+  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/sideCars/properties/volumes/items/properties/ephemeral/properties/volumeClaimTemplate/properties/metadata/properties/creationTimestamp
+  value:
+    type: string

--- a/timestampPatch/kustomization.yaml
+++ b/timestampPatch/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github.com/minio/operator/resources/base?ref=v4.5.8
+
+patchesJson6902:
+- path: ct-patch.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: tenants.minio.min.io


### PR DESCRIPTION
Patch to add `creationTimestamp` property to the VolumeClaimTemplate objects.
This is not an ideal solution, only a workaround to keep the Operator logs clear, would probably need to merge it if the proper solution (applyconfiguration client) is not ready by the next Operator release.

Woraround for https://github.com/minio/operator/issues/1388