### PR TITLE
Fixing issue due to missing tenant being removed

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -782,8 +782,11 @@ func (c *Controller) syncHandler(key string) error {
 
 	// Custom certificates
 	if customCertificates, err := c.getCustomCertificates(ctx, tenant); err == nil {
-		if tenant, err = c.updateCustomCertificatesStatus(ctx, tenant, customCertificates); err != nil {
+		if newTenant, err := c.updateCustomCertificatesStatus(ctx, tenant, customCertificates); err != nil {
 			klog.V(2).Infof(err.Error())
+		} else {
+			// Only change tenant if there was no error, otherwise tenant is being deleted
+			tenant = newTenant
 		}
 	} else {
 		klog.V(2).Infof(err.Error())


### PR DESCRIPTION
### Objective:

To fix issue:

```
E0403 10:03:24.437181       1 main-controller.go:666] error syncing 'speed9-tenant/speed9-tenant': an empty namespace may not be set when a resource name is provided
```

### Root Cause:

In PR https://github.com/minio/operator/pull/1438 we introduced a new feature which during upgrade is wiping out our `tenant` causing this issue due to missing namespace needed from the `tenant` that was wipped out already at this point. 

### Solution provided:

If we need to change `tenant`, let's change it only after it has been observed there is no error coming from the certificate function added here; otherwise `tenant` object is empty and no namespace can be obtained.