### PR TITLE
Removing duplicated string from registry

### DIFF
--- a/olm-post-script.sh
+++ b/olm-post-script.sh
@@ -39,7 +39,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # Console Image in Digested form: sha256:xxxx
   consoleImage=$(yq eval-all '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml)
   echo "consoleImage: ${consoleImage}"
-  consoleImageDigest=$(docker pull "quay.io/"${consoleImage} | grep Digest | awk -F ' ' '{print $2}')
+  consoleImageDigest=$(docker pull ${consoleImage} | grep Digest | awk -F ' ' '{print $2}')
   echo "consoleImageDigest: ${consoleImageDigest}"
   consoleImageDigest="quay.io/minio/console@${consoleImageDigest}"
   yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= (\"${consoleImageDigest}\")" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml


### PR DESCRIPTION
### Objective:

Upgrade OperatorHub Version in the Catalogs.

### Issue:

Currently post script is facing this problem:

```
Error response from daemon: repository quay.io/quay.io/minio/operator not found: name unknown: repository not found
consoleImageDigest: 
```

### Root cause:

Notice the duplicated `quay.io/quay.io` we should have once only.

### Result with this change:

```
$ source olm-post-script.sh 
minioVersionInExample: quay.io/minio/minio:RELEASE.2023-03-24T21-41-23Z
minioVersionDigest: quay.io/minio/minio@sha256:ac727c1d3d54dda5dddb687f7304ece600237792e01a73d134e129e3c5c26dae
 
certified-operators
package: minio-operator
containerImage: quay.io/minio/operator:v5.0.2
operatorImageDigest: quay.io/minio/operator@sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb @ sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
consoleImage: quay.io/minio/operator:v5.0.2
consoleImageDigest: sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
 
redhat-marketplace
package: minio-operator-rhmp
containerImage: quay.io/minio/operator:v5.0.2
operatorImageDigest: quay.io/minio/operator@sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb @ sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
consoleImage: quay.io/minio/operator:v5.0.2
consoleImageDigest: sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
 
community-operators
package: minio-operator
containerImage: quay.io/minio/operator:v5.0.2
operatorImageDigest: quay.io/minio/operator@sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb @ sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
consoleImage: quay.io/minio/operator:v5.0.2
consoleImageDigest: sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
```

>

```
$ git diff bundles/certified-operators/5.0.2/manifests/minio-operator.clusterserviceversion.yaml
diff --git a/bundles/certified-operators/5.0.2/manifests/minio-operator.clusterserviceversion.yaml b/bundles/certified-operators/5.0.2/manifests/minio-operator.clusterserviceversion.yaml
index 61248ade..ae89ffc2 100644
--- a/bundles/certified-operators/5.0.2/manifests/minio-operator.clusterserviceversion.yaml
+++ b/bundles/certified-operators/5.0.2/manifests/minio-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: "Full Lifecycle"
     operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.operatorframework.io/project_layout: unknown
-    containerImage: quay.io/minio/operator:v5.0.2
+    containerImage: quay.io/minio/operator@sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
     categories: "AI/Machine Learning, Big Data, Cloud Provider, Storage"
     description: |-
       MinIO is a Kubernetes-native high performance object store with an
@@ -470,7 +470,7 @@ spec:
                   - args:
                       - ui
                       - --certs-dir=/tmp/certs
-                    image: quay.io/minio/operator:v5.0.2
+                    image: quay.io/minio/console@sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
                     imagePullPolicy: IfNotPresent
                     name: console
                     ports:
@@ -540,7 +540,7 @@ spec:
                         value: "off"
                       - name: OPERATOR_STS_ENABLED
                         value: "off"
-                    image: quay.io/minio/operator:v5.0.2
+                    image: quay.io/minio/operator@sha256:407355dd4e403efa12b426212707aba3048071a5a3acd144f542e882be731edb
                     imagePullPolicy: IfNotPresent
                     name: minio-operator
                     resources:
```

At the end we need digested form to pass tests in OLM certification from RedHat.