### PR TITLE
Added bucket schema example to tenant values file

### DIFF
--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -99,7 +99,11 @@ tenant:
   features:
     bucketDNS: false
     domains: { }
-  ## List of bucket names to create during tenant provisioning
+  ## List of bucket definitions to create during tenant provisioning.
+  ## Example:
+  #   - name: my-minio-bucket
+  #     objectLock: false        # optional
+  #     region: us-east-1        # optional
   buckets: [ ]
   ## List of secret names to use for generating MinIO users during tenant provisioning
   users: [ ]


### PR DESCRIPTION
The previous comment implied it was a list of strings, which fails object creation in the cluster, so adding an example might save someone the time of having to look it up in the CRD or elsewhere.