### PR TITLE
Warn user about the proper use of subPath field

### DIFF
--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -146,6 +146,12 @@ spec:
   ## Mount path where PV will be mounted inside container(s).
   mountPath: /export
   ## Sub path inside Mount path where MinIO stores data.
+  ## WARNING:
+  ## We recommend you to keep the same mountPath and the same subPath once the
+  ## Tenant has been deployed over your different PVs.
+  ## This is because if you change these values once Tenant is deployed, then
+  ## you will end up with multiple paths for different buckets. So please, be
+  ## very careful to keep same value for the life of the Tenant.
   subPath: ""
   ## Service account to be used for all the MinIO Pods
   serviceAccountName: ""

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -72,6 +72,12 @@ tenant:
   ## Mount path where PV will be mounted inside container(s).
   mountPath: /export
   ## Sub path inside Mount path where MinIO stores data.
+  ## WARNING:
+  ## We recommend you to keep the same mountPath and the same subPath once the
+  ## Tenant has been deployed over your different PVs.
+  ## This is because if you change these values once Tenant is deployed, then
+  ## you will end up with multiple paths for different buckets. So please, be
+  ## very careful to keep same value for the life of the Tenant.
   subPath: /data
   # pool metrics to be read by Prometheus
   metrics:


### PR DESCRIPTION
### Objective:

Avoid having two `.minio.sys` files under the same `PV` as already observed with one of our customers.

### Reasoning:

In https://github.com/minio/operator/blob/master/examples/kustomization/base/tenant.yaml#L149 we are using `subPath: ""`:

```
  mountPath: /export
  ## Sub path inside Mount path where MinIO stores data.
  subPath: ""
```

but in Helm we introduced `/data` back in https://github.com/minio/operator/pull/526 then if a user install the tenant via Kustomize and then remove just the tenant and put it back using helm, will end up with a new Tenant with same name and same namespace but two `.minio.sys` files under the same PV. Then user will think buckets are gone when in fact they are still in the PV just in different path. To avoid this confusion we can warn user about the proper use of this field.


