### PR TITLE
fix release command

### DIFF
--- a/api/consts.go
+++ b/api/consts.go
@@ -32,7 +32,7 @@ const (
 
 	// Image versions
 
-	KESImageVersion = "minio/kes:v0.17.6"
+	KESImageVersion = "minio/kes:v0.18.0"
 
 	// Constants for common configuration
 	MinioImage         = "OPERATOR_MINIO_IMAGE"

--- a/docs/policybinding_crd.adoc
+++ b/docs/policybinding_crd.adoc
@@ -6,9 +6,6 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2023-01-12T02-06-16Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.18.0]
-:prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
-:logsearch-image: https://hub.docker.com/r/minio/operator/tags[minio/operator:v4.5.8]
-:postgres-image: https://github.com/docker-library/postgres[library/postgres]
 
 
 [id="{anchor_prefix}-sts-min-io-v1alpha1"]

--- a/docs/templates/asciidoctor/gv_list.tpl
+++ b/docs/templates/asciidoctor/gv_list.tpl
@@ -9,9 +9,6 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2023-01-12T02-06-16Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.18.0]
-:prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
-:logsearch-image: https://hub.docker.com/r/minio/operator/tags[minio/operator:v4.5.8]
-:postgres-image: https://github.com/docker-library/postgres[library/postgres]
 
 {{ range $groupVersions }}
 {{ template "gvDetails" . }}

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -6,9 +6,6 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2023-01-12T02-06-16Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:v0.18.0]
-:prometheus-image: https://quay.io/prometheus/prometheus:latest[prometheus/prometheus:latest]
-:logsearch-image: https://hub.docker.com/r/minio/operator/tags[minio/operator:v4.5.8]
-:postgres-image: https://github.com/docker-library/postgres[library/postgres]
 
 
 [id="{anchor_prefix}-minio-min-io-v2"]

--- a/examples/kustomization/tenant-certmanager-kes/tenant.yaml
+++ b/examples/kustomization/tenant-certmanager-kes/tenant.yaml
@@ -14,7 +14,7 @@ spec:
     externalCertSecret:
       name: tenant-certmanager-2-tls
       type: cert-manager.io/v1
-    image: minio/kes:v0.17.6
+    image: minio/kes:v0.18.0
     imagePullPolicy: IfNotPresent
     kesSecret:
       name: kes-configuration

--- a/release.sh
+++ b/release.sh
@@ -9,20 +9,40 @@ get_latest_release() {
 }
 
 MINIO_RELEASE=$(get_latest_release minio/minio)
-CONSOLE_RELEASE=$(get_latest_release minio/console)
-CONSOLE_RELEASE="${CONSOLE_RELEASE:1}"
+KES_RELEASE=$(get_latest_release minio/kes)
 
-# Figure out the FROM console release we are updating from
-CONSOLE_CURRENT_RELEASE=$(grep -Eo 'minio\/console:v([0-9]?[0-9].[0-9]?[0-9].[0-9]?[0-9])' resources/base/console-ui.yaml | grep -Eo '([0-9]?[0-9].[0-9]?[0-9].[0-9]?[0-9])')
+KES_CURRENT_RELEASE=$(sed -nr 's/.*(minio\/kes\:)([v]?.*)"/\2/p' pkg/apis/minio.min.io/v2/constants.go)
 
