### PR TITLE
fix broken request error handling

### DIFF
--- a/web-app/src/common/api/index.ts
+++ b/web-app/src/common/api/index.ts
@@ -62,13 +62,11 @@ export class API {
 
   onError(err: any) {
     if (err.status) {
-      const errMessage = get(
-        err.response,
-        "body.message",
-        `Error ${err.status.toString()}`
-      );
+      const errMessage =
+        get(err.response, "body.message", `Error ${err.status.toString()}`) ||
+        "";
 
-      let detailedMessage = get(err.response, "body.detailedMessage", "");
+      let detailedMessage = get(err.response, "body.detailedMessage", "") || "";
 
       if (errMessage === detailedMessage) {
         detailedMessage = "";

--- a/web-app/src/common/types.ts
+++ b/web-app/src/common/types.ts
@@ -166,6 +166,7 @@ export interface ErrorResponseHandler {
   errorMessage: string;
   detailedError: string;
   statusCode?: number;
+  message?: string; // if any type error thrown
 }
 
 export interface IBytesCalc {

--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantYAML.tsx
@@ -87,21 +87,24 @@ const TenantYAML = ({ classes }: ITenantYAMLProps) => {
       })
       .catch((err: ErrorResponseHandler) => {
         setAddLoading(false);
-        setErrorMessage(err.errorMessage);
+        const errMessage = err?.message || "" || err.errorMessage;
+        setErrorMessage(errMessage);
       });
   };
 
   useEffect(() => {
-    api
-      .invoke("GET", `/api/v1/namespaces/${namespace}/tenants/${tenant}/yaml`)
-      .then((res: ITenantYAML) => {
-        setLoading(false);
-        setTenantYaml(res.yaml);
-      })
-      .catch((err: ErrorResponseHandler) => {
-        setLoading(false);
-        dispatch(setModalErrorSnackMessage(err));
-      });
+    if (namespace && tenant) {
+      api
+        .invoke("GET", `/api/v1/namespaces/${namespace}/tenants/${tenant}/yaml`)
+        .then((res: ITenantYAML) => {
+          setLoading(false);
+          setTenantYaml(res.yaml);
+        })
+        .catch((err: ErrorResponseHandler) => {
+          setLoading(false);
+          dispatch(setModalErrorSnackMessage(err));
+        });
+    }
   }, [tenant, namespace, dispatch]);
 
   useEffect(() => {}, []);
@@ -116,15 +119,13 @@ const TenantYAML = ({ classes }: ITenantYAMLProps) => {
             <LinearProgress />
           </Grid>
         ))}
-      {errorMessage !== "" && (
-        <div className={classes.errorState}>{errorMessage}</div>
-      )}
 
       {!loading && (
         <form
           noValidate
           autoComplete="off"
           onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+            e.preventDefault();
             updateTenant(e);
           }}
         >
@@ -132,7 +133,26 @@ const TenantYAML = ({ classes }: ITenantYAMLProps) => {
             <Grid item xs={12}>
               <SectionTitle>Tenant Specification</SectionTitle>
             </Grid>
-            <Grid item xs={12}>
+            {errorMessage ? (
+              <Grid
+                item
+                xs={12}
+                sx={{
+                  marginTop: "5px",
+                  marginBottom: "2px",
+                  border: "1px solid #b53b4b",
+                  borderRadius: "2px",
+                  padding: "5px",
+                }}
+              >
+                <div className={classes.errorState}>{errorMessage}</div>
+              </Grid>
+            ) : null}
+            <Grid
+              item
+              xs={12}
+              sx={errorMessage ? { border: "1px solid #b53b4b" } : {}}
+            >
               <CodeMirrorWrapper
                 value={tenantYaml}
                 mode={"yaml"}


### PR DESCRIPTION
fix broken request error handling

common error handler was crashing with TypeError  because of methods invoked on null object. 

Fixed and improved the error display in Yaml edittor 

Fixes #1655

How does it look:
![Screenshot from 2023-07-06 17-10-58](https://github.com/minio/operator/assets/23444145/b01e2d1e-1879-49a3-bbd2-6c4b49bf01a2)

