### PR TITLE
Fix Hop Websockets

### DIFF
--- a/api/configure_operator.go
+++ b/api/configure_operator.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/klauspost/compress/gzhttp"
 	"io"
 	"io/fs"
 	"net/http"
@@ -32,6 +31,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/klauspost/compress/gzhttp"
 
 	"github.com/minio/operator/pkg/logger"
 	"github.com/minio/operator/pkg/utils"

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -19,6 +19,7 @@ package api
 import (
 	"bytes"
 	"crypto/sha1"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -276,6 +277,9 @@ func handleWSRequest(responseWriter http.ResponseWriter, req *http.Request, prox
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: 45 * time.Second,
 		Jar:              proxyCookieJar,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
 	}
 
 	upgrader.CheckOrigin = func(r *http.Request) bool {

--- a/cmd/operator/ui.go
+++ b/cmd/operator/ui.go
@@ -108,7 +108,7 @@ func buildOperatorServer() (*api.Server, error) {
 	server := api.NewServer(operatorapi)
 
 	parser := flags.NewParser(server, flags.Default)
-	parser.ShortDescription = "MinIO Console Server"
+	parser.ShortDescription = "MinIO Operator Server"
 	parser.LongDescription = swaggerSpec.Spec().Info.Description
 
 	server.ConfigureFlags()


### PR DESCRIPTION
Fixes websockets in hope iframes. This was caused by a corruption of the http.ResponseWriter by the AuditLogger middleware.

# To Test this PR
1.- Deploy a tenant via the `Operator UI`
2.- Wait for the tenant to come online
3.- in the tenant details screen, use the Hop button to get into the tenant
4.- Create a bucket, upload some files
5.- The bucket should list the files