### PR TITLE
To provide upgrade channel for Operator

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -77,6 +77,12 @@ for catalog in "${redhatCatalogs[@]}"; do
   yq -i eval 'del(.spec.install.spec.deployments[1].spec.template.spec.containers[0].securityContext.runAsGroup)' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
   yq -i eval 'del(.spec.install.spec.deployments[1].spec.template.spec.containers[0].securityContext.runAsUser)' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
 
+  # To provide channel for upgrade where we tell what versions can be replaced by the new version we offer
+  # You can read the documentation at link below:
+  # https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/understanding-the-operator-lifecycle-manager-olm#olm-upgrades_olm-understanding-olm
+  echo "To provide channel for upgrading Operator..."
+  yq -i e ".metadata.annotations.\"olm.skipRange\" |= \">=4.4.16 <$RELEASE\"" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
+
   # In order to deploy via OLM, we should let OLM to decide on the security
   # context; otherwise deploy will fail and operator update will not be possible
   # already tested this manually to prove the point:


### PR DESCRIPTION
### Why is needed:

We need to provide an upgrade method when installing via OperatorHub so that the user can move forward with our Operator every time there is a new release. They can decide if it is automatically or manual but the upgrade channel is a must once installed. Otherwise, they will get trapped in one version only.

### How it looks:

<img width="683" alt="Screenshot 2023-04-17 at 11 08 19 AM" src="https://user-images.githubusercontent.com/6667358/232530954-ff3ca2cc-6000-4bae-b27f-d312c3c796da.png">
