### PR TITLE
Add Tests and fixes for Describe Pod api

### DIFF
--- a/api/pod-handlers_test.go
+++ b/api/pod-handlers_test.go
@@ -126,7 +126,7 @@ func (suite *TenantTestSuite) initDescribePodRequest() (params operator_api.Desc
 }
 
 func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
-	mockTime := time.Date(2023, 4, 25, 14, 30, 45, 100, time.Local)
+	mockTime := time.Date(2023, 4, 25, 14, 30, 45, 100, time.UTC)
 	mockContainerOne := corev1.Container{
 		Name:  "c1",
 		Image: "c1-image",
@@ -222,7 +222,8 @@ func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
 			DeletionTimestamp:          &metav1.Time{Time: mockTime},
 			DeletionGracePeriodSeconds: swag.Int64(60),
 			OwnerReferences: []metav1.OwnerReference{
-				{APIVersion: "v1",
+				{
+					APIVersion: "v1",
 					Kind:       "ReferenceKind",
 					Name:       "ReferenceName",
 					Controller: swag.Bool(true),
@@ -394,7 +395,7 @@ func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
 				Message:  "",
 				Reason:   "",
 				Signal:   int64(0),
-				Started:  "Tue, 25 Apr 2023 14:30:45 -0700",
+				Started:  "Tue, 25 Apr 2023 14:30:45 +0000",
 				State:    "Running",
 			},
 			LastState: &models.State{
@@ -447,16 +448,16 @@ func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
 				Message:  "",
 				Reason:   "",
 				Signal:   int64(0),
-				Started:  "Tue, 25 Apr 2023 14:30:45 -0700",
+				Started:  "Tue, 25 Apr 2023 14:30:45 +0000",
 				State:    "Running",
 			},
 			LastState: &models.State{
 				ExitCode: int64(4),
-				Finished: "Tue, 25 Apr 2023 14:30:45 -0700",
+				Finished: "Tue, 25 Apr 2023 14:30:45 +0000",
 				Message:  "c2-some-message",
 				Reason:   "c2-some-reason",
 				Signal:   int64(1),
-				Started:  "Tue, 25 Apr 2023 14:30:45 -0700",
+				Started:  "Tue, 25 Apr 2023 14:30:45 +0000",
 				State:    "Terminated",
 			},
 			EnvironmentVariables: []*models.EnvironmentVariable{

--- a/api/pod-handlers_test.go
+++ b/api/pod-handlers_test.go
@@ -367,10 +367,10 @@ func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
 	suite.assert.Equal(mockPodInfo.Spec.NodeName, res.NodeName)
 	suite.assert.Equal(int64(10), res.Priority)
 	suite.assert.Equal(mockPodInfo.Status.StartTime.Time.String(), res.StartTime)
-	suite.assert.Contains(&models.Label{Key: "Key1", Value: "Val1"}, res.Labels)
-	suite.assert.Contains(&models.Label{Key: "Key2", Value: "Val2"}, res.Labels)
-	suite.assert.Contains(&models.Annotation{Key: "Annotation1", Value: "Annotation1Val1"}, res.Annotations)
-	suite.assert.Contains(&models.Annotation{Key: "Annotation2", Value: "Annotation1Val2"}, res.Annotations)
+	suite.assert.Contains(res.Labels, &models.Label{Key: "Key1", Value: "Val1"})
+	suite.assert.Contains(res.Labels, &models.Label{Key: "Key2", Value: "Val2"})
+	suite.assert.Contains(res.Annotations, &models.Annotation{Key: "Annotation1", Value: "Annotation1Val1"})
+	suite.assert.Contains(res.Annotations, &models.Annotation{Key: "Annotation2", Value: "Annotation1Val2"})
 	suite.assert.Equal(duration.HumanDuration(time.Since(mockTime)), res.DeletionTimestamp)
 	suite.assert.Equal(int64(60), res.DeletionGracePeriodSeconds)
 	suite.assert.Equal("phase", res.Phase)
@@ -527,14 +527,14 @@ func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
 		},
 	}, res.Volumes)
 	suite.assert.Equal("BestEffort", res.QosClass)
-	suite.assert.Contains(&models.NodeSelector{
+	suite.assert.Contains(res.NodeSelector, &models.NodeSelector{
 		Key:   "p1-ns-key1",
 		Value: "p1-ns-val1",
-	}, res.NodeSelector)
-	suite.assert.Contains(&models.NodeSelector{
+	})
+	suite.assert.Contains(res.NodeSelector, &models.NodeSelector{
 		Key:   "p1-ns-key2",
 		Value: "p1-ns-val2",
-	}, res.NodeSelector)
+	})
 	suite.assert.Equal([]*models.Toleration{
 		{
 			Key:               "p1-t1-key",

--- a/api/pod-handlers_test.go
+++ b/api/pod-handlers_test.go
@@ -20,11 +20,14 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-openapi/swag"
+
 	"github.com/minio/operator/api/operations"
 	"github.com/minio/operator/api/operations/operator_api"
 	"github.com/minio/operator/models"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
 )
 
 func (suite *TenantTestSuite) TestDeletePodHandlerWithoutError() {
@@ -120,4 +123,431 @@ func (suite *TenantTestSuite) initDescribePodRequest() (params operator_api.Desc
 	params.Tenant = "mock-tenant"
 	params.PodName = "mock-pod"
 	return params, api
+}
+
+func (suite *TenantTestSuite) TestGetDescribePodBuildsResponseFromPodInfo() {
+	mockTime := time.Date(2023, 4, 25, 14, 30, 45, 100, time.Local)
+	mockContainerOne := corev1.Container{
+		Name:  "c1",
+		Image: "c1-image",
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "c1-port-1",
+				HostPort:      int32(9000),
+				ContainerPort: int32(8080),
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
+				Name:          "c1-port-2",
+				HostPort:      int32(3000),
+				ContainerPort: int32(7070),
+				Protocol:      corev1.ProtocolUDP,
+			},
+		},
+		Args: []string{"c1-arg1", "c1-arg2"},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "c1-env-var1",
+				Value: "c1-env-value1",
+			},
+			{
+				Name:  "c1-env-var2",
+				Value: "c1-env-value2",
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "c1-mount1",
+				MountPath: "c1-mount1-path",
+				ReadOnly:  true,
+				SubPath:   "c1-mount1-subpath",
+			},
+			{
+				Name:      "c1-mount2",
+				MountPath: "c1-mount2-path",
+				ReadOnly:  true,
+				SubPath:   "c1-mount2-subpath",
+			},
+		},
+	}
+	mockContainerTwo := corev1.Container{
+		Name:  "c2",
+		Image: "c2-image",
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "c2-port-1",
+				HostPort:      int32(9000),
+				ContainerPort: int32(8080),
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
+				Name:          "c2-port-2",
+				HostPort:      int32(3000),
+				ContainerPort: int32(7070),
+				Protocol:      corev1.ProtocolUDP,
+			},
+		},
+		Args: []string{"c2-arg1", "c2-arg2"},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "c2-env-var1",
+				Value: "c2-env-value1",
+			},
+			{
+				Name:  "c2-env-var2",
+				Value: "c2-env-value2",
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "c2-mount1",
+				MountPath: "c2-mount1-path",
+				ReadOnly:  true,
+				SubPath:   "c2-mount1-subpath",
+			},
+			{
+				Name:      "c2-mount2",
+				MountPath: "c2-mount2-path",
+				ReadOnly:  true,
+				SubPath:   "c2-mount2-subpath",
+			},
+		},
+	}
+	mockPodInfo := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       "mock-pod",
+			Namespace:                  "mock-namespace",
+			Labels:                     map[string]string{"Key1": "Val1", "Key2": "Val2"},
+			Annotations:                map[string]string{"Annotation1": "Annotation1Val1", "Annotation2": "Annotation1Val2"},
+			DeletionTimestamp:          &metav1.Time{Time: mockTime},
+			DeletionGracePeriodSeconds: swag.Int64(60),
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "v1",
+					Kind:       "ReferenceKind",
+					Name:       "ReferenceName",
+					Controller: swag.Bool(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			PriorityClassName: "mock-priority-class",
+			NodeName:          "mock-node",
+			Priority:          swag.Int32(10),
+			Containers:        []corev1.Container{mockContainerOne, mockContainerTwo},
+			Volumes: []corev1.Volume{
+				{
+					Name: "v1",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "v1-pvc",
+							ReadOnly:  true,
+						},
+					},
+				},
+				{
+					Name: "v1",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									Secret: &corev1.SecretProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "v1-vs-secret1",
+										},
+									},
+									DownwardAPI: &corev1.DownwardAPIProjection{
+										Items: []corev1.DownwardAPIVolumeFile{},
+									},
+									ConfigMap: &corev1.ConfigMapProjection{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "v1-vs-configmap1",
+										},
+									},
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										ExpirationSeconds: swag.Int64(1000),
+									},
+								},
+							},
+							DefaultMode: swag.Int32(511),
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				"p1-ns-key1": "p1-ns-val1",
+				"p1-ns-key2": "p1-ns-val2",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					Key:               "p1-t1-key",
+					Operator:          corev1.TolerationOpExists,
+					Value:             "p1-t1-val",
+					Effect:            corev1.TaintEffectNoSchedule,
+					TolerationSeconds: swag.Int64(60),
+				},
+				{
+					Key:               "p1-t2-key",
+					Operator:          corev1.TolerationOpEqual,
+					Value:             "p1-t2-val",
+					Effect:            corev1.TaintEffectPreferNoSchedule,
+					TolerationSeconds: swag.Int64(70),
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			StartTime: &metav1.Time{Time: mockTime},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "c1",
+					ContainerID:  "c1-id",
+					ImageID:      "c1-image-id",
+					Ready:        true,
+					RestartCount: int32(3),
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{Time: mockTime},
+						},
+					},
+					LastTerminationState: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "c1-some-reason",
+							Message: "c1-some-message",
+						},
+					},
+				},
+				{
+					Name:         "c2",
+					ContainerID:  "c2-id",
+					ImageID:      "c2-image-id",
+					Ready:        true,
+					RestartCount: int32(3),
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{Time: mockTime},
+						},
+					},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:      "c2-some-reason",
+							Message:     "c2-some-message",
+							ExitCode:    int32(4),
+							Signal:      int32(1),
+							StartedAt:   metav1.Time{Time: mockTime},
+							FinishedAt:  metav1.Time{Time: mockTime},
+							ContainerID: "c2-id",
+						},
+					},
+				},
+			},
+			Phase:   corev1.PodPhase("phase"),
+			Reason:  "StatusReason",
+			Message: "StatusMessage",
+			PodIP:   "192.1.2.3",
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.ContainersReady,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.PodInitialized,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	res, err := getDescribePod(mockPodInfo)
+
+	suite.assert.NotNil(res)
+	suite.assert.Nil(err)
+	suite.assert.Equal(mockPodInfo.Name, res.Name)
+	suite.assert.Equal(mockPodInfo.Namespace, res.Namespace)
+	suite.assert.Equal(mockPodInfo.Spec.PriorityClassName, res.PriorityClassName)
+	suite.assert.Equal(mockPodInfo.Spec.NodeName, res.NodeName)
+	suite.assert.Equal(int64(10), res.Priority)
+	suite.assert.Equal(mockPodInfo.Status.StartTime.Time.String(), res.StartTime)
+	suite.assert.Contains(&models.Label{Key: "Key1", Value: "Val1"}, res.Labels)
+	suite.assert.Contains(&models.Label{Key: "Key2", Value: "Val2"}, res.Labels)
+	suite.assert.Contains(&models.Annotation{Key: "Annotation1", Value: "Annotation1Val1"}, res.Annotations)
+	suite.assert.Contains(&models.Annotation{Key: "Annotation2", Value: "Annotation1Val2"}, res.Annotations)
+	suite.assert.Equal(duration.HumanDuration(time.Since(mockTime)), res.DeletionTimestamp)
+	suite.assert.Equal(int64(60), res.DeletionGracePeriodSeconds)
+	suite.assert.Equal("phase", res.Phase)
+	suite.assert.Equal("StatusReason", res.Reason)
+	suite.assert.Equal("StatusMessage", res.Message)
+	suite.assert.Equal("192.1.2.3", res.PodIP)
+	suite.assert.Equal("&OwnerReference{Kind:ReferenceKind,Name:ReferenceName,UID:,APIVersion:v1,Controller:*true,BlockOwnerDeletion:nil,}", res.ControllerRef)
+	suite.assert.Equal([]*models.Container{
+		{
+			Name:         "c1",
+			Image:        "c1-image",
+			Ports:        []string{"8080/TCP", "7070/UDP"},
+			HostPorts:    []string{"9000/TCP", "3000/UDP"},
+			Args:         []string{"c1-arg1", "c1-arg2"},
+			ContainerID:  "c1-id",
+			ImageID:      "c1-image-id",
+			Ready:        true,
+			RestartCount: int64(3),
+			State: &models.State{
+				ExitCode: int64(0),
+				Finished: "",
+				Message:  "",
+				Reason:   "",
+				Signal:   int64(0),
+				Started:  "Tue, 25 Apr 2023 14:30:45 -0700",
+				State:    "Running",
+			},
+			LastState: &models.State{
+				ExitCode: int64(0),
+				Finished: "",
+				Message:  "c1-some-message",
+				Reason:   "c1-some-reason",
+				Signal:   int64(0),
+				Started:  "",
+				State:    "Waiting",
+			},
+			EnvironmentVariables: []*models.EnvironmentVariable{
+				{
+					Key:   "c1-env-var1",
+					Value: "c1-env-value1",
+				},
+				{
+					Key:   "c1-env-var2",
+					Value: "c1-env-value2",
+				},
+			},
+			Mounts: []*models.Mount{
+				{
+					Name:      "c1-mount1",
+					MountPath: "c1-mount1-path",
+					ReadOnly:  true,
+					SubPath:   "c1-mount1-subpath",
+				},
+				{
+					Name:      "c1-mount2",
+					MountPath: "c1-mount2-path",
+					ReadOnly:  true,
+					SubPath:   "c1-mount2-subpath",
+				},
+			},
+		},
+		{
+			Name:         "c2",
+			Image:        "c2-image",
+			Ports:        []string{"8080/TCP", "7070/UDP"},
+			HostPorts:    []string{"9000/TCP", "3000/UDP"},
+			Args:         []string{"c2-arg1", "c2-arg2"},
+			ContainerID:  "c2-id",
+			ImageID:      "c2-image-id",
+			Ready:        true,
+			RestartCount: int64(3),
+			State: &models.State{
+				ExitCode: int64(0),
+				Finished: "",
+				Message:  "",
+				Reason:   "",
+				Signal:   int64(0),
+				Started:  "Tue, 25 Apr 2023 14:30:45 -0700",
+				State:    "Running",
+			},
+			LastState: &models.State{
+				ExitCode: int64(4),
+				Finished: "Tue, 25 Apr 2023 14:30:45 -0700",
+				Message:  "c2-some-message",
+				Reason:   "c2-some-reason",
+				Signal:   int64(1),
+				Started:  "Tue, 25 Apr 2023 14:30:45 -0700",
+				State:    "Terminated",
+			},
+			EnvironmentVariables: []*models.EnvironmentVariable{
+				{
+					Key:   "c2-env-var1",
+					Value: "c2-env-value1",
+				},
+				{
+					Key:   "c2-env-var2",
+					Value: "c2-env-value2",
+				},
+			},
+			Mounts: []*models.Mount{
+				{
+					Name:      "c2-mount1",
+					MountPath: "c2-mount1-path",
+					ReadOnly:  true,
+					SubPath:   "c2-mount1-subpath",
+				},
+				{
+					Name:      "c2-mount2",
+					MountPath: "c2-mount2-path",
+					ReadOnly:  true,
+					SubPath:   "c2-mount2-subpath",
+				},
+			},
+		},
+	}, res.Containers)
+	suite.assert.Equal([]*models.Condition{
+		{
+			Type:   "ContainersReady",
+			Status: "True",
+		},
+		{
+			Type:   "Initialized",
+			Status: "False",
+		},
+	}, res.Conditions)
+	suite.assert.Equal([]*models.Volume{
+		{
+			Name: "v1",
+			Pvc: &models.Pvc{
+				ClaimName: "v1-pvc",
+				ReadOnly:  true,
+			},
+		},
+		{
+			Name: "v1",
+			Projected: &models.ProjectedVolume{
+				Sources: []*models.ProjectedVolumeSource{
+					{
+						Secret: &models.Secret{
+							Name:     "v1-vs-secret1",
+							Optional: false,
+						},
+						DownwardAPI: true,
+						ConfigMap: &models.ConfigMap{
+							Name:     "v1-vs-configmap1",
+							Optional: false,
+						},
+						ServiceAccountToken: &models.ServiceAccountToken{
+							ExpirationSeconds: int64(1000),
+						},
+					},
+				},
+			},
+		},
+	}, res.Volumes)
+	suite.assert.Equal("BestEffort", res.QosClass)
+	suite.assert.Contains(&models.NodeSelector{
+		Key:   "p1-ns-key1",
+		Value: "p1-ns-val1",
+	}, res.NodeSelector)
+	suite.assert.Contains(&models.NodeSelector{
+		Key:   "p1-ns-key2",
+		Value: "p1-ns-val2",
+	}, res.NodeSelector)
+	suite.assert.Equal([]*models.Toleration{
+		{
+			Key:               "p1-t1-key",
+			Operator:          "Exists",
+			Value:             "p1-t1-val",
+			Effect:            "NoSchedule",
+			TolerationSeconds: int64(60),
+		},
+		{
+			Key:               "p1-t2-key",
+			Operator:          "Equal",
+			Value:             "p1-t2-val",
+			Effect:            "PreferNoSchedule",
+			TolerationSeconds: int64(70),
+		},
+	}, res.Tolerations)
 }