-files=("docs/tenant_crd.adoc" "docs/policybinding_crd.adoc" "docs/templates/asciidoctor/gv_list.tpl" "examples/kustomization/base/tenant.yaml" "helm/operator/Chart.yaml" "helm/operator/values.yaml" "helm/tenant/Chart.yaml" "helm/tenant/values.yaml" "kubectl-minio/README.md" "kubectl-minio/cmd/helpers/constants.go" "kubectl-minio/cmd/tenant-upgrade.go" "pkg/apis/minio.min.io/v2/constants.go" "resources/base/deployment.yaml" "update-operator-krew.py" "resources/base/console-ui.yaml")
+files=(
+  "api/consts.go"
+  "docs/tenant_crd.adoc"
+  "docs/policybinding_crd.adoc"
+  "docs/templates/asciidoctor/gv_list.tpl"
+  "examples/kustomization/base/tenant.yaml"
+  "examples/kustomization/tenant-certmanager-kes/tenant.yaml"
+  "examples/kustomization/tenant-kes-encryption/tenant.yaml"
+  "helm/operator/Chart.yaml"
+  "helm/operator/values.yaml"
+  "helm/tenant/Chart.yaml"
+  "helm/tenant/values.yaml"
+  "kubectl-minio/README.md"
+  "kubectl-minio/cmd/helpers/constants.go"
+  "kubectl-minio/cmd/tenant-upgrade.go"
+  "pkg/apis/minio.min.io/v2/constants.go"
+  "pkg/controller/operator.go"
+  "resources/base/deployment.yaml"
+  "resources/base/console-ui.yaml"
+  "update-operator-krew.py"
+  "testing/console-tenant+kes.sh"
+  "web-app/src/screens/Console/Tenants/AddTenant/Steps/Images.tsx"
+  "web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx")
 
 CURRENT_RELEASE=$(get_latest_release minio/operator)
 CURRENT_RELEASE="${CURRENT_RELEASE:1}"
 
 echo "MinIO: $MINIO_RELEASE"
 echo "Upgrade: $CURRENT_RELEASE => $RELEASE"
-echo "Console: $CONSOLE_CURRENT_RELEASE => $CONSOLE_RELEASE"
+echo "KES: $KES_CURRENT_RELEASE => $KES_RELEASE"
 
 if [ -z "$MINIO_RELEASE" ]; then
   echo "\$MINIO_RELEASE is empty"
@@ -32,7 +52,7 @@ fi
 for file in "${files[@]}"; do
   sed -i -e "s/${CURRENT_RELEASE}/${RELEASE}/g" "$file"
   sed -i -e "s/RELEASE\.[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9]Z/${MINIO_RELEASE}/g" "$file"
-  sed -i -e "s/${CONSOLE_CURRENT_RELEASE}/${CONSOLE_RELEASE}/g" "$file"
+  sed -i -e "s/${KES_CURRENT_RELEASE}/${KES_RELEASE}/g" "$file"
 done
 
 echo "Re-indexing helm chart releases for $RELEASE"

--- a/testing/console-tenant+kes.sh
+++ b/testing/console-tenant+kes.sh
@@ -113,7 +113,7 @@ function test_kes_tenant() {
 	sed -i -e 's/ROLE_ID/'"$ROLE_ID"'/g' "${SCRIPT_DIR}/kes-config.yaml"
 	sed -i -e 's/SECRET_ID/'"$SECRET_ID"'/g' "${SCRIPT_DIR}/kes-config.yaml"
 	cp "${SCRIPT_DIR}/kes-config.yaml" "${SCRIPT_DIR}/../examples/kustomization/tenant-kes-encryption/kes-configuration-secret.yaml"
-	yq e -i '.spec.kes.image = "minio/kes:v0.22.3"' "${SCRIPT_DIR}/../examples/kustomization/tenant-kes-encryption/tenant.yaml"
+	yq e -i '.spec.kes.image = "minio/kes:v0.18.0"' "${SCRIPT_DIR}/../examples/kustomization/tenant-kes-encryption/tenant.yaml"
 	kubectl apply -k "${SCRIPT_DIR}/../examples/kustomization/tenant-kes-encryption"
 
     echo "Check Tenant Status in tenant-kms-encrypted namespace for myminio:"

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/Images.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/Images.tsx
@@ -195,7 +195,7 @@ const Images = ({ classes }: IImagesProps) => {
             label="KES"
             value={kesImage}
             error={validationErrors["kesImage"] || ""}
-            placeholder="minio/kes:v0.17.6"
+            placeholder="minio/kes:v0.18.0"
           />
         </Grid>
       </Fragment>

--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx
@@ -1601,7 +1601,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
                   setImage(e.target.value)
                 }
                 label="Image"
-                placeholder="minio/kes:v0.17.6"
+                placeholder="minio/kes:v0.18.0"
                 value={image}
               />
             </Grid>


### PR DESCRIPTION
After the latest changes `VERSION=1.2.3 make release` command was not working, fixing it:
* Removed the search for console image, we no longer ship Operator console as an independent image, Operator console is now part of operator binary
* Now Updating the KES image version when creating an Operator release
* Removed references in adocs for prometheus, logsearch and postgres docker images.

Once this PR  + https://github.com/minio/operator/pull/1511 are merged will contine with fix olm.sh to generate Openshift releases as well.
