### PR TITLE
Updating OpenShift Version

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -190,7 +190,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # as well as the default.
   {
     echo "  # Annotations to specify OCP versions compatibility."
-    echo "  com.redhat.openshift.versions: v4.8-v4.12"
+    echo "  com.redhat.openshift.versions: v4.8-v4.13"
     echo "  # Annotation to add default bundle channel as potential is declared"
     echo "  operators.operatorframework.io.bundle.channel.default.v1: stable"
   } >> bundles/$catalog/$RELEASE/metadata/annotations.yaml


### PR DESCRIPTION
### Objective:

To support OpenShift Version 4.13 in our Annotations for the Catalogs.