### PR TITLE
Put under the MINIO_OPERATOR_RUNTIME the Openshit csr-signer addition

### DIFF
--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -24,3 +24,17 @@ const (
 	WebhookAPIBucketService = WebhookAPIVersion + "/bucketsrv"
 	WebhookAPIUpdate        = WebhookAPIVersion + "/update"
 )
+
+const (
+	// OperatorRuntimeK8s is the default runtime when no specific runtime is set
+	OperatorRuntimeK8s Runtime = "k8s"
+	// OperatorRuntimeEKS is the EKS runtime flag
+	OperatorRuntimeEKS Runtime = "EKS"
+	// OperatorRuntimeOpenshift is the Openshift runtime flag
+	OperatorRuntimeOpenshift Runtime = "OPENSHIFT"
+	// OperatorRuntimeRancher is the Rancher runtime flag
+	OperatorRuntimeRancher Runtime = "RANCHER"
+)
+
+// Runtime type to for Operator runtime
+type Runtime string

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -38,5 +38,13 @@ const (
 	OperatorRuntimeRancher Runtime = "RANCHER"
 )
 
+// Runtimes is a map of the supported Kubernetes runtimes
+var Runtimes = map[string]Runtime{
+	"K8S":       OperatorRuntimeK8s,
+	"EKS":       OperatorRuntimeK8s,
+	"OPENSHIFT": OperatorRuntimeOpenshift,
+	"RANCHER":   OperatorRuntimeRancher,
+}
+
 // Runtime type to for Operator runtime
 type Runtime string

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -29,7 +29,7 @@ const (
 	// OperatorRuntimeEnv tells us which runtime we have. (EKS, Rancher, OpenShift, etc...)
 	OperatorRuntimeEnv = "MINIO_OPERATOR_RUNTIME"
 	// OperatorRuntimeK8s is the default runtime when no specific runtime is set
-	OperatorRuntimeK8s Runtime = "k8s"
+	OperatorRuntimeK8s Runtime = "K8S"
 	// OperatorRuntimeEKS is the EKS runtime flag
 	OperatorRuntimeEKS Runtime = "EKS"
 	// OperatorRuntimeOpenshift is the Openshift runtime flag

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -26,6 +26,8 @@ const (
 )
 
 const (
+	// OperatorRuntimeEnv tells us which runtime we have. (EKS, Rancher, OpenShift, etc...)
+	OperatorRuntimeEnv = "MINIO_OPERATOR_RUNTIME"
 	// OperatorRuntimeK8s is the default runtime when no specific runtime is set
 	OperatorRuntimeK8s Runtime = "k8s"
 	// OperatorRuntimeEKS is the EKS runtime flag

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -41,7 +41,7 @@ const (
 // Runtimes is a map of the supported Kubernetes runtimes
 var Runtimes = map[string]Runtime{
 	"K8S":       OperatorRuntimeK8s,
-	"EKS":       OperatorRuntimeK8s,
+	"EKS":       OperatorRuntimeEKS,
 	"OPENSHIFT": OperatorRuntimeOpenshift,
 	"RANCHER":   OperatorRuntimeRancher,
 }

--- a/pkg/controller/certificates/csr.go
+++ b/pkg/controller/certificates/csr.go
@@ -16,6 +16,7 @@ package certificates
 
 import (
 	"context"
+	"github.com/minio/operator/pkg/common"
 	"github.com/minio/operator/pkg/controller"
 	"os"
 	"strings"
@@ -111,7 +112,7 @@ func GetCSRSignerName(clientSet kubernetes.Interface) string {
 		// get certificates using their CSRSignerName https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html
 		if GetCertificatesAPIVersion(clientSet) == CSRV1 {
 			// if the user specified the EKS runtime, no need to do the check
-			if controller.GetOperatorRuntime() == controller.OperatorRuntimeEKS {
+			if controller.GetOperatorRuntime() == common.OperatorRuntimeEKS {
 				csrSignerName = EKSCsrSignerName
 				return
 			}

--- a/pkg/controller/certificates/csr.go
+++ b/pkg/controller/certificates/csr.go
@@ -16,6 +16,7 @@ package certificates
 
 import (
 	"context"
+	"github.com/minio/operator/pkg/controller"
 	"os"
 	"strings"
 	"sync"
@@ -30,8 +31,6 @@ import (
 const (
 	// OperatorCertificatesVersion is the ENV var to force the certificates api version to use.
 	OperatorCertificatesVersion = "MINIO_OPERATOR_CERTIFICATES_VERSION"
-	// OperatorRuntime tells us which runtime we have. (EKS, Rancher, OpenShift, etc...)
-	OperatorRuntime = "MINIO_OPERATOR_RUNTIME"
 	// CSRSignerName is the name to use for the CSR Signer, will override the default
 	CSRSignerName = "MINIO_OPERATOR_CSR_SIGNER_NAME"
 	// EKSCsrSignerName is the signer we should use on EKS after version 1.22
@@ -112,7 +111,7 @@ func GetCSRSignerName(clientSet kubernetes.Interface) string {
 		// get certificates using their CSRSignerName https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html
 		if GetCertificatesAPIVersion(clientSet) == CSRV1 {
 			// if the user specified the EKS runtime, no need to do the check
-			if os.Getenv(OperatorRuntime) == "EKS" {
+			if controller.GetOperatorRuntime() == controller.OperatorRuntimeEKS {
 				csrSignerName = EKSCsrSignerName
 				return
 			}

--- a/pkg/controller/certificates/csr.go
+++ b/pkg/controller/certificates/csr.go
@@ -16,11 +16,12 @@ package certificates
 
 import (
 	"context"
-	"github.com/minio/operator/pkg/common"
-	"github.com/minio/operator/pkg/controller"
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/minio/operator/pkg/common"
+	"github.com/minio/operator/pkg/utils"
 
 	certificatesV1 "k8s.io/api/certificates/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -112,7 +113,7 @@ func GetCSRSignerName(clientSet kubernetes.Interface) string {
 		// get certificates using their CSRSignerName https://docs.aws.amazon.com/eks/latest/userguide/cert-signing.html
 		if GetCertificatesAPIVersion(clientSet) == CSRV1 {
 			// if the user specified the EKS runtime, no need to do the check
-			if controller.GetOperatorRuntime() == common.OperatorRuntimeEKS {
+			if utils.GetOperatorRuntime() == common.OperatorRuntimeEKS {
 				csrSignerName = EKSCsrSignerName
 				return
 			}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"crypto/tls"
+	"github.com/minio/operator/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,20 +53,6 @@ const (
 	// DefaultOperatorImage is the version fo the operator being used
 	DefaultOperatorImage = "minio/operator:v5.0.6"
 )
-
-const (
-	// OperatorRuntimeK8s is the default runtime when no specific runtime is set
-	OperatorRuntimeK8s Runtime = "k8s"
-	// OperatorRuntimeEKS is the EKS runtime flag
-	OperatorRuntimeEKS Runtime = "EKS"
-	// OperatorRuntimeOpenshift is the Openshift runtime flag
-	OperatorRuntimeOpenshift Runtime = "OPENSHIFT"
-	// OperatorRuntimeRancher is the Rancher runtime flag
-	OperatorRuntimeRancher Runtime = "RANCHER"
-)
-
-// Runtime type to for Operator runtime
-type Runtime string
 
 var serverCertsManager *xcerts.Manager
 
@@ -127,7 +114,7 @@ func (c *Controller) getTransport() *http.Transport {
 
 	// These chunk of code is intended for OpenShift ONLY and it will help us trust the signer to solve issue:
 	// https://github.com/minio/operator/issues/1412
-	if GetOperatorRuntime() == OperatorRuntimeOpenshift {
+	if GetOperatorRuntime() == common.OperatorRuntimeOpenshift {
 		openShiftCATLSCert, err := c.kubeClientSet.CoreV1().Secrets("openshift-kube-controller-manager-operator").Get(
 			context.Background(), "csr-signer", metav1.GetOptions{})
 		klog.Info("Checking if this is OpenShift Environment to append the certificates...")
@@ -257,22 +244,22 @@ func getOperatorDeploymentName() string {
 
 func GetOperatorRuntime() Runtime {
 	envString := os.Getenv(OperatorRuntimeEnv)
-	runtimeReturn := OperatorRuntimeK8s
+	runtimeReturn := common.OperatorRuntimeK8s
 	if envString != "" {
 		envString = strings.TrimSpace(envString)
 		envString = strings.ToUpper(envString)
 		switch envString {
-		case string(OperatorRuntimeEKS):
-			runtimeReturn = OperatorRuntimeEKS
+		case string(common.OperatorRuntimeEKS):
+			runtimeReturn = common.OperatorRuntimeEKS
 			break
-		case string(OperatorRuntimeOpenshift):
-			runtimeReturn = OperatorRuntimeEKS
+		case string(common.OperatorRuntimeOpenshift):
+			runtimeReturn = common.OperatorRuntimeEKS
 			break
-		case string(OperatorRuntimeRancher):
-			runtimeReturn = OperatorRuntimeRancher
+		case string(common.OperatorRuntimeRancher):
+			runtimeReturn = common.OperatorRuntimeRancher
 			break
 		default:
-			runtimeReturn = OperatorRuntimeK8s
+			runtimeReturn = common.OperatorRuntimeK8s
 		}
 	}
 	return runtimeReturn

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/minio/operator/pkg/common"
@@ -239,5 +238,5 @@ func (c *Controller) createBuckets(ctx context.Context, tenant *miniov2.Tenant, 
 
 // getOperatorDeploymentName Internal func returns the Operator deployment name from MINIO_OPERATOR_DEPLOYMENT_NAME ENV variable or the default name
 func getOperatorDeploymentName() string {
-	return strings.ToUpper(env.Get(OperatorDeploymentNameEnv, DefaultDeploymentName))
+	return env.Get(OperatorDeploymentNameEnv, DefaultDeploymentName)
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -19,16 +19,17 @@ package controller
 import (
 	"context"
 	"crypto/tls"
-	"net"
-	"net/http"
-	"time"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	xcerts "github.com/minio/pkg/certs"
@@ -40,8 +41,10 @@ import (
 const (
 	// CertPasswordEnv Env variable is used to decrypt the private key in the TLS certificate for operator if need it
 	CertPasswordEnv = "OPERATOR_CERT_PASSWD"
-	// OperatorDeplymentNameEnv Env variable to specify a custom deployment name for Operator
-	OperatorDeplymentNameEnv = "MINIO_OPERATOR_DEPLOYMENT_NAME"
+	// OperatorDeploymentNameEnv Env variable to specify a custom deployment name for Operator
+	OperatorDeploymentNameEnv = "MINIO_OPERATOR_DEPLOYMENT_NAME"
+	// OperatorRuntimeEnv tells us which runtime we have. (EKS, Rancher, OpenShift, etc...)
+	OperatorRuntimeEnv = "MINIO_OPERATOR_RUNTIME"
 	// OperatorCATLSSecretName is the name of the secret for the operator CA
 	OperatorCATLSSecretName = "operator-ca-tls"
 	// DefaultDeploymentName is the default name of the operator deployment
@@ -49,6 +52,20 @@ const (
 	// DefaultOperatorImage is the version fo the operator being used
 	DefaultOperatorImage = "minio/operator:v5.0.6"
 )
+
+const (
+	// OperatorRuntimeK8s is the default runtime when no specific runtime is set
+	OperatorRuntimeK8s Runtime = "k8s"
+	// OperatorRuntimeEKS is the EKS runtime flag
+	OperatorRuntimeEKS Runtime = "EKS"
+	// OperatorRuntimeOpenshift is the Openshift runtime flag
+	OperatorRuntimeOpenshift Runtime = "OPENSHIFT"
+	// OperatorRuntimeRancher is the Rancher runtime flag
+	OperatorRuntimeRancher Runtime = "RANCHER"
+)
+
+// Runtime type to for Operator runtime
+type Runtime string
 
 var serverCertsManager *xcerts.Manager
 
@@ -110,32 +127,33 @@ func (c *Controller) getTransport() *http.Transport {
 
 	// These chunk of code is intended for OpenShift ONLY and it will help us trust the signer to solve issue:
 	// https://github.com/minio/operator/issues/1412
-	openShiftCATLSCert, err := c.kubeClientSet.CoreV1().Secrets("openshift-kube-controller-manager-operator").Get(
-		context.Background(), "csr-signer", metav1.GetOptions{})
-	klog.Info("Checking if this is OpenShift Environment to append the certificates...")
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			// Do nothing special, because this is maybe k8s vanilla
-			klog.Info("csr-signer secret wasn't found, very likely this is not OpenShift but k8s Vanilla or other...")
-		} else {
-			// Lack of permissions to read the secret
-			klog.Errorf("csr-signer secret was found but we failed to get openShiftCATLSCert: %#v", err)
-		}
-	} else if err == nil && openShiftCATLSCert != nil {
-		// When secret was obtained with no errors
-		if val, ok := openShiftCATLSCert.Data["tls.crt"]; ok {
-			// OpenShift csr-signer secret has tls.crt certificates that we need to append in order
-			// to trust the signer. If we append the val, Operator will be able to provisioning the
-			// initial users and get Tenant Health, so tenant can be properly initialized and in
-			// green status, otherwise if we don't append it, it will get stuck and expose this
-			// issue in the log:
-			// Failed to get cluster health: Get "https://minio.tenant-lite.svc.cluster.local/minio/health/cluster":
-			// x509: certificate signed by unknown authority
-			klog.Info("Appending OpenShift csr-signer to trust the Signer")
-			rootCAs.AppendCertsFromPEM(val)
+	if GetOperatorRuntime() == OperatorRuntimeOpenshift {
+		openShiftCATLSCert, err := c.kubeClientSet.CoreV1().Secrets("openshift-kube-controller-manager-operator").Get(
+			context.Background(), "csr-signer", metav1.GetOptions{})
+		klog.Info("Checking if this is OpenShift Environment to append the certificates...")
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				// Do nothing special, because this is maybe k8s vanilla
+				klog.Info("csr-signer secret wasn't found, very likely this is not OpenShift but k8s Vanilla or other...")
+			} else {
+				// Lack of permissions to read the secret
+				klog.Errorf("csr-signer secret was found but we failed to get openShiftCATLSCert: %#v", err)
+			}
+		} else if err == nil && openShiftCATLSCert != nil {
+			// When secret was obtained with no errors
+			if val, ok := openShiftCATLSCert.Data["tls.crt"]; ok {
+				// OpenShift csr-signer secret has tls.crt certificates that we need to append in order
+				// to trust the signer. If we append the val, Operator will be able to provisioning the
+				// initial users and get Tenant Health, so tenant can be properly initialized and in
+				// green status, otherwise if we don't append it, it will get stuck and expose this
+				// issue in the log:
+				// Failed to get cluster health: Get "https://minio.tenant-lite.svc.cluster.local/minio/health/cluster":
+				// x509: certificate signed by unknown authority
+				klog.Info("Appending OpenShift csr-signer to trust the Signer")
+				rootCAs.AppendCertsFromPEM(val)
+			}
 		}
 	}
-
 	dialer := &net.Dialer{
 		Timeout:   15 * time.Second,
 		KeepAlive: 15 * time.Second,
@@ -234,5 +252,28 @@ func (c *Controller) createBuckets(ctx context.Context, tenant *miniov2.Tenant, 
 
 // getOperatorDeploymentName Internal func returns the Operator deployment name from MINIO_OPERATOR_DEPLOYMENT_NAME ENV variable or the default name
 func getOperatorDeploymentName() string {
-	return env.Get(OperatorDeplymentNameEnv, DefaultDeploymentName)
+	return env.Get(OperatorDeploymentNameEnv, DefaultDeploymentName)
+}
+
+func GetOperatorRuntime() Runtime {
+	envString := os.Getenv(OperatorRuntimeEnv)
+	runtimeReturn := OperatorRuntimeK8s
+	if envString != "" {
+		envString = strings.TrimSpace(envString)
+		envString = strings.ToUpper(envString)
+		switch envString {
+		case string(OperatorRuntimeEKS):
+			runtimeReturn = OperatorRuntimeEKS
+			break
+		case string(OperatorRuntimeOpenshift):
+			runtimeReturn = OperatorRuntimeEKS
+			break
+		case string(OperatorRuntimeRancher):
+			runtimeReturn = OperatorRuntimeRancher
+			break
+		default:
+			runtimeReturn = OperatorRuntimeK8s
+		}
+	}
+	return runtimeReturn
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -238,5 +238,5 @@ func (c *Controller) createBuckets(ctx context.Context, tenant *miniov2.Tenant, 
 
 // getOperatorDeploymentName Internal func returns the Operator deployment name from MINIO_OPERATOR_DEPLOYMENT_NAME ENV variable or the default name
 func getOperatorDeploymentName() string {
-	return env.Get(OperatorDeploymentNameEnv, DefaultDeploymentName)
+	return strings.ToUpper(env.Get(OperatorDeploymentNameEnv, DefaultDeploymentName))
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/minio/operator/pkg/common"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -65,15 +65,8 @@ func GetOperatorRuntime() common.Runtime {
 	if envString != "" {
 		envString = strings.TrimSpace(envString)
 		envString = strings.ToUpper(envString)
-		switch envString {
-		case string(common.OperatorRuntimeEKS):
-			runtimeReturn = common.OperatorRuntimeEKS
-		case string(common.OperatorRuntimeOpenshift):
-			runtimeReturn = common.OperatorRuntimeEKS
-		case string(common.OperatorRuntimeRancher):
-			runtimeReturn = common.OperatorRuntimeRancher
-		default:
-			runtimeReturn = common.OperatorRuntimeK8s
+		if val, ok := common.Runtimes[envString]; ok {
+			runtimeReturn = val
 		}
 	}
 	return runtimeReturn

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,10 @@ package utils
 
 import (
 	"encoding/base64"
+	"os"
+	"strings"
+
+	"github.com/minio/operator/pkg/common"
 
 	"github.com/google/uuid"
 )
@@ -53,3 +57,24 @@ const (
 	ContextRequestRemoteAddr = key("request-remote-addr")
 	ContextAuditKey          = key("request-audit-entry")
 )
+
+// GetOperatorRuntime Retrieves the runtime from env variable
+func GetOperatorRuntime() common.Runtime {
+	envString := os.Getenv(common.OperatorRuntimeEnv)
+	runtimeReturn := common.OperatorRuntimeK8s
+	if envString != "" {
+		envString = strings.TrimSpace(envString)
+		envString = strings.ToUpper(envString)
+		switch envString {
+		case string(common.OperatorRuntimeEKS):
+			runtimeReturn = common.OperatorRuntimeEKS
+		case string(common.OperatorRuntimeOpenshift):
+			runtimeReturn = common.OperatorRuntimeEKS
+		case string(common.OperatorRuntimeRancher):
+			runtimeReturn = common.OperatorRuntimeRancher
+		default:
+			runtimeReturn = common.OperatorRuntimeK8s
+		}
+	}
+	return runtimeReturn
+}


### PR DESCRIPTION
We will try to import the `csr-singer` secret and load the CA when the `MINIO_OPERATOR_RUNTIME` exists and is set to `Openshift` (case insensitive)
