### PR TITLE
Set the env var `MINIO_SERVER_URL`

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -108,6 +108,8 @@ func minioEnvironmentVars(t *miniov2.Tenant, skipEnvVars map[string][]byte, opVe
 				useSchema = "https"
 			}
 			serverURL = fmt.Sprintf("%s://%s", useSchema, t.Spec.Features.Domains.Minio[0])
+		} else {
+			serverURL = t.Spec.Features.Domains.Minio[0]
 		}
 	}
 	envVarsMap[miniov2.MinIOServerURL] = corev1.EnvVar{


### PR DESCRIPTION
Operator should set `MINIO_DOMAIN` and `MINIO_SERVER_URL` in the pool statefulset when a domain is specified on Operator console.

Fixes: https://github.com/minio/operator/issues/1601

### Steps to test
Follow the steps mentioned in github issue.
It fixes the issue as below

![image](https://github.com/minio/operator/assets/6771252/73995b46-6406-4f39-9dce-ea8f98e9ee61)

![image](https://github.com/minio/operator/assets/6771252/24b4c791-74bd-4049-9e8e-003e71c854ec)


