### PR TITLE
Stop tests to execute for hours when they are stuck

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   goreleaser:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -7,6 +7,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   shellcheck:
+    timeout-minutes: 30
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +24,7 @@ jobs:
           curl -L -o nancy https://github.com/sonatype-nexus-community/nancy/releases/download/${nancy_version}/nancy-${nancy_version}-linux-amd64 && chmod +x nancy
           go list -deps -json ./... | jq -s 'unique_by(.Module.Path)|.[]|select(has("Module"))|.Module' | ./nancy sleuth
   lint:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -38,6 +40,7 @@ jobs:
         run: |
           make lint
   govet:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -53,6 +56,7 @@ jobs:
         run: |
           make govet
   vulnerable-dependencies-checks:
+    timeout-minutes: 30
     name: "Check for vulnerable dependencies"
     runs-on: ubuntu-latest
     strategy:
@@ -73,6 +77,7 @@ jobs:
         run: govulncheck ./...
         shell: bash
   gotest:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     needs:
       - lint
@@ -92,6 +97,7 @@ jobs:
         run: |
           make gotest
   operator:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     needs:
       - lint
@@ -118,6 +124,7 @@ jobs:
         run: |
           make operator
   test-tenant:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     needs:
       - operator
@@ -141,6 +148,7 @@ jobs:
         run: |
           "${GITHUB_WORKSPACE}/testing/deploy-tenant.sh"
   test-tenant-upgrade:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     needs:
       - operator
@@ -164,6 +172,7 @@ jobs:
         run: |
           "${GITHUB_WORKSPACE}/testing/deploy-tenant-upgrade.sh"
   test-kes:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     needs:
       - operator
@@ -188,6 +197,7 @@ jobs:
           "${GITHUB_WORKSPACE}/testing/console-tenant+kes.sh"
 
   test-policy-binding:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     needs:
       - operator
@@ -211,6 +221,7 @@ jobs:
           "${GITHUB_WORKSPACE}/testing/test-policy-binding.sh"
 
   helm:
+    timeout-minutes: 30
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     needs:
@@ -241,6 +252,7 @@ jobs:
           mv kubectl /usr/local/bin
           "${GITHUB_WORKSPACE}/testing/check-helm.sh"
   helm-floor:
+    timeout-minutes: 30
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     needs:

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
 
   semgrep-static-code-analysis:
+    timeout-minutes: 30
     name: "semgrep checks"
     runs-on: ubuntu-latest
     strategy:
@@ -36,6 +37,7 @@ jobs:
 
 
   ui-assets:
+    timeout-minutes: 30
     name: "React No Warnings & Prettified"
     runs-on: ubuntu-latest
     strategy:
@@ -76,6 +78,7 @@ jobs:
         run: |
           ./check-prettier.sh
   reuse-golang-dependencies:
+    timeout-minutes: 30
     name: reuse golang dependencies
     runs-on: ubuntu-latest
     strategy:
@@ -99,6 +102,7 @@ jobs:
           go mod download
 
   compile-binary:
+    timeout-minutes: 30
     name: Compiles on Go ${{ matrix.go-version }} and ${{ matrix.os }}
     needs:
       - ui-assets
@@ -142,6 +146,7 @@ jobs:
   
   
   react-code-known-vulnerabilities:
+    timeout-minutes: 30
     name: "React No Known Vulnerable Deps"
     needs:
       - ui-assets
@@ -165,6 +170,7 @@ jobs:
           yarn audit  
 
   all-operator-tests-1:
+    timeout-minutes: 30
     name: Operator UI Tests Part 1
     needs:
       - compile-binary
@@ -201,6 +207,7 @@ jobs:
         with:
           args: '"chrome:headless" web-app/tests/operator/login --skip-js-errors -c 3'
   all-operator-tests-2:
+    timeout-minutes: 30
     name: Operator UI Tests Part 2
     needs:
       - compile-binary
@@ -238,6 +245,7 @@ jobs:
           args: '"chrome:headless" web-app/tests/operator/tenant/test-1 --skip-js-errors -c 3'
 
   test-operatorapi-on-go:
+    timeout-minutes: 30
     name: Test Operatorapi on Go ${{ matrix.go-version }} and ${{ matrix.os }}
     needs:
       - ui-assets
@@ -275,6 +283,7 @@ jobs:
             ./api/coverage/
           key: ${{ runner.os }}-coverage-unittest-operatorapi-2-${{ github.run_id }}
   react-tests:
+    timeout-minutes: 30
     name: React Tests
     needs:
       - ui-assets
@@ -290,6 +299,7 @@ jobs:
         working-directory: ./web-app
         run: yarn test
   c-operator-api-tests:
+    timeout-minutes: 30
 
     name: Operator API Tests
     needs:
@@ -330,6 +340,7 @@ jobs:
             ./operator-integration/coverage/
           key: ${{ runner.os }}-coverage-2-operator-${{ github.run_id }}
   coverage:
+    timeout-minutes: 30
     name: "Coverage Limit Check"
     needs:
       - test-operatorapi-on-go


### PR DESCRIPTION
### Objective:

To stop tests to run for hours when they are stuck

### User Story:

I have seen lately that even setup go action can fail and last for hours, we shouldn't allow this to happen and instead stop those test after 30 minutes or so.

### Evidence:

* https://github.com/minio/operator/actions/runs/4524643468/jobs/7968671601?pr=1522

```
cancelled yesterday in 6h 0m 0s
```

<img width="1840" alt="Screenshot 2023-03-27 at 2 15 03 PM" src="https://user-images.githubusercontent.com/6667358/228030299-fdd7f1af-ef34-4b18-95fb-042ae079da9f.png">
