### PR TITLE
Allow Operator Create the namespace for the tenant

### DIFF
--- a/helm/operator/templates/cluster-role.yaml
+++ b/helm/operator/templates/cluster-role.yaml
@@ -24,6 +24,7 @@ rules:
       - namespaces
       - nodes
     verbs:
+      - create
       - get
       - watch
       - list


### PR DESCRIPTION
### Objective:

Allow Operator to create the namespace of the tenant, we are observing below message when trying to create the namespace via UI, we installed the Operator with Helm:

```
Namespaces is forbidden: User "system:serviceaccount:minio-operator:default" cannot create resource "namespaces" in API group "" at the cluster scope
```

<img width="1840" alt="Screenshot 2023-04-04 at 9 34 56 AM" src="https://user-images.githubusercontent.com/6667358/229809791-56856ef3-a45a-4182-87de-32668b73a164.png">
