### PR TITLE
Fix use of UI in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ RUN \
     microdnf install curl ca-certificates shadow-utils --nodocs
 
 COPY minio-operator /minio-operator
+COPY web-app/build /build
 
 ENTRYPOINT ["/minio-operator"]


### PR DESCRIPTION
UI needs static assets to be in the container. During the creation, the assets are created but not copied.

This commit fix the issue.

it will fix #1528.