### PR TITLE
feat(helm): console disable flag and image digests

### DIFF
--- a/helm/operator/templates/NOTES.txt
+++ b/helm/operator/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled -}}
 1. Get the JWT for logging in to the console:
 kubectl apply -f - <<EOF
 apiVersion: v1
@@ -14,3 +15,4 @@ kubectl -n minio-operator  get secret console-sa-secret -o jsonpath="{.data.toke
 2. Get the Operator Console URL by running these commands:
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/console 9090:9090
   echo "Visit the Operator Console at http://127.0.0.1:9090"
+{{- end -}}

--- a/helm/operator/templates/_helpers.tpl
+++ b/helm/operator/templates/_helpers.tpl
@@ -82,3 +82,12 @@ Selector labels Operator
 app.kubernetes.io/name: {{ include "minio-operator.name" . }}
 app.kubernetes.io/instance: {{ printf "%s-%s" .Release.Name "console" }}
 {{- end -}}
+
+{{/*
+Image with tag/digest
+*/}}
+{{- define "minio-operator.image" -}}
+{{- $tag := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
+{{- $digest := ternary "" (printf "@%s" .digest) (empty .digest) -}}
+{{- printf "%s%s%s" .repository $tag $digest -}}
+{{- end -}}

--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,7 +43,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.console.image.repository }}:{{ .Values.console.image.tag }}"
+          image: "{{ .Values.console.image.repository }}{{ ternary (printf ":%s" .Values.console.image.tag) (printf "@%s" .Values.console.image.digest) (empty .Values.console.image.digest) }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           ports:
             - containerPort: 9090
@@ -74,3 +75,4 @@ spec:
       runtimeClassName:
       {{- toYaml . | nindent 8 }}
   {{- end}}
+{{- end -}}

