### PR TITLE
Added logic to set custom images for init container and sidecar

### DIFF
--- a/kubectl-minio/cmd/init.go
+++ b/kubectl-minio/cmd/init.go
@@ -87,6 +87,8 @@ func newInitCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	f.StringVar(&o.operatorOpts.PrometheusNamespace, "prometheus-namespace", "", "namespace of the prometheus managed by prometheus-operator")
 	f.StringVar(&o.operatorOpts.PrometheusName, "prometheus-name", "", "name of the prometheus managed by prometheus-operator")
 	f.BoolVarP(&o.output, "output", "o", false, "dry run this command and generate requisite yaml")
+	f.StringVar(&o.operatorOpts.InitContainerImage, "init-container-image", "", "init container image")
+	f.StringVar(&o.operatorOpts.SidecarImage, "sidecar-image", "", "sidecar image")
 
 	return cmd
 }
@@ -238,6 +240,26 @@ func (o *operatorInitCmd) run(writer io.Writer) error {
 			Value: corev1.EnvVar{
 				Name:  "OPERATOR_STS_ENABLED",
 				Value: "on",
+			},
+		})
+	}
+	if o.operatorOpts.InitContainerImage != "" {
+		operatorDepPatches = append(operatorDepPatches, opInterface{
+			Op:   "add",
+			Path: "/spec/template/spec/containers/0/env/0",
+			Value: corev1.EnvVar{
+				Name:  "INIT_CONTAINER_IMAGE",
+				Value: o.operatorOpts.InitContainerImage,
+			},
+		})
+	}
+	if o.operatorOpts.SidecarImage != "" {
+		operatorDepPatches = append(operatorDepPatches, opInterface{
+			Op:   "add",
+			Path: "/spec/template/spec/containers/0/env/0",
+			Value: corev1.EnvVar{
+				Name:  "SIDECAR_IMAGE",
+				Value: o.operatorOpts.SidecarImage,
 			},
 		})
 	}

--- a/kubectl-minio/cmd/resources/deployment.go
+++ b/kubectl-minio/cmd/resources/deployment.go
@@ -31,4 +31,6 @@ type OperatorOptions struct {
 	PrometheusNamespace string
 	PrometheusName      string
 	STS                 bool
+	InitContainerImage  string
+	SidecarImage        string
 }

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -208,3 +208,7 @@ const PrometheusAddlScrapeConfigSecret = "minio-prom-additional-scrape-config"
 
 // PrometheusAddlScrapeConfigKey is the key in secret data
 const PrometheusAddlScrapeConfigKey = "prometheus-additional.yaml"
+
+const initContainerImageEnv = "INIT_CONTAINER_IMAGE"
+
+const sidecarImageEnv = "SIDECAR_IMAGE"

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -81,13 +81,17 @@ type hostsTemplateValues struct {
 }
 
 var (
-	once                    sync.Once
-	tenantMinIOImageOnce    sync.Once
-	tenantKesImageOnce      sync.Once
-	monitoringIntervalOnce  sync.Once
-	k8sClusterDomain        string
-	tenantMinIOImage        string
-	tenantKesImage          string
+	once                   sync.Once
+	tenantMinIOImageOnce   sync.Once
+	tenantKesImageOnce     sync.Once
+	monitoringIntervalOnce sync.Once
+	// initContainerImageOnce  sync.Once
+	// sidecarImageOnce        sync.Once
+	k8sClusterDomain string
+	tenantMinIOImage string
+	tenantKesImage   string
+	// initContainerImage      string
+	// sidecarImage            string
 	monitoringInterval      int
 	prometheusNamespace     string
 	prometheusName          string
@@ -942,6 +946,22 @@ func GetTenantKesImage() string {
 	})
 	return tenantKesImage
 }
+
+// // GetInitContainerImage returns the init container image
+// func GetInitContainerImage() string {
+// 	initContainerImageOnce.Do(func() {
+// 		initContainerImage = envGet(initContainerImageEnv, "")
+// 	})
+// 	return initContainerImage
+// }
+
+// // GetSidecarImage returns the sidecar image
+// func GetSidecarImage() string {
+// 	sidecarImageOnce.Do(func() {
+// 		sidecarImage = envGet(sidecarImageEnv, "")
+// 	})
+// 	return sidecarImage
+// }
 
 // GetMonitoringInterval returns how ofter we should query tenants for cluster/health
 func GetMonitoringInterval() int {

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -41,6 +41,10 @@ spec:
               value: "off"
             - name: OPERATOR_STS_ENABLED
               value: "off"
+            - name: SIDECAR_IMAGE
+              value: minio/operator:v5.0.6
+            - name: INIT_CONTAINER_IMAGE
+              value: minio/operator:v5.0.6
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1656,6 +1656,10 @@ definitions:
           $ref: "#/definitions/pool"
       image:
         type: string
+      initContainerImage:
+        type: string
+      sidecarImage:
+        type: string
       namespace:
         type: string
       total_size:
@@ -1821,6 +1825,10 @@ definitions:
         type: string
         pattern: "^[a-z0-9-]{3,63}$"
       image:
+        type: string
+      initContainerImage:
+        type: string
+      sidecarImage:
         type: string
       pools:
         type: array
@@ -3413,4 +3421,4 @@ definitions:
       filename:
         type: string
       blob:
-       type: string        
+       type: string


### PR DESCRIPTION
## How to test
Use below command to set the init container and sidecar images
`./kubectl-minio init --image docker.io/minio/operator:custom-images --init-container-image minio/operator:v5.0.6 --sidecar-image minio/operator:v5.0.6`

Then create a tenant as below

`./kubectl-minio tenant create tenant-1 --servers 4 --volumes 4 --capacity 16Gi --namespace tenant-ns`
