### PR TITLE
OpenShift 4.7 has reached its end of life

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -133,7 +133,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # as well as the default.
   {
     echo "  # Annotations to specify OCP versions compatibility."
-    echo "  com.redhat.openshift.versions: v4.6-v4.12"
+    echo "  com.redhat.openshift.versions: v4.8-v4.12"
     echo "  # Annotation to add default bundle channel as potential is declared"
     echo "  operators.operatorframework.io.bundle.channel.default.v1: stable"
   } >> bundles/$catalog/$RELEASE/metadata/annotations.yaml


### PR DESCRIPTION
### Objective:

Upgrade RedHat MarketPlace and other catalogs.

### User Story:

Back in https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/345 I faced an error in `get-supported-versions` test. The error was `ValueError: OpenShift 4.7 has reached its end of life` meaning we have to remove old versions and keep only newer versions to pass this test and put our new Operator version in their catalogs and that I did but manually. Now, I am trying to upgrade our scripts, so that I don't do this on my own anymore.
