### PR TITLE
Add --force flag to minio  delete command

### DIFF
--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/helm/operator/templates/sts.min.io_policybindings.yaml
+++ b/helm/operator/templates/sts.min.io_policybindings.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -60,7 +60,7 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !o.force {
 				if !helpers.Ask("This will delete the MinIO Operator and ALL its data. Do you want to proceed") {
-					return fmt.Errorf(helpers.Bold("Aborting MinIO Operator deletion"))
+					return fmt.Errorf("Aborting MinIO Operator deletion")
 				}
 			}
 			err := o.run(out)

--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -45,6 +45,7 @@ type deleteCmd struct {
 	errOut       io.Writer
 	output       bool
 	operatorOpts resources.OperatorOptions
+	force        bool
 }
 
 func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
@@ -57,8 +58,10 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		Example: deleteExample,
 		Args:    cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !helpers.Ask("Are you sure you want to delete ALL the MinIO Tenants and MinIO Operator, this is not a reversible operation") {
-				return fmt.Errorf(Bold("Aborting Operator deletion"))
+			if !o.force {
+				if !helpers.Ask("This will delete the MinIO Operator and ALL its data. Do you want to proceed") {
+					return fmt.Errorf(helpers.Bold("Aborting MinIO Operator deletion"))
+				}
 			}
 			err := o.run(out)
 			if err != nil {
@@ -71,6 +74,7 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd = helpers.DisableHelp(cmd)
 	f := cmd.Flags()
 	f.StringVarP(&o.operatorOpts.Namespace, "namespace", "n", helpers.DefaultNamespace, "namespace scope for this request")
+	f.BoolVarP(&o.force, "force", "f", false, "force delete without confirmation")
 	return cmd
 }
 

--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -60,7 +60,7 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		Args:    cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !o.force {
-				if !helpers.Ask("This will delete the MinIO Operator and ALL its data. Do you want to proceed") {
+				if !helpers.Ask("Are you sure you want to delete MinIO Operator and all it's tenants? This is not a reversible operation.") {
 					return fmt.Errorf("Aborting MinIO Operator deletion")
 				}
 			}
@@ -80,8 +80,8 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	cmd = helpers.DisableHelp(cmd)
 	f := cmd.Flags()
 	f.StringVarP(&o.operatorOpts.Namespace, "namespace", "n", helpers.DefaultNamespace, "namespace scope for this request")
-	f.BoolVarP(&o.force, "force", "f", false, "force delete without confirmation")
-	f.BoolVarP(&o.dangerous, "dangerous", "d", false, "delete without confirmation")
+	f.BoolVarP(&o.force, "force", "f", false, "allow without confirmation")
+	f.BoolVarP(&o.dangerous, "dangerous", "d", false, "confirm deletion")
 	return cmd
 }
 

--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -46,6 +46,7 @@ type deleteCmd struct {
 	output       bool
 	operatorOpts resources.OperatorOptions
 	force        bool
+	dangerous    bool
 }
 
 func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
@@ -63,6 +64,11 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 					return fmt.Errorf("Aborting MinIO Operator deletion")
 				}
 			}
+			if !o.dangerous {
+				if !helpers.Ask("Please provide the dangerous flag to confirm deletion") {
+					return fmt.Errorf("Aborting MinIO Operator deletion")
+				}
+			}
 			err := o.run(out)
 			if err != nil {
 				klog.Warning(err)
@@ -75,6 +81,7 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&o.operatorOpts.Namespace, "namespace", "n", helpers.DefaultNamespace, "namespace scope for this request")
 	f.BoolVarP(&o.force, "force", "f", false, "force delete without confirmation")
+	f.BoolVarP(&o.dangerous, "dangerous", "d", false, "delete without confirmation")
 	return cmd
 }
 

