### PR TITLE
Allow operator console to be hosted at subpath

### DIFF
--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -13,4 +13,5 @@ Operator behavior can be customized using environment variables in the `minio-op
 |OPERATOR_STS_ENABLED| This toggles the STS Service on or off                                                                                                                         | `on`, `off`                 | `off`                           |
 |MINIO_CONSOLE_DEPLOYMENT_NAME| This is the default name of the console deployment                                                                                                                                |                  | `console`                       |
 |MINIO_CONSOLE_TLS_ENABLE| This toggles the Console TLS on or off                                                                                                                                   | `on`, `off`                 | `off`                           |
-|WATCHED_NAMESPACE| The namespaces which the operator watches for MinIO tenants. Defaults to `""` for all namespaces.                                                                              |                         |                               |
+|WATCHED_NAMESPACE| The namespaces which the operator watches for MinIO tenants. Defaults to `""` for all namespaces.
+|OPERATOR_SUBPATH| the subpath that the operator console is served from.   


### PR DESCRIPTION
It is a common practice to server k8s hosted applications at a subpath, current this does not work, but appears that is is meant to.  Used [Mino/console PR 275](https://github.com/minio/console/pull/2725) as reference.