### PR TITLE
To add back kubeconfig flag missing in v5.0.x

### DIFF
--- a/cmd/operator/controller.go
+++ b/cmd/operator/controller.go
@@ -25,8 +25,14 @@ var controllerCmd = cli.Command{
 	Aliases: []string{"ctl"},
 	Usage:   "Start MinIO Operator Controller",
 	Action:  startController,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "kubeconfig",
+			Usage: "Load configuration from `KUBECONFIG`",
+		},
+	},
 }
 
 func startController(ctx *cli.Context) {
-	controller.StartOperator()
+	controller.StartOperator(ctx.String("kubeconfig"))
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -66,7 +66,7 @@ func init() {
 }
 
 // StartOperator starts the MinIO Operator controller
-func StartOperator() {
+func StartOperator(kubeconfig string) {
 	klog.Info("Starting MinIO Operator")
 	// set up signals, so we handle the first shutdown signal gracefully
 	stopCh := setupSignalHandler()


### PR DESCRIPTION
### Objective:

To add back `--kubeconfig=/home/user/.kube/config` flag missing in v5.0.x, this flag is intended for `controller` only.

### How it looks:

```sh
$ ./operator controller --help
NAME:
  operator controller - Start MinIO Operator Controller

USAGE:
  operator controller [command options] [arguments...]

FLAGS:
  --kubeconfig KUBECONFIG  Load configuration from KUBECONFIG
  --help, -h               show help
```