--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -60,7 +60,7 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		Args:    cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !o.force {
-				if !helpers.Ask("This is irreversible, Are you sure you want to delete MinIO Operator and all it's tenants") {
+				if !helpers.Ask("This is irreversible, are you sure you want to delete MinIO Operator and all it's tenants") {
 					return fmt.Errorf("Aborting MinIO Operator deletion")
 				}
 			}

--- a/kubectl-minio/cmd/delete.go
+++ b/kubectl-minio/cmd/delete.go
@@ -60,7 +60,7 @@ func newDeleteCmd(out io.Writer, errOut io.Writer) *cobra.Command {
 		Args:    cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !o.force {
-				if !helpers.Ask("Are you sure you want to delete MinIO Operator and all it's tenants? This is not a reversible operation.") {
+				if !helpers.Ask("This is irreversible, Are you sure you want to delete MinIO Operator and all it's tenants") {
 					return fmt.Errorf("Aborting MinIO Operator deletion")
 				}
 			}

--- a/kubectl-minio/cmd/kubectl-minio.go
+++ b/kubectl-minio/cmd/kubectl-minio.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 // New creates a new root command for kubectl-minio
-func New(streams genericclioptions.IOStreams) *cobra.Command {
+func New(_ genericclioptions.IOStreams) *cobra.Command {
 	rootCmd = helpers.DisableHelp(rootCmd)
 	cobra.EnableCommandSorting = false
 	rootCmd.AddCommand(newInitCmd(rootCmd.OutOrStdout(), rootCmd.ErrOrStderr()))

--- a/kubectl-minio/cmd/resources/tenant.go
+++ b/kubectl-minio/cmd/resources/tenant.go
@@ -148,7 +148,7 @@ func NewTenant(opts *TenantOptions, userSecret *v1.Secret) (*miniov2.Tenant, err
 	return t, t.Validate()
 }
 
-func getAutoCertConfig(opts *TenantOptions) *miniov2.CertificateConfig {
+func getAutoCertConfig(_ *TenantOptions) *miniov2.CertificateConfig {
 	return &miniov2.CertificateConfig{
 		CommonName:       "",
 		OrganizationName: []string{},

--- a/kubectl-minio/cmd/tenant-create.go
+++ b/kubectl-minio/cmd/tenant-create.go
@@ -121,7 +121,7 @@ func (c *createCmd) validate(args []string) error {
 }
 
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
-func (c *createCmd) run(args []string) error {
+func (c *createCmd) run(_ []string) error {
 	// Create operator and kube client
 	path, _ := rootCmd.Flags().GetString(kubeconfig)
 	operatorClient, err := helpers.GetKubeOperatorClient(path)

--- a/kubectl-minio/cmd/tenant-list.go
+++ b/kubectl-minio/cmd/tenant-list.go
@@ -69,7 +69,7 @@ func (d *listCmd) validate(args []string) error {
 }
 
 // run initializes local config and installs MinIO Operator to Kubernetes cluster.
-func (d *listCmd) run(args []string) error {
+func (d *listCmd) run(_ []string) error {
 	// Create operator client
 	path, _ := rootCmd.Flags().GetString(kubeconfig)
 	oclient, err := helpers.GetKubeOperatorClient(path)

--- a/kubectl-minio/cmd/tenant.go
+++ b/kubectl-minio/cmd/tenant.go
@@ -48,7 +48,7 @@ func getTenantNamespace(client *operatorv1.Clientset, tenantName string) (string
 	return "", fmt.Errorf("tenant: %s not found on any namespace", tenantName)
 }
 
-func newTenantCmd(out io.Writer, errOut io.Writer) *cobra.Command {
+func newTenantCmd(_ io.Writer, _ io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tenant",
 		Short: "Manage MinIO tenant(s)",


### PR DESCRIPTION
### Objective:

To delete the operator with a flag

### Additional Information:

This pr is based on the issue [here](https://github.com/minio/operator/issues/1683)


### how to test

1) Rebuild kubectl krew command

```sh
make -B "plugin-binary"
```

2) install plugin 
```sh
cp kubectl-minio/kubectl-minio ~/.krew/bin/kubectl-minio-dev
```

3) expand tenant with plugin, do not assign a name to the pool

```sh
kubectl-minio-dev delete --force --dangerous

namespace "minio-operator" deleted
serviceaccount "minio-operator" deleted
clusterrole.rbac.authorization.k8s.io "minio-operator-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "minio-operator-binding" deleted
customresourcedefinition.apiextensions.k8s.io "tenants.minio.min.io" deleted
customresourcedefinition.apiextensions.k8s.io "policybindings.sts.min.io" deleted
service "operator" deleted
service "sts" deleted
deployment.apps "minio-operator" deleted
serviceaccount "console-sa" deleted
clusterrole.rbac.authorization.k8s.io "console-sa-role" deleted
clusterrolebinding.rbac.authorization.k8s.io "console-sa-binding" deleted
configmap "console-env" deleted
service "console" deleted
deployment.apps "console" deleted
```
