### PR TITLE
OLM: Conversion webhook is no longer needed

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -65,7 +65,6 @@ for catalog in "${redhatCatalogs[@]}"; do
   # the deployment name you set is "operator", and in CSV, there are two deployments 'console' and 'minio-operator'
   # but there is no 'operator' option, without this change error is: "calculated deployment install is bad"
   yq -i 'del(.spec.webhookdefinitions)' bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml 
-  yq -i '.spec.conversion.webhook.clientConfig.service.name = "operator"' bundles/$catalog/$RELEASE/manifests/minio.min.io_tenants.yaml
 
   # I get the update from engineering team, typically no user/group specification is made in a container image.
   # Rather, the user spec (if there is one) is placed in the clusterserviceversion.yaml file as a RunAsUser clause.


### PR DESCRIPTION
### Objective:

To deploy Operator v5.0.3 via OLM

### Current Issue:

```sh
$ operator-sdk run bundle quay.io/cniackz4/minio-operator:v5.0.3 --index-image=quay.io/operator-framework/opm:v1.23.0
WARN[0004] quay.io/operator-framework/opm:v1.23.0 is a SQLite index image. SQLite based index images are being deprecated and will be removed in a future release, please migrate your catalogs to the new File-Based Catalog format 
INFO[0009] Created registry pod: quay-io-cniackz4-minio-operator-v5-0-3 
INFO[0009] Created CatalogSource: minio-operator-catalog 
INFO[0009] OperatorGroup "operator-sdk-og" created      
INFO[0009] Created Subscription: minio-operator-v5-0-3-sub 
INFO[0013] Approved InstallPlan install-t95vj for the Subscription: minio-operator-v5-0-3-sub 
INFO[0013] Waiting for ClusterServiceVersion "default/minio-operator.v5.0.3" to reach 'Succeeded' phase 
INFO[0013]   Waiting for ClusterServiceVersion "default/minio-operator.v5.0.3" to appear 
INFO[0024]   Found ClusterServiceVersion "default/minio-operator.v5.0.3" phase: Pending 
FATA[0120] Failed to run bundle: error waiting for CSV to install: timed out waiting for the condition 
```

### Explanation:

We no longer have a `spec.conversion.strategy` got removed by Daniel when we deprecated tenant v1:
https://github.com/minio/operator/pull/1428/files#diff-19e1df82f13242efb9d69306d9f2933249a8559930041b3e3ad2f0bfe6f0e365L13

<img width="1728" alt="Screenshot 2023-04-19 at 1 56 51 PM" src="https://user-images.githubusercontent.com/6667358/233160177-fb44b99f-97f5-4154-942b-79b6a9b18edc.png">

Hence we are facing this issue while deploying in Catalogs:

```
err="the bundle cannot be deployed because deployment validation has failed: [
	{

		Name:tenants.minio.min.io Errors:[

			Error: Field spec.conversion.strategy, 
			Value : spec.conversion.strategy: 
			Required value Error: Field spec.conversion.webhookClientConfig, 
			Value : spec.conversion.webhookClientConfig: 
			Forbidden: should not be set when strategy is not set to Webhook
		] 

		Warnings:[]

	}
]" 
```

### Solution:

The solution is simple, remove webhook for now. We can add it back when v3 comes up.

### Tested Locally:

```sh
$ operator-sdk run bundle quay.io/cniackz4/minio-operator:v5.0.3 --index-image=quay.io/operator-framework/opm:v1.23.0
WARN[0037] quay.io/operator-framework/opm:v1.23.0 is a SQLite index image. SQLite based index images are being deprecated and will be removed in a future release, please migrate your catalogs to the new File-Based Catalog format 
INFO[0043] Created registry pod: quay-io-cniackz4-minio-operator-v5-0-3 
INFO[0043] Created CatalogSource: minio-operator-catalog 
INFO[0043] OperatorGroup "operator-sdk-og" created      
INFO[0043] Created Subscription: minio-operator-v5-0-3-sub 
INFO[0047] Approved InstallPlan install-fvvvs for the Subscription: minio-operator-v5-0-3-sub 
INFO[0047] Waiting for ClusterServiceVersion "default/minio-operator.v5.0.3" to reach 'Succeeded' phase 
INFO[0047]   Waiting for ClusterServiceVersion "default/minio-operator.v5.0.3" to appear 
INFO[0070]   Found ClusterServiceVersion "default/minio-operator.v5.0.3" phase: Pending 
INFO[0073]   Found ClusterServiceVersion "default/minio-operator.v5.0.3" phase: Installing 
INFO[0082]   Found ClusterServiceVersion "default/minio-operator.v5.0.3" phase: Succeeded 
INFO[0082] OLM has successfully installed "minio-operator.v5.0.3" 
```