### PR TITLE
fix: krew plugin not assigning pool name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ plugin: regen-crd
 		GO111MODULE=on ${GOPATH}/bin/golangci-lint cache clean && \
 		GO111MODULE=on ${GOPATH}/bin/golangci-lint run --timeout=5m --config ../.golangci.yml)
 
+plugin-binary: plugin
+	@(cd $(PLUGIN_HOME) && CGO_ENABLED=0 go build -trimpath --ldflags $(LDFLAGS) -o kubectl-minio .)
 
 generate-code:
 	@./k8s/update-codegen.sh

--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -16,6 +16,7 @@
 package resources
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"log"
@@ -97,6 +98,11 @@ func Pool(opts *TenantOptions, volumes int32, q resource.Quantity) miniov2.Pool 
 		}
 	}
 	return p
+}
+
+// GeneratePoolName Pool Name Generator
+func GeneratePoolName(poolNumber int) string {
+	return fmt.Sprintf("pool-%d", poolNumber)
 }
 
 // GetSchemeDecoder returns a decoder for the scheme's that we use

--- a/kubectl-minio/cmd/tenant-expand.go
+++ b/kubectl-minio/cmd/tenant-expand.go
@@ -129,6 +129,11 @@ func (v *expandCmd) run() error {
 		return err
 	}
 
+	// Tenant pool id is zero based, generating pool using the count of existing pools in the tenant
+	if v.tenantOpts.PoolName == "" {
+		v.tenantOpts.PoolName = resources.GeneratePoolName(len(t.Spec.Pools))
+	}
+
 	t.Spec.Pools = append(t.Spec.Pools, resources.Pool(&v.tenantOpts, volumesPerServer, *capacityPerVolume))
 	expandedCapacity := helpers.TotalCapacity(*t)
 	if !v.output {


### PR DESCRIPTION
## What this do
* `kubectl minio tenant expand` Setting a default name to the new pool when no explicit name is assigned
* Add make target `plugin-binary` to build krew plugin locally

Related to https://github.com/minio/operator/issues/1613


## how to test

1) Rebuild kubectl krew command

```sh
make -B "plugin-binary"
```

2) install plugin 
```sh
cp kubectl-minio/kubectl-minio ~/.krew/bin/kubectl-minio-dev
```

3) expand tenant with plugin, do not assign a name to the pool

```sh
kubectl-minio-dev tenant expand minio-tenant-1 -n minio-tenant-1 --servers 3 --storage-class standard --volumes 6 --capacity 16Gi

Expanding Tenant 'minio-tenant-1/minio-tenant-1' from 1.0 TiB to 1.0 TiB

```

4) should list the new pool in Operator console

![list new pool](https://github.com/minio/operator/assets/1334362/cf5905b5-7196-49d8-bd96-8ad88419d780)
