### PR TITLE
Warning instead of panic on Discovery().ServerPreferredResources()

### DIFF
--- a/pkg/controller/certificates/csr.go
+++ b/pkg/controller/certificates/csr.go
@@ -87,7 +87,7 @@ func GetCertificatesAPIVersion(clientSet kubernetes.Interface) CSRVersion {
 					klog.Warningf("The Kubernetes server has an orphaned API service. Server reports: %s", err)
 					klog.Warningf("To fix this, check related API Server or kubectl delete apiservice <service-name>")
 				} else {
-					panic(err)
+					klog.Warningf("API Discovery failed, Certificate generation might be affected: %s", err)
 				}
 			}
 			for _, api := range apiVersions {


### PR DESCRIPTION
There is many reasons why discrovery API might fail, warning error instead of panic in this API call error.

Closes https://github.com/minio/operator/issues/1443