--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.console.image.repository }}{{ ternary (printf ":%s" .Values.console.image.tag) (printf "@%s" .Values.console.image.digest) (empty .Values.console.image.digest) }}"
+          image: {{ include "minio-operator.image" .Values.console.image | quote }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           ports:
             - containerPort: 9090

--- a/helm/operator/templates/console-ingress.yaml
+++ b/helm/operator/templates/console-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.console.ingress.enabled }}
+{{- if and .Values.console.enabled .Values.console.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm/operator/templates/console-service.yaml
+++ b/helm/operator/templates/console-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
     port: 9443
   selector:
     {{- include "minio-operator.console-selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/helm/operator/templates/console-ui.yaml
+++ b/helm/operator/templates/console-ui.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -272,3 +273,4 @@ kind: ConfigMap
 metadata:
   name: console-env
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
+          image: "{{ .Values.operator.image.repository }}{{ ternary (printf ":%s" .Values.operator.image.tag) (printf "@%s" .Values.operator.image.digest) (empty .Values.operator.image.digest) }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:
             - controller

--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.operator.image.repository }}{{ ternary (printf ":%s" .Values.operator.image.tag) (printf "@%s" .Values.operator.image.digest) (empty .Values.operator.image.digest) }}"
+          image: {{ include "minio-operator.image" .Values.operator.image | quote }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:
             - controller

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -12,8 +12,7 @@ operator:
   image:
     repository: quay.io/minio/operator
     tag: v5.0.5
-    # Setting the digest takes precedence over the tag
-    digest: ""  # e.g. sha256:123456789abcdef123456789abcdef123456789abcdef123456789abcdef
+    digest: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: [ ]
   initcontainers: [ ]
@@ -52,8 +51,7 @@ console:
   image:
     repository: quay.io/minio/operator
     tag: v5.0.5
-    # Setting the digest takes precedence over the tag
-    digest: ""  # e.g. sha256:123456789abcdef123456789abcdef123456789abcdef123456789abcdef
+    digest: ""
     pullPolicy: IfNotPresent
   imagePullSecrets: [ ]
   initcontainers: [ ]

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -12,6 +12,8 @@ operator:
   image:
     repository: quay.io/minio/operator
     tag: v5.0.5
+    # Setting the digest takes precedence over the tag
+    digest: ""  # e.g. sha256:123456789abcdef123456789abcdef123456789abcdef123456789abcdef
     pullPolicy: IfNotPresent
   imagePullSecrets: [ ]
   initcontainers: [ ]
@@ -46,9 +48,12 @@ operator:
       ephemeral-storage: 500Mi
 
 console:
+  enabled: true
   image:
     repository: quay.io/minio/operator
     tag: v5.0.5
+    # Setting the digest takes precedence over the tag
+    digest: ""  # e.g. sha256:123456789abcdef123456789abcdef123456789abcdef123456789abcdef
     pullPolicy: IfNotPresent
   imagePullSecrets: [ ]
   initcontainers: [ ]

--- a/helm/tenant/templates/_helpers.tpl
+++ b/helm/tenant/templates/_helpers.tpl
@@ -82,3 +82,12 @@ Selector labels Operator
 app.kubernetes.io/name: {{ include "minio-operator.name" . }}
 app.kubernetes.io/instance: {{ printf "%s-%s" .Release.Name "console" }}
 {{- end -}}
+
+{{/*
+Image with tag/digest
+*/}}
+{{- define "minio-operator.image" -}}
+{{- $tag := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
+{{- $digest := ternary "" (printf "@%s" .digest) (empty .digest) -}}
+{{- printf "%s%s%s" .repository $tag $digest -}}
+{{- end -}}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -19,7 +19,7 @@ metadata:
     name: {{ dig "scheduler" "name" "" . }}
   {{- end }}
 spec:
-  image: {{ dig "image" "repository" "minio/minio" . }}{{ ternary (printf ":%s" (dig "image" "tag" "RELEASE.2022-01-08T03-11-54Z" .)) (printf "@%s" .image.digest) (empty (dig "image" "digest" nil .)) }}
+  image: {{ include "minio-operator.image" (merge .image (dict "repository" "minio/minio" "tag" "RELEASE.2022-01-08T03-11-54Z")) | quote }}
   imagePullPolicy: {{ dig "image" "pullPolicy" "IfNotPresent" . }}
   {{- if dig "imagePullSecret" "name" "" . }}
   imagePullSecret:

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -19,7 +19,7 @@ metadata:
     name: {{ dig "scheduler" "name" "" . }}
   {{- end }}
 spec:
-  image: {{ dig "image" "repository" "minio/minio" . }}:{{ dig "image" "tag" "RELEASE.2022-01-08T03-11-54Z" . }}
+  image: {{ dig "image" "repository" "minio/minio" . }}{{ ternary (printf ":%s" (dig "image" "tag" "RELEASE.2022-01-08T03-11-54Z" .)) (printf "@%s" .image.digest) (empty (dig "image" "digest" nil .)) }}
   imagePullPolicy: {{ dig "image" "pullPolicy" "IfNotPresent" . }}
   {{- if dig "imagePullSecret" "name" "" . }}
   imagePullSecret:

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -13,6 +13,8 @@ tenant:
   image:
     repository: quay.io/minio/minio
     tag: RELEASE.2023-05-27T05-56-19Z
+    # Setting the digest takes precedence over the tag
+    digest: ""  # e.g. sha256:123456789abcdef123456789abcdef123456789abcdef123456789abcdef
     pullPolicy: IfNotPresent
   ## Customize any private registry image pull secret.
   ## currently only one secret registry is supported

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -12,9 +12,8 @@ tenant:
   ## Registry location and Tag to download MinIO Server image
   image:
     repository: quay.io/minio/minio
-    tag: RELEASE.2023-05-27T05-56-19Z
-    # Setting the digest takes precedence over the tag
-    digest: ""  # e.g. sha256:123456789abcdef123456789abcdef123456789abcdef123456789abcdef
+    tag: RELEASE.2023-05-27T05-56-19Z  # Set to "-" to ignore default value of "RELEASE.2022-01-08T03-11-54Z"
+    digest: ""
     pullPolicy: IfNotPresent
   ## Customize any private registry image pull secret.
   ## currently only one secret registry is supported


### PR DESCRIPTION
Helm chart features:
- Ability to add image digests for operator and minio images instead of tags in both charts.  Digests will override tag if both are present.
- Ability to disable console in operator chart using `console.enabled=false`.  Default is enabled.

There shouldn't be any breaking changes.  Defaults were preserved.

Closes #1598

Closes #1599 