### PR TITLE
display configured kms policies from kes config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ nancy
 examples/.DS_Store
 testing/openshift/bundle/*
 examples/**/obj/
+.idea

--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -2726,6 +2726,9 @@ func init() {
               "type": "object",
               "$ref": "#/definitions/keyPairConfiguration"
             },
+            "policies": {
+              "type": "object"
+            },
             "raw": {
               "type": "string"
             },
@@ -2797,6 +2800,9 @@ func init() {
             "minio_mtls": {
               "type": "object",
               "$ref": "#/definitions/certificateInfo"
+            },
+            "policies": {
+              "type": "object"
             },
             "raw": {
               "type": "string"
@@ -8245,6 +8251,9 @@ func init() {
               "type": "object",
               "$ref": "#/definitions/keyPairConfiguration"
             },
+            "policies": {
+              "type": "object"
+            },
             "raw": {
               "type": "string"
             },
@@ -8316,6 +8325,9 @@ func init() {
             "minio_mtls": {
               "type": "object",
               "$ref": "#/definitions/certificateInfo"
+            },
+            "policies": {
+              "type": "object"
             },
             "raw": {
               "type": "string"

--- a/api/encryption-handlers.go
+++ b/api/encryption-handlers.go
@@ -463,7 +463,9 @@ func getConfigurationResponseFromV1(ctx context.Context, clientSet K8sClientI, r
 		}
 		encryptConfig.Azure = azureConfig
 	}
-
+	if kesConfiguration.Policies != nil {
+		encryptConfig.Policies = kesConfiguration.Policies
+	}
 	return nil
 }
 
@@ -589,6 +591,9 @@ func getConfigurationResponseFromV2(ctx context.Context, clientSet K8sClientI, r
 			return err
 		}
 		encryptConfig.Azure = azureConfig
+	}
+	if kesConfiguration.Policies != nil {
+		encryptConfig.Policies = kesConfiguration.Policies
 	}
 	return nil
 }