--- a/web-app/src/screens/Console/Tenants/TenantDetails/pods/PodDescribe.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/pods/PodDescribe.tsx
@@ -346,8 +346,11 @@ const PodDescribeContainers = ({ containers }: IPodDescribeContainersProps) => {
               label={"Arguments"}
               value={container.args.join(", ")}
             />
-            <LabelValuePair label={"Started"} value={container.state.started} />
-            <LabelValuePair label={"State"} value={container.state.state} />
+            <LabelValuePair
+              label={"Started"}
+              value={container.state?.started}
+            />
+            <LabelValuePair label={"State"} value={container.state?.state} />
           </Box>
           <Box
             style={{ wordBreak: "break-all" }}


### PR DESCRIPTION
## Description:
Added unittest for Describe Pod handler. It also includes some fixes for bugs found during the creation of the tests.

## Changes
- [x] Added `TestGetDescribePodBuildsResponseFromPodInfo`
- [x] Refactored getDescribePodResponse and created `getDescribePod` to be able to unittest it
- [x] Added null validation for `DeletionGracePeriodSeconds`
- [x] Created  `describeContainerState`  which refactored previous function `describeStatus` which contained duplicated code.
- [x] Moved the logic for `LastState` to not be only defined when current state was `Terminated`.
- [x] Added missing value **Message** for `Waiting` state
- [x] Added missing value  **Reason** for `Terminated` state
- [x] Added null validation for `ExpirationSeconds`
- [x] Fixed a UI issue which showed a blank page sometimes if the Container is restarted cause the `state` value was not being defined (due to not being defined by the k8s api in `ContainerStatuses` field while restarting)

## Test Steps
Prerequirements: 
- Kind environment
- Tenant initialized (preferably)

Build image from branch like:
```
make docker TAG="minio/operator:cesnietor" && kind load docker-image minio/operator:cesnietor   
```
Load image to your kind environment
```
kind load docker-image minio/operator:cesnietor
```

Create operator.yaml:
```
kubectl kustomize . > operator.yaml
```
Update console image to use the new one:
```
yq -i -e '(. | select(.spec.selector.matchLabels.app=="console") .spec.template.spec.containers[0].image) = "minio/operator:cesnietor"' operator.yaml
```

Apply your changes
```
kubectl apply -f operator.yaml
```
Portforward Operator Console to your local env:
```
kubectl port-forward $(kubectl get pods -n minio-operator -l app=console | grep console | awk '{print $1}') 9090 -n minio-operator
```
In other terminal get the secrets to login to console:
```
kubectl describe secrets -n minio-operator console-sa-secret | grep 'token:' | awk '{print $2}' | pbcopy
```

- Go to your browser http://localhost:9090
- Login using your JWT
- Go to Tenants/Pods > Your Pod
- Go to Describe > Containers
- Container info should be shown

If **State** is not being defined it now shows blank values instead of showing blank page while container is restarting:

<img width="592" alt="Screenshot 2023-04-28 at 9 48 16 AM" src="https://user-images.githubusercontent.com/11819101/235217576-3b563a1f-3dd0-40f1-9a96-01eca4f3e7f4.png">

It now shows `Terminated` state (before it was not being returned):

<img width="587" alt="Screenshot 2023-04-28 at 9 52 57 AM" src="https://user-images.githubusercontent.com/11819101/235217747-5e927d5e-8d0c-438a-9649-3c57965c4d2a.png">