### PR TITLE
Fix describe api to include correct container index

### DIFF
--- a/api/pod-handlers.go
+++ b/api/pod-handlers.go
@@ -277,7 +277,7 @@ func getDescribePodResponse(session *models.Principal, params operator_api.Descr
 			retval.Containers[i].RestartCount = int64(statusMap[pod.Spec.Containers[i].Name].RestartCount)
 			retval.Containers[i].State, retval.Containers[i].LastState = describeStatus(statusMap[pod.Spec.Containers[i].Name])
 		}
-		retval.Containers[i].EnvironmentVariables = make([]*models.EnvironmentVariable, len(pod.Spec.Containers[0].Env))
+		retval.Containers[i].EnvironmentVariables = make([]*models.EnvironmentVariable, len(pod.Spec.Containers[i].Env))
 		for j := range pod.Spec.Containers[i].Env {
 			retval.Containers[i].EnvironmentVariables[j] = &models.EnvironmentVariable{
 				Key:   pod.Spec.Containers[i].Env[j].Name,

--- a/web-app/src/screens/Console/Tenants/TenantDetails/pods/PodDescribe.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/pods/PodDescribe.tsx
@@ -305,15 +305,15 @@ const PodDescribeTable = ({
               </TableRow>
             </TableHead>
             <TableBody>
-              {items
-                .filter((item) => item !== null)
-                .map((item, i) => (
+              {items.map((item, i) => {
+                return (
                   <TableRow key={i}>
                     {columns.map((column, j) => (
                       <TableCell key={j}>{item[column]}</TableCell>
                     ))}
                   </TableRow>
-                ))}
+                );
+              })}
             </TableBody>
           </Table>
         </TableContainer>
@@ -412,7 +412,8 @@ const PodDescribe = ({
           `/api/v1/namespaces/${namespace}/tenants/${tenant}/pods/${podName}/describe`
         )
         .then((res: DescribeResponse) => {
-          setDescribeInfo(res);
+          const cleanRes = cleanDescribeResponseEnvVariables(res);
+          setDescribeInfo(cleanRes);
           setLoading(false);
         })
         .catch((err: ErrorResponseHandler) => {
@@ -421,6 +422,18 @@ const PodDescribe = ({
         });
     }
   }, [loading, podName, namespace, tenant, dispatch]);
+
+  const cleanDescribeResponseEnvVariables = (
+    res: DescribeResponse
+  ): DescribeResponse => {
+    res.containers = res.containers.map((c) => {
+      c.environmentVariables = c.environmentVariables.filter(
+        (item) => item !== null
+      );
+      return c;
+    });
+    return res;
+  };
 
   const renderTabComponent = (index: number, info: DescribeResponse) => {
     switch (index) {


### PR DESCRIPTION
Describe api was returning always the information of the first container.

It also updates the previous change done in https://github.com/minio/operator/pull/1583 so that we clean the response from null values before storing it in the state.

Should still be showing Containers info like:

Response now comes correctly without null objects in Container EnvVariables:
Before:
![Screenshot 2023-04-21 at 4 58 39 PM](https://user-images.githubusercontent.com/11819101/234138538-d633bef8-c4ad-448b-8961-2710fd93e1a2.png)
After:
<img width="639" alt="Screenshot 2023-04-24 at 9 51 04 AM" src="https://user-images.githubusercontent.com/11819101/234138506-df13f245-7ce0-460d-ab80-76fce5f67383.png">


![Screenshot 2023-04-24 at 4 38 05 PM](https://user-images.githubusercontent.com/11819101/234138165-73a207db-0149-45ec-bcc3-2239f266e356.png)



## Test Steps
Similar to : https://github.com/minio/operator/pull/1583