--- a/models/encryption_configuration.go
+++ b/models/encryption_configuration.go
@@ -57,6 +57,9 @@ type EncryptionConfiguration struct {
 	// minio mtls
 	MinioMtls *KeyPairConfiguration `json:"minio_mtls,omitempty"`
 
+	// policies
+	Policies interface{} `json:"policies,omitempty"`
+
 	// raw
 	Raw string `json:"raw,omitempty"`
 
@@ -101,6 +104,8 @@ func (m *EncryptionConfiguration) UnmarshalJSON(raw []byte) error {
 
 		MinioMtls *KeyPairConfiguration `json:"minio_mtls,omitempty"`
 
+		Policies interface{} `json:"policies,omitempty"`
+
 		Raw string `json:"raw,omitempty"`
 
 		Replicas string `json:"replicas,omitempty"`
@@ -130,6 +135,8 @@ func (m *EncryptionConfiguration) UnmarshalJSON(raw []byte) error {
 	m.KmsMtls = dataAO1.KmsMtls
 
 	m.MinioMtls = dataAO1.MinioMtls
+
+	m.Policies = dataAO1.Policies
 
 	m.Raw = dataAO1.Raw
 
@@ -170,6 +177,8 @@ func (m EncryptionConfiguration) MarshalJSON() ([]byte, error) {
 
 		MinioMtls *KeyPairConfiguration `json:"minio_mtls,omitempty"`
 
+		Policies interface{} `json:"policies,omitempty"`
+
 		Raw string `json:"raw,omitempty"`
 
 		Replicas string `json:"replicas,omitempty"`
@@ -196,6 +205,8 @@ func (m EncryptionConfiguration) MarshalJSON() ([]byte, error) {
 	dataAO1.KmsMtls = m.KmsMtls
 
 	dataAO1.MinioMtls = m.MinioMtls
+
+	dataAO1.Policies = m.Policies
 
 	dataAO1.Raw = m.Raw
 

--- a/models/encryption_configuration_response.go
+++ b/models/encryption_configuration_response.go
@@ -57,6 +57,9 @@ type EncryptionConfigurationResponse struct {
 	// minio mtls
 	MinioMtls *CertificateInfo `json:"minio_mtls,omitempty"`
 
+	// policies
+	Policies interface{} `json:"policies,omitempty"`
+
 	// raw
 	Raw string `json:"raw,omitempty"`
 
@@ -98,6 +101,8 @@ func (m *EncryptionConfigurationResponse) UnmarshalJSON(raw []byte) error {
 
 		MinioMtls *CertificateInfo `json:"minio_mtls,omitempty"`
 
+		Policies interface{} `json:"policies,omitempty"`
+
 		Raw string `json:"raw,omitempty"`
 
 		Replicas string `json:"replicas,omitempty"`
@@ -125,6 +130,8 @@ func (m *EncryptionConfigurationResponse) UnmarshalJSON(raw []byte) error {
 	m.KmsMtls = dataAO1.KmsMtls
 
 	m.MinioMtls = dataAO1.MinioMtls
+
+	m.Policies = dataAO1.Policies
 
 	m.Raw = dataAO1.Raw
 
@@ -163,6 +170,8 @@ func (m EncryptionConfigurationResponse) MarshalJSON() ([]byte, error) {
 
 		MinioMtls *CertificateInfo `json:"minio_mtls,omitempty"`
 
+		Policies interface{} `json:"policies,omitempty"`
+
 		Raw string `json:"raw,omitempty"`
 
 		Replicas string `json:"replicas,omitempty"`
@@ -187,6 +196,8 @@ func (m EncryptionConfigurationResponse) MarshalJSON() ([]byte, error) {
 	dataAO1.KmsMtls = m.KmsMtls
 
 	dataAO1.MinioMtls = m.MinioMtls
+
+	dataAO1.Policies = m.Policies
 
 	dataAO1.Raw = m.Raw
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -2027,6 +2027,8 @@ definitions:
                 type: string
               ca:
                 type: string
+          policies:
+            type: object
           gemalto:
             type: object
             $ref: "#/definitions/gemaltoConfiguration"
@@ -2053,6 +2055,8 @@ definitions:
         properties:
           raw:
             type: string
+          policies:
+            type: object
           image:
             type: string
           replicas:

--- a/web-app/src/api/operatorApi.ts
+++ b/web-app/src/api/operatorApi.ts
@@ -308,6 +308,7 @@ export type EncryptionConfiguration = MetadataFields & {
     crt?: string;
     ca?: string;
   };
+  policies?: object;
   gemalto?: GemaltoConfiguration;
   aws?: AwsConfiguration;
   vault?: VaultConfiguration;
@@ -318,6 +319,7 @@ export type EncryptionConfiguration = MetadataFields & {
 
 export type EncryptionConfigurationResponse = MetadataFields & {
   raw?: string;
+  policies?: object;
   image?: string;
   replicas?: string;
   server_tls?: CertificateInfo;

--- a/web-app/src/screens/Console/Tenants/TenantDetails/KMSPolicyInfo.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/KMSPolicyInfo.tsx
@@ -1,0 +1,107 @@
+import React, { Fragment } from "react";
+import Grid from "@mui/material/Grid";
+import { Box } from "mds";
+
+const getPolicyData = (policies: Record<string, any> = {}) => {
+  const policyNames = Object.keys(policies);
+  return policyNames.map((polName: string) => {
+    const policyConfig = policies[polName] || {};
+    return {
+      name: polName || "",
+      identities: policyConfig.identities || [],
+      // v1 specific
+      paths: policyConfig.paths || [],
+      // v2 specific
+      allow: policyConfig.allow || [],
+      deny: policyConfig.deny || [],
+    };
+  });
+};
+
+const PolicyItem = ({
+  items = [],
+  title = "",
+}: {
+  items: string[];
+  title: string;
+}) => {
+  return items?.length ? (
+    <Fragment>
+      <div
+        style={{
+          fontSize: "0.83em",
+          fontWeight: "bold",
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: "2px",
+          flexFlow: "column",
+          marginLeft: "8px",
+        }}
+      >
+        {items.map((iTxt: string) => {
+          return <span style={{ fontSize: "12px" }}>- {iTxt}</span>;
+        })}
+      </div>
+    </Fragment>
+  ) : null;
+};
+
+const KMSPolicyInfo = ({
+  policies = {},
+}: {
+  policies: Record<string, any>;
+}) => {
+  const fmtPolicies = getPolicyData(policies);
+  return fmtPolicies.length ? (
+    <Grid xs={12} marginBottom={"5px"}>
+      <h4>Policies</h4>
+      <Box
+        withBorders
+        sx={{
+          maxHeight: "200px",
+          overflow: "auto",
+          padding: 0,
+        }}
+      >
+        {fmtPolicies.map((pConf: Record<string, any>) => {
+          return (
+            <Box
+              withBorders
+              sx={{
+                display: "flex",
+                flexFlow: "column",
+                gap: "2px",
+                borderLeft: 0,
+                borderRight: 0,
+                borderTop: 0,
+              }}
+            >
+              <div>
+                <b
+                  style={{
+                    fontSize: "0.83em",
+                    fontWeight: "bold",
+                  }}
+                >
+                  Policy Name:
+                </b>{" "}
+                {pConf.name}
+              </div>
+              <PolicyItem title={"Allow"} items={pConf?.allow} />
+              <PolicyItem title={"Deny"} items={pConf?.deny} />
+              <PolicyItem title={"Paths"} items={pConf?.paths} />
+              <PolicyItem title={"Identities"} items={pConf?.identities} />
+            </Box>
+          );
+        })}
+      </Box>
+    </Grid>
+  ) : null;
+};
+
+export default KMSPolicyInfo;

--- a/web-app/src/screens/Console/Tenants/TenantDetails/KMSPolicyInfo.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/KMSPolicyInfo.tsx
@@ -1,3 +1,19 @@
+// This file is part of MinIO Operator
+// Copyright (c) 2023 MinIO, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import React, { Fragment } from "react";
 import Grid from "@mui/material/Grid";
 import { Box } from "mds";

--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx
@@ -1,5 +1,5 @@
 // This file is part of MinIO Operator
-// Copyright (c) 2022 MinIO, Inc.
+// Copyright (c) 2023 MinIO, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by

--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantEncryption.tsx
@@ -16,7 +16,7 @@
 
 import { ICertificateInfo, ITenantEncryptionResponse } from "../types";
 import { Theme } from "@mui/material/styles";
-import { Button, WarnIcon } from "mds";
+import { Button, WarnIcon, SectionTitle } from "mds";
 import createStyles from "@mui/styles/createStyles";
 import withStyles from "@mui/styles/withStyles";
 import {
@@ -50,13 +50,13 @@ import {
 } from "../../../../utils/validationFunctions";
 import ConfirmDialog from "../../Common/ModalWrapper/ConfirmDialog";
 import TLSCertificate from "../../Common/TLSCertificate/TLSCertificate";
-import SectionTitle from "../../Common/SectionTitle";
 import { setErrorSnackMessage } from "../../../../systemSlice";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import CodeMirrorWrapper from "../../Common/FormComponents/CodeMirrorWrapper/CodeMirrorWrapper";
 import FormHr from "../../Common/FormHr";
 import { SecurityContext } from "../../../../api/operatorApi";
+import KMSPolicyInfo from "./KMSPolicyInfo";
 
 interface ITenantEncryption {
   classes: any;
@@ -105,6 +105,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
     runAsNonRoot: true,
     runAsUser: "1000",
   });
+  const [policies, setPolicies] = useState<any>([]);
   const [vaultConfiguration, setVaultConfiguration] = useState<any>(null);
   const [awsConfiguration, setAWSConfiguration] = useState<any>(null);
   const [gemaltoConfiguration, setGemaltoConfiguration] = useState<any>(null);
@@ -356,7 +357,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
   ]);
 
   const fetchEncryptionInfo = () => {
-    if (!refreshEncryptionInfo) {
+    if (!refreshEncryptionInfo && tenant?.namespace && tenant?.name) {
       setRefreshEncryptionInfo(true);
       api
         .invoke(
@@ -365,6 +366,9 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
         )
         .then((resp: ITenantEncryptionResponse) => {
           setEncryptionRawConfiguration(resp.raw);
+          if (resp.policies) {
+            setPolicies(resp.policies);
+          }
           if (resp.vault) {
             setEncryptionType("vault");
             setVaultConfiguration(resp.vault);
@@ -413,7 +417,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
   useEffect(() => {
     fetchEncryptionInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [tenant]);
 
   const removeCertificate = (certificateInfo: ICertificateInfo) => {
     setCertificatesToBeRemoved([
@@ -677,7 +681,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
       )}
       <Grid container spacing={1}>
         <Grid item xs>
-          <h1 className={classes.sectionTitle}>Encryption</h1>
+          <SectionTitle>Encryption</SectionTitle>
         </Grid>
         <Grid item xs={4} justifyContent={"end"} textAlign={"right"}>
           <FormSwitchWrapper
@@ -730,6 +734,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
               </Fragment>
             ) : (
               <Fragment>
+                <KMSPolicyInfo policies={policies} />
                 <Grid item xs={12} className={classes.encryptionTypeOptions}>
                   <RadioGroupSelector
                     currentSelection={encryptionType}
@@ -748,6 +753,7 @@ const TenantEncryption = ({ classes }: ITenantEncryption) => {
                     ]}
                   />
                 </Grid>
+
                 {encryptionType === "vault" && (
                   <Fragment>
                     <Grid item xs={12}>

--- a/web-app/src/screens/Console/Tenants/types.ts
+++ b/web-app/src/screens/Console/Tenants/types.ts
@@ -89,6 +89,7 @@ export interface ITenantEncryptionResponse {
   raw: string;
   image: string;
   replicas: string;
+  policies?: Record<string, any>;
   securityContext: SecurityContext;
   server_tls: ICertificateInfo;
   minio_mtls: ICertificateInfo;


### PR DESCRIPTION
display configured kms policies from kes config

Currently the policies are visible only in Raw Edit mode. 

Also fix a refresh bug ( once in the tab, just reload the page and the encryption details api is called with undefined for tenant name)

Note: The editing of policy will still be done from Raw Edit mode Tab.

Testing:
```
have  A running kind cluster with operator/valult deployed 

e.g https://github.com/minio/operator/wiki/Vault,-KES-and-MinIO-Deployed-in-k8s-Cluster

TAG="minio/operator:prakash-test-v3" make all
kind load docker-image docker.io/minio/operator:prakash-test-v3

kubectl kustomize . > operator-test.yaml
# Edit the operator Image  to docker.io/minio/operator:prakash-test-v3
kubectl apply -f operator-test.yaml
#Wait for tenat pods to restart
kubectl minio proxy -n minio-operator

Refresh the tenant and verify that the kms  policies are displayed if available (if not defined it is not displayed)

If there are more policies, they are displayed inside of the scroll able area separated by a line.
```

how does it look:
![With_Policy](https://github.com/minio/operator/assets/23444145/55a8020d-4b8a-4899-863a-ff253b77aaf3)

![No_Policy](https://github.com/minio/operator/assets/23444145/39adb7d7-8229-4ea2-a364-ea4cd9776c84)





