### PR TITLE
Applying same console fix for the subpath issue

### DIFF
--- a/cmd/operator/ui.go
+++ b/cmd/operator/ui.go
@@ -103,6 +103,10 @@ func buildOperatorServer() (*api.Server, error) {
 		return nil, err
 	}
 
+	subPath := api.GetSubPath()
+	swaggerSpec.Spec().BasePath = subPath + swaggerSpec.Spec().BasePath
+	swaggerSpec.OrigSpec().BasePath = subPath + swaggerSpec.OrigSpec().BasePath
+
 	operatorapi := operations.NewOperatorAPI(swaggerSpec)
 	operatorapi.Logger = api.LogInfo
 	server := api.NewServer(operatorapi)

--- a/web-app/src/api/index.ts
+++ b/web-app/src/api/index.ts
@@ -2,6 +2,7 @@ import { Api, Error, FullRequestParams, HttpResponse } from "./operatorApi";
 
 export let api = new Api();
 const internalRequestFunc = api.request;
+api.baseUrl = `${new URL(document.baseURI).pathname}api/v1`;
 api.request = async <T = any, E = any>({
   body,
   secure,


### PR DESCRIPTION
### Objective:

To fix issue: https://github.com/minio/operator/issues/1607 and be able to use a sub-path for Operator UI.

### Story:

This issue is very similar to https://github.com/minio/console/issues/2045 and maybe same fix should apply here: https://github.com/minio/console/pull/2725

### Reasoning:

I think this fix is easier than console because we don't need minio binary for Operator, hence the testing is more straightforward

### How to test locally:

* Put the assets inside to test in port 9090:

```sh
cd ~/operator
make swagger-gen

cd ~/operator/web-app
yarn && yarn build
```

* Add a sub-path via env var as observed below

<img width="1152" alt="Screenshot 2023-05-26 at 8 03 38 AM" src="https://github.com/minio/operator/assets/6667358/bbd9cf78-1bf0-4ba7-a3cc-a7920f5739ae">

* Compile with the assets of this PR, and you will be able to load the UI from the sub-path as expected:

<img width="1840" alt="Screenshot 2023-05-26 at 8 04 07 AM" src="https://github.com/minio/operator/assets/6667358/15507762-56e0-4d26-88e1-006e61e50946">

Thank you https://github.com/polaris-phecda @polaris-phecda for the fix!.

### Also tested in k8s environment:

* Service using node port in kind:

```yaml
spec:
  ports:
    - name: http
      protocol: TCP
      port: 9090
      targetPort: 9090
      nodePort: 30082
    - name: https
      protocol: TCP
      port: 9443
      targetPort: 9443
      nodePort: 31813
  selector:
    app.kubernetes.io/instance: minio-operator-console
    app.kubernetes.io/name: operator
  clusterIP: 10.96.247.6
  clusterIPs:
    - 10.96.247.6
  type: NodePort
```

* Console Deployment:

```yaml
apiVersion: apps/v1
kind: Deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/instance: minio-operator-console
      app.kubernetes.io/name: operator
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/instance: minio-operator-console
        app.kubernetes.io/name: operator
    spec:
      containers:
        - name: operator
          image: docker.io/minio/operator:v5.0.4-13-g041a74ca
          args:
            - ui
            - '--certs-dir=/tmp/certs'
          ports:
            - name: http
              containerPort: 9090
              protocol: TCP
            - name: https
              containerPort: 9443
              protocol: TCP
          env:
            - name: OPERATOR_SUBPATH
              value: /minio-operator/
```

* Created the image:

```
cd ~/operator
make docker
```

> Got

```
=> => naming to docker.io/minio/operator:v5.0.4-13-g041a74ca
```

> Loaded in the local cluster:

```
kind load docker-image docker.io/minio/operator:v5.0.4-13-g041a74ca
```

* Changed images in the Deployments to test.

<img width="1840" alt="Screenshot 2023-05-26 at 8 59 44 AM" src="https://github.com/minio/operator/assets/6667358/c4f1a90a-a58a-43bf-bf17-911290f2efbc">
