### PR TITLE
Fix timing error leading to a false positive.

### DIFF
--- a/testing/console-tenant+kes.sh
+++ b/testing/console-tenant+kes.sh
@@ -73,6 +73,7 @@ function test_kes_tenant() {
     end_time=$((SECONDS + 120)) #timeout the log search 120 seconds
     while [ $SECONDS -lt $end_time ]; do
       if kubectl logs -l app=vault | grep -q "Root Token: "; then
+        # shellcheck disable=SC2155
         export VAULT_ROOT_TOKEN=$(kubectl logs -l app=vault | grep "Root Token: " | sed -e "s/Root Token: //g")
         break
       fi


### PR DESCRIPTION
# What is the isse?
When the KES pod starts we read from the pod logs the "Root Token" 

https://github.com/minio/operator/blob/5ef838a70a45d9a7de9a5400be153bcbdb2e5223/testing/console-tenant%2Bkes.sh#L73

However pod running doesn't mean vault process inside already reached that step on the init process and we end up with an empty root token sometimes

# Solution

We wait for the KES deploy Status instead of the pod running, then we wait for the log message to show, with timeout.
If the log message doesn't show, this time is a possitive fail.