### PR TITLE
Fix failing React pipeline test

### DIFF
--- a/web-app/src/screens/LoginPage/LoginPage.tsx
+++ b/web-app/src/screens/LoginPage/LoginPage.tsx
@@ -292,10 +292,6 @@ const Login = () => {
 
   const isK8S = useSelector((state: AppState) => state.login.isK8S);
 
-  const isOperator =
-    loginStrategy.loginStrategy === loginStrategyType.serviceAccount ||
-    loginStrategy.loginStrategy === loginStrategyType.redirectServiceAccount;
-
   useEffect(() => {
     if (navigateTo !== "") {
       dispatch(resetForm());


### PR DESCRIPTION
This commit removes the unused isOperator variable on LoginPage.tsx file
which was causing the No React Warnings pipeline test to fail.