### PR TITLE
moving Tenant scheduler to correct location

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -14,10 +14,10 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/scheme: {{ dig "metrics" "protocol" "http" . | quote }}
   {{- end }}
-  {{- if dig "scheduler" "name" "" . }}
-  scheduler:
-    name: {{ dig "scheduler" "name" "" . }}
-  {{- end }}
+{{- if dig "scheduler" "name" "" . }}
+scheduler:
+  name: {{ dig "scheduler" "name" "" . }}
+{{- end }}
 spec:
   image: {{ dig "image" "repository" "minio/minio" . }}:{{ dig "image" "tag" "RELEASE.2022-01-08T03-11-54Z" . }}
   imagePullPolicy: {{ dig "image" "pullPolicy" "IfNotPresent" . }}


### PR DESCRIPTION
Scheduler in the tenant resource was under metadata.scheduler.  This fails when specifying any scheduler.  Moving it to .scheduler according to the CRD schema.

Schema Reference:
```
      schema:
        openAPIV3Schema:
          properties:
            apiVersion:
              type: string
            kind:
              type: string
            metadata:
              type: object
            scheduler:
              properties:
                name:
                  type: string
```