### PR TITLE
Operator console changes to allow enabling of SFTP for tenant

### DIFF
--- a/api/configuration-handlers.go
+++ b/api/configuration-handlers.go
@@ -166,10 +166,12 @@ func updateTenantConfigurationFile(ctx context.Context, operatorClient OperatorC
 	}
 
 	// Update SFTP flag
-	tenant.Spec.Features.EnableSFTP = &requestBody.SftpExposed
-	_, err = operatorClient.TenantUpdate(ctx, tenant, metav1.UpdateOptions{})
-	if err != nil {
-		return err
+	if tenant.Spec.Features != nil {
+		tenant.Spec.Features.EnableSFTP = &requestBody.SftpExposed
+		_, err = operatorClient.TenantUpdate(ctx, tenant, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
 	}
 
 	// Restart all MinIO pods at the same time for they to take the new configuration

--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -4239,6 +4239,9 @@ func init() {
             "$ref": "#/definitions/pool"
           }
         },
+        "sftpExposed": {
+          "type": "boolean"
+        },
         "status": {
           "$ref": "#/definitions/tenantStatus"
         },
@@ -4265,6 +4268,9 @@ func init() {
           "items": {
             "$ref": "#/definitions/environmentVariable"
           }
+        },
+        "sftpExposed": {
+          "type": "boolean"
         }
       }
     },
@@ -4561,6 +4567,9 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "sftpExposed": {
+          "type": "boolean"
         }
       }
     },
@@ -4576,6 +4585,9 @@ func init() {
         },
         "image_registry": {
           "$ref": "#/definitions/imageRegistry"
+        },
+        "sftpExposed": {
+          "type": "boolean"
         }
       }
     },
@@ -9620,6 +9632,9 @@ func init() {
             "$ref": "#/definitions/pool"
           }
         },
+        "sftpExposed": {
+          "type": "boolean"
+        },
         "status": {
           "$ref": "#/definitions/tenantStatus"
         },
@@ -9646,6 +9661,9 @@ func init() {
           "items": {
             "$ref": "#/definitions/environmentVariable"
           }
+        },
+        "sftpExposed": {
+          "type": "boolean"
         }
       }
     },
@@ -9942,6 +9960,9 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "sftpExposed": {
+          "type": "boolean"
         }
       }
     },
@@ -9957,6 +9978,9 @@ func init() {
         },
         "image_registry": {
           "$ref": "#/definitions/imageRegistry"
+        },
+        "sftpExposed": {
+          "type": "boolean"
         }
       }
     },

--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -2417,6 +2417,9 @@ func init() {
         "expose_minio": {
           "type": "boolean"
         },
+        "expose_sftp": {
+          "type": "boolean"
+        },
         "idp": {
           "type": "object",
           "$ref": "#/definitions/idpConfiguration"
@@ -7940,6 +7943,9 @@ func init() {
           "type": "boolean"
         },
         "expose_minio": {
+          "type": "boolean"
+        },
+        "expose_sftp": {
           "type": "boolean"
         },
         "idp": {

--- a/api/operations/operator_api.go
+++ b/api/operations/operator_api.go
@@ -1041,6 +1041,6 @@ func (o *OperatorAPI) AddMiddlewareFor(method, path string, builder middleware.B
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }

--- a/api/tenant-add-handlers.go
+++ b/api/tenant-add-handlers.go
@@ -270,8 +270,8 @@ func createTenant(ctx context.Context, params operator_api.CreateTenantParams, c
 	}
 	minInst.Spec.Configuration = &corev1.LocalObjectReference{Name: tenantConfigurationName}
 
+	var features miniov2.Features
 	if tenantReq.Domains != nil {
-		var features miniov2.Features
 		var domains miniov2.TenantDomains
 
 		// tenant domains
@@ -284,9 +284,11 @@ func createTenant(ctx context.Context, params operator_api.CreateTenantParams, c
 		}
 
 		features.Domains = &domains
-
-		minInst.Spec.Features = &features
 	}
+	if tenantReq.ExposeSftp {
+		features.EnableSFTP = &tenantReq.ExposeSftp
+	}
+	minInst.Spec.Features = &features
 
 	opClient, err := GetOperatorClient(session.STSSessionToken)
 	if err != nil {

--- a/api/tenant-get-handlers.go
+++ b/api/tenant-get-handlers.go
@@ -140,10 +140,15 @@ func getTenantDetailsResponse(session *models.Principal, params operator_api.Ten
 
 	var domains models.DomainsConfiguration
 
-	if minTenant.Spec.Features != nil && minTenant.Spec.Features.Domains != nil {
-		domains = models.DomainsConfiguration{
-			Console: minTenant.Spec.Features.Domains.Console,
-			Minio:   minTenant.Spec.Features.Domains.Minio,
+	if minTenant.Spec.Features != nil {
+		if minTenant.Spec.Features.EnableSFTP != nil {
+			info.SftpExposed = *minTenant.Spec.Features.EnableSFTP
+		}
+		if minTenant.Spec.Features.Domains != nil {
+			domains = models.DomainsConfiguration{
+				Console: minTenant.Spec.Features.Domains.Console,
+				Minio:   minTenant.Spec.Features.Domains.Minio,
+			}
 		}
 	}
 

--- a/api/tenant_update.go
+++ b/api/tenant_update.go
@@ -60,6 +60,7 @@ func updateTenantAction(ctx context.Context, operatorClient OperatorClientI, cli
 		}
 	}
 
+	minInst.Spec.Features.EnableSFTP = &params.Body.SftpExposed
 	payloadBytes, err := json.Marshal(minInst)
 	if err != nil {
 		return err

--- a/api/tenant_update.go
+++ b/api/tenant_update.go
@@ -60,7 +60,9 @@ func updateTenantAction(ctx context.Context, operatorClient OperatorClientI, cli
 		}
 	}
 
-	minInst.Spec.Features.EnableSFTP = &params.Body.SftpExposed
+	if minInst.Spec.Features != nil {
+		minInst.Spec.Features.EnableSFTP = &params.Body.SftpExposed
+	}
 	payloadBytes, err := json.Marshal(minInst)
 	if err != nil {
 		return err

--- a/models/allocatable_resources_response.go
+++ b/models/allocatable_resources_response.go
@@ -125,6 +125,11 @@ func (m *AllocatableResourcesResponse) ContextValidate(ctx context.Context, form
 func (m *AllocatableResourcesResponse) contextValidateCPUPriority(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CPUPriority != nil {
+
+		if swag.IsZero(m.CPUPriority) { // not required
+			return nil
+		}
+
 		if err := m.CPUPriority.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cpu_priority")
@@ -141,6 +146,11 @@ func (m *AllocatableResourcesResponse) contextValidateCPUPriority(ctx context.Co
 func (m *AllocatableResourcesResponse) contextValidateMemPriority(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MemPriority != nil {
+
+		if swag.IsZero(m.MemPriority) { // not required
+			return nil
+		}
+
 		if err := m.MemPriority.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mem_priority")

--- a/models/aws_configuration.go
+++ b/models/aws_configuration.go
@@ -92,6 +92,7 @@ func (m *AwsConfiguration) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *AwsConfiguration) contextValidateSecretsmanager(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Secretsmanager != nil {
+
 		if err := m.Secretsmanager.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretsmanager")
@@ -221,6 +222,7 @@ func (m *AwsConfigurationSecretsmanager) ContextValidate(ctx context.Context, fo
 func (m *AwsConfigurationSecretsmanager) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretsmanager" + "." + "credentials")

--- a/models/azure_configuration.go
+++ b/models/azure_configuration.go
@@ -92,6 +92,7 @@ func (m *AzureConfiguration) ContextValidate(ctx context.Context, formats strfmt
 func (m *AzureConfiguration) contextValidateKeyvault(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Keyvault != nil {
+
 		if err := m.Keyvault.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyvault")
@@ -199,6 +200,11 @@ func (m *AzureConfigurationKeyvault) ContextValidate(ctx context.Context, format
 func (m *AzureConfigurationKeyvault) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
+		if swag.IsZero(m.Credentials) { // not required
+			return nil
+		}
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyvault" + "." + "credentials")

--- a/models/container.go
+++ b/models/container.go
@@ -223,6 +223,11 @@ func (m *Container) contextValidateEnvironmentVariables(ctx context.Context, for
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
+
+			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
+				return nil
+			}
+
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))
@@ -241,6 +246,11 @@ func (m *Container) contextValidateEnvironmentVariables(ctx context.Context, for
 func (m *Container) contextValidateLastState(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LastState != nil {
+
+		if swag.IsZero(m.LastState) { // not required
+			return nil
+		}
+
 		if err := m.LastState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lastState")
@@ -259,6 +269,11 @@ func (m *Container) contextValidateMounts(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m.Mounts); i++ {
 
 		if m.Mounts[i] != nil {
+
+			if swag.IsZero(m.Mounts[i]) { // not required
+				return nil
+			}
+
 			if err := m.Mounts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("mounts" + "." + strconv.Itoa(i))
@@ -277,6 +292,11 @@ func (m *Container) contextValidateMounts(ctx context.Context, formats strfmt.Re
 func (m *Container) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.State != nil {
+
+		if swag.IsZero(m.State) { // not required
+			return nil
+		}
+
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")

--- a/models/create_tenant_request.go
+++ b/models/create_tenant_request.go
@@ -67,6 +67,9 @@ type CreateTenantRequest struct {
 	// expose minio
 	ExposeMinio bool `json:"expose_minio,omitempty"`
 
+	// expose sftp
+	ExposeSftp bool `json:"expose_sftp,omitempty"`
+
 	// idp
 	Idp *IdpConfiguration `json:"idp,omitempty"`
 
@@ -362,6 +365,11 @@ func (m *CreateTenantRequest) ContextValidate(ctx context.Context, formats strfm
 func (m *CreateTenantRequest) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
+
+		if swag.IsZero(m.Domains) { // not required
+			return nil
+		}
+
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")
@@ -378,6 +386,11 @@ func (m *CreateTenantRequest) contextValidateDomains(ctx context.Context, format
 func (m *CreateTenantRequest) contextValidateEncryption(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Encryption != nil {
+
+		if swag.IsZero(m.Encryption) { // not required
+			return nil
+		}
+
 		if err := m.Encryption.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryption")
@@ -396,6 +409,11 @@ func (m *CreateTenantRequest) contextValidateEnvironmentVariables(ctx context.Co
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
+
+			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
+				return nil
+			}
+
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))
@@ -414,6 +432,11 @@ func (m *CreateTenantRequest) contextValidateEnvironmentVariables(ctx context.Co
 func (m *CreateTenantRequest) contextValidateIdp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Idp != nil {
+
+		if swag.IsZero(m.Idp) { // not required
+			return nil
+		}
+
 		if err := m.Idp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("idp")
@@ -430,6 +453,11 @@ func (m *CreateTenantRequest) contextValidateIdp(ctx context.Context, formats st
 func (m *CreateTenantRequest) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ImageRegistry != nil {
+
+		if swag.IsZero(m.ImageRegistry) { // not required
+			return nil
+		}
+
 		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image_registry")
@@ -448,6 +476,11 @@ func (m *CreateTenantRequest) contextValidatePools(ctx context.Context, formats 
 	for i := 0; i < len(m.Pools); i++ {
 
 		if m.Pools[i] != nil {
+
+			if swag.IsZero(m.Pools[i]) { // not required
+				return nil
+			}
+
 			if err := m.Pools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pools" + "." + strconv.Itoa(i))
@@ -466,6 +499,11 @@ func (m *CreateTenantRequest) contextValidatePools(ctx context.Context, formats 
 func (m *CreateTenantRequest) contextValidateTLS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TLS != nil {
+
+		if swag.IsZero(m.TLS) { // not required
+			return nil
+		}
+
 		if err := m.TLS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tls")

--- a/models/create_tenant_response.go
+++ b/models/create_tenant_response.go
@@ -102,6 +102,11 @@ func (m *CreateTenantResponse) contextValidateConsole(ctx context.Context, forma
 	for i := 0; i < len(m.Console); i++ {
 
 		if m.Console[i] != nil {
+
+			if swag.IsZero(m.Console[i]) { // not required
+				return nil
+			}
+
 			if err := m.Console[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("console" + "." + strconv.Itoa(i))

--- a/models/csr_element.go
+++ b/models/csr_element.go
@@ -120,6 +120,11 @@ func (m *CsrElement) contextValidateAnnotations(ctx context.Context, formats str
 	for i := 0; i < len(m.Annotations); i++ {
 
 		if m.Annotations[i] != nil {
+
+			if swag.IsZero(m.Annotations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Annotations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("annotations" + "." + strconv.Itoa(i))

--- a/models/csr_elements.go
+++ b/models/csr_elements.go
@@ -99,6 +99,11 @@ func (m *CsrElements) contextValidateCsrElement(ctx context.Context, formats str
 	for i := 0; i < len(m.CsrElement); i++ {
 
 		if m.CsrElement[i] != nil {
+
+			if swag.IsZero(m.CsrElement[i]) { // not required
+				return nil
+			}
+
 			if err := m.CsrElement[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("csrElement" + "." + strconv.Itoa(i))

--- a/models/describe_p_v_c_wrapper.go
+++ b/models/describe_p_v_c_wrapper.go
@@ -163,6 +163,11 @@ func (m *DescribePVCWrapper) contextValidateAnnotations(ctx context.Context, for
 	for i := 0; i < len(m.Annotations); i++ {
 
 		if m.Annotations[i] != nil {
+
+			if swag.IsZero(m.Annotations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Annotations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("annotations" + "." + strconv.Itoa(i))
@@ -183,6 +188,11 @@ func (m *DescribePVCWrapper) contextValidateLabels(ctx context.Context, formats 
 	for i := 0; i < len(m.Labels); i++ {
 
 		if m.Labels[i] != nil {
+
+			if swag.IsZero(m.Labels[i]) { // not required
+				return nil
+			}
+
 			if err := m.Labels[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("labels" + "." + strconv.Itoa(i))

--- a/models/describe_pod_wrapper.go
+++ b/models/describe_pod_wrapper.go
@@ -363,6 +363,11 @@ func (m *DescribePodWrapper) contextValidateAnnotations(ctx context.Context, for
 	for i := 0; i < len(m.Annotations); i++ {
 
 		if m.Annotations[i] != nil {
+
+			if swag.IsZero(m.Annotations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Annotations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("annotations" + "." + strconv.Itoa(i))
@@ -383,6 +388,11 @@ func (m *DescribePodWrapper) contextValidateConditions(ctx context.Context, form
 	for i := 0; i < len(m.Conditions); i++ {
 
 		if m.Conditions[i] != nil {
+
+			if swag.IsZero(m.Conditions[i]) { // not required
+				return nil
+			}
+
 			if err := m.Conditions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("conditions" + "." + strconv.Itoa(i))
@@ -403,6 +413,11 @@ func (m *DescribePodWrapper) contextValidateContainers(ctx context.Context, form
 	for i := 0; i < len(m.Containers); i++ {
 
 		if m.Containers[i] != nil {
+
+			if swag.IsZero(m.Containers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Containers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("containers" + "." + strconv.Itoa(i))
@@ -423,6 +438,11 @@ func (m *DescribePodWrapper) contextValidateLabels(ctx context.Context, formats 
 	for i := 0; i < len(m.Labels); i++ {
 
 		if m.Labels[i] != nil {
+
+			if swag.IsZero(m.Labels[i]) { // not required
+				return nil
+			}
+
 			if err := m.Labels[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("labels" + "." + strconv.Itoa(i))
@@ -443,6 +463,11 @@ func (m *DescribePodWrapper) contextValidateNodeSelector(ctx context.Context, fo
 	for i := 0; i < len(m.NodeSelector); i++ {
 
 		if m.NodeSelector[i] != nil {
+
+			if swag.IsZero(m.NodeSelector[i]) { // not required
+				return nil
+			}
+
 			if err := m.NodeSelector[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodeSelector" + "." + strconv.Itoa(i))
@@ -463,6 +488,11 @@ func (m *DescribePodWrapper) contextValidateTolerations(ctx context.Context, for
 	for i := 0; i < len(m.Tolerations); i++ {
 
 		if m.Tolerations[i] != nil {
+
+			if swag.IsZero(m.Tolerations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Tolerations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tolerations" + "." + strconv.Itoa(i))
@@ -483,6 +513,11 @@ func (m *DescribePodWrapper) contextValidateVolumes(ctx context.Context, formats
 	for i := 0; i < len(m.Volumes); i++ {
 
 		if m.Volumes[i] != nil {
+
+			if swag.IsZero(m.Volumes[i]) { // not required
+				return nil
+			}
+
 			if err := m.Volumes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumes" + "." + strconv.Itoa(i))

--- a/models/encryption_configuration.go
+++ b/models/encryption_configuration.go
@@ -513,6 +513,11 @@ func (m *EncryptionConfiguration) ContextValidate(ctx context.Context, formats s
 func (m *EncryptionConfiguration) contextValidateAws(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Aws != nil {
+
+		if swag.IsZero(m.Aws) { // not required
+			return nil
+		}
+
 		if err := m.Aws.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("aws")
@@ -529,6 +534,11 @@ func (m *EncryptionConfiguration) contextValidateAws(ctx context.Context, format
 func (m *EncryptionConfiguration) contextValidateAzure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Azure != nil {
+
+		if swag.IsZero(m.Azure) { // not required
+			return nil
+		}
+
 		if err := m.Azure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azure")
@@ -545,6 +555,11 @@ func (m *EncryptionConfiguration) contextValidateAzure(ctx context.Context, form
 func (m *EncryptionConfiguration) contextValidateGcp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gcp != nil {
+
+		if swag.IsZero(m.Gcp) { // not required
+			return nil
+		}
+
 		if err := m.Gcp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gcp")
@@ -561,6 +576,11 @@ func (m *EncryptionConfiguration) contextValidateGcp(ctx context.Context, format
 func (m *EncryptionConfiguration) contextValidateGemalto(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gemalto != nil {
+
+		if swag.IsZero(m.Gemalto) { // not required
+			return nil
+		}
+
 		if err := m.Gemalto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gemalto")
@@ -577,6 +597,11 @@ func (m *EncryptionConfiguration) contextValidateGemalto(ctx context.Context, fo
 func (m *EncryptionConfiguration) contextValidateKmsMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.KmsMtls != nil {
+
+		if swag.IsZero(m.KmsMtls) { // not required
+			return nil
+		}
+
 		if err := m.KmsMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls")
@@ -593,6 +618,11 @@ func (m *EncryptionConfiguration) contextValidateKmsMtls(ctx context.Context, fo
 func (m *EncryptionConfiguration) contextValidateMinioMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MinioMtls != nil {
+
+		if swag.IsZero(m.MinioMtls) { // not required
+			return nil
+		}
+
 		if err := m.MinioMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minio_mtls")
@@ -609,6 +639,11 @@ func (m *EncryptionConfiguration) contextValidateMinioMtls(ctx context.Context, 
 func (m *EncryptionConfiguration) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
+
+		if swag.IsZero(m.SecurityContext) { // not required
+			return nil
+		}
+
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -625,6 +660,11 @@ func (m *EncryptionConfiguration) contextValidateSecurityContext(ctx context.Con
 func (m *EncryptionConfiguration) contextValidateServerTLS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ServerTLS != nil {
+
+		if swag.IsZero(m.ServerTLS) { // not required
+			return nil
+		}
+
 		if err := m.ServerTLS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("server_tls")
@@ -641,6 +681,11 @@ func (m *EncryptionConfiguration) contextValidateServerTLS(ctx context.Context, 
 func (m *EncryptionConfiguration) contextValidateVault(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Vault != nil {
+
+		if swag.IsZero(m.Vault) { // not required
+			return nil
+		}
+
 		if err := m.Vault.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vault")

--- a/models/encryption_configuration_response.go
+++ b/models/encryption_configuration_response.go
@@ -502,6 +502,11 @@ func (m *EncryptionConfigurationResponse) ContextValidate(ctx context.Context, f
 func (m *EncryptionConfigurationResponse) contextValidateAws(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Aws != nil {
+
+		if swag.IsZero(m.Aws) { // not required
+			return nil
+		}
+
 		if err := m.Aws.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("aws")
@@ -518,6 +523,11 @@ func (m *EncryptionConfigurationResponse) contextValidateAws(ctx context.Context
 func (m *EncryptionConfigurationResponse) contextValidateAzure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Azure != nil {
+
+		if swag.IsZero(m.Azure) { // not required
+			return nil
+		}
+
 		if err := m.Azure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azure")
@@ -534,6 +544,11 @@ func (m *EncryptionConfigurationResponse) contextValidateAzure(ctx context.Conte
 func (m *EncryptionConfigurationResponse) contextValidateGcp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gcp != nil {
+
+		if swag.IsZero(m.Gcp) { // not required
+			return nil
+		}
+
 		if err := m.Gcp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gcp")
@@ -550,6 +565,11 @@ func (m *EncryptionConfigurationResponse) contextValidateGcp(ctx context.Context
 func (m *EncryptionConfigurationResponse) contextValidateGemalto(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gemalto != nil {
+
+		if swag.IsZero(m.Gemalto) { // not required
+			return nil
+		}
+
 		if err := m.Gemalto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gemalto")
@@ -566,6 +586,11 @@ func (m *EncryptionConfigurationResponse) contextValidateGemalto(ctx context.Con
 func (m *EncryptionConfigurationResponse) contextValidateKmsMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.KmsMtls != nil {
+
+		if swag.IsZero(m.KmsMtls) { // not required
+			return nil
+		}
+
 		if err := m.KmsMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls")
@@ -582,6 +607,11 @@ func (m *EncryptionConfigurationResponse) contextValidateKmsMtls(ctx context.Con
 func (m *EncryptionConfigurationResponse) contextValidateMinioMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MinioMtls != nil {
+
+		if swag.IsZero(m.MinioMtls) { // not required
+			return nil
+		}
+
 		if err := m.MinioMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minio_mtls")
@@ -598,6 +628,11 @@ func (m *EncryptionConfigurationResponse) contextValidateMinioMtls(ctx context.C
 func (m *EncryptionConfigurationResponse) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
+
+		if swag.IsZero(m.SecurityContext) { // not required
+			return nil
+		}
+
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -614,6 +649,11 @@ func (m *EncryptionConfigurationResponse) contextValidateSecurityContext(ctx con
 func (m *EncryptionConfigurationResponse) contextValidateServerTLS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ServerTLS != nil {
+
+		if swag.IsZero(m.ServerTLS) { // not required
+			return nil
+		}
+
 		if err := m.ServerTLS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("server_tls")
@@ -630,6 +670,11 @@ func (m *EncryptionConfigurationResponse) contextValidateServerTLS(ctx context.C
 func (m *EncryptionConfigurationResponse) contextValidateVault(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Vault != nil {
+
+		if swag.IsZero(m.Vault) { // not required
+			return nil
+		}
+
 		if err := m.Vault.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vault")
@@ -750,6 +795,11 @@ func (m *EncryptionConfigurationResponseAO1KmsMtls) ContextValidate(ctx context.
 func (m *EncryptionConfigurationResponseAO1KmsMtls) contextValidateCa(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Ca != nil {
+
+		if swag.IsZero(m.Ca) { // not required
+			return nil
+		}
+
 		if err := m.Ca.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls" + "." + "ca")
@@ -766,6 +816,11 @@ func (m *EncryptionConfigurationResponseAO1KmsMtls) contextValidateCa(ctx contex
 func (m *EncryptionConfigurationResponseAO1KmsMtls) contextValidateCrt(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Crt != nil {
+
+		if swag.IsZero(m.Crt) { // not required
+			return nil
+		}
+
 		if err := m.Crt.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls" + "." + "crt")

--- a/models/event_list_wrapper.go
+++ b/models/event_list_wrapper.go
@@ -71,6 +71,11 @@ func (m EventListWrapper) ContextValidate(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/models/gcp_configuration.go
+++ b/models/gcp_configuration.go
@@ -92,6 +92,7 @@ func (m *GcpConfiguration) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *GcpConfiguration) contextValidateSecretmanager(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Secretmanager != nil {
+
 		if err := m.Secretmanager.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretmanager")
@@ -202,6 +203,11 @@ func (m *GcpConfigurationSecretmanager) ContextValidate(ctx context.Context, for
 func (m *GcpConfigurationSecretmanager) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
+		if swag.IsZero(m.Credentials) { // not required
+			return nil
+		}
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretmanager" + "." + "credentials")

--- a/models/gemalto_configuration.go
+++ b/models/gemalto_configuration.go
@@ -92,6 +92,7 @@ func (m *GemaltoConfiguration) ContextValidate(ctx context.Context, formats strf
 func (m *GemaltoConfiguration) contextValidateKeysecure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Keysecure != nil {
+
 		if err := m.Keysecure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure")
@@ -201,6 +202,7 @@ func (m *GemaltoConfigurationKeysecure) ContextValidate(ctx context.Context, for
 func (m *GemaltoConfigurationKeysecure) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure" + "." + "credentials")

--- a/models/gemalto_configuration_response.go
+++ b/models/gemalto_configuration_response.go
@@ -92,6 +92,7 @@ func (m *GemaltoConfigurationResponse) ContextValidate(ctx context.Context, form
 func (m *GemaltoConfigurationResponse) contextValidateKeysecure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Keysecure != nil {
+
 		if err := m.Keysecure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure")
@@ -201,6 +202,7 @@ func (m *GemaltoConfigurationResponseKeysecure) ContextValidate(ctx context.Cont
 func (m *GemaltoConfigurationResponseKeysecure) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
+
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure" + "." + "credentials")

--- a/models/idp_configuration.go
+++ b/models/idp_configuration.go
@@ -158,6 +158,11 @@ func (m *IdpConfiguration) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *IdpConfiguration) contextValidateActiveDirectory(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ActiveDirectory != nil {
+
+		if swag.IsZero(m.ActiveDirectory) { // not required
+			return nil
+		}
+
 		if err := m.ActiveDirectory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("active_directory")
@@ -176,6 +181,11 @@ func (m *IdpConfiguration) contextValidateKeys(ctx context.Context, formats strf
 	for i := 0; i < len(m.Keys); i++ {
 
 		if m.Keys[i] != nil {
+
+			if swag.IsZero(m.Keys[i]) { // not required
+				return nil
+			}
+
 			if err := m.Keys[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("keys" + "." + strconv.Itoa(i))
@@ -194,6 +204,11 @@ func (m *IdpConfiguration) contextValidateKeys(ctx context.Context, formats strf
 func (m *IdpConfiguration) contextValidateOidc(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Oidc != nil {
+
+		if swag.IsZero(m.Oidc) { // not required
+			return nil
+		}
+
 		if err := m.Oidc.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("oidc")

--- a/models/list_p_v_cs_response.go
+++ b/models/list_p_v_cs_response.go
@@ -99,6 +99,11 @@ func (m *ListPVCsResponse) contextValidatePvcs(ctx context.Context, formats strf
 	for i := 0; i < len(m.Pvcs); i++ {
 
 		if m.Pvcs[i] != nil {
+
+			if swag.IsZero(m.Pvcs[i]) { // not required
+				return nil
+			}
+
 			if err := m.Pvcs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pvcs" + "." + strconv.Itoa(i))

--- a/models/list_tenants_response.go
+++ b/models/list_tenants_response.go
@@ -102,6 +102,11 @@ func (m *ListTenantsResponse) contextValidateTenants(ctx context.Context, format
 	for i := 0; i < len(m.Tenants); i++ {
 
 		if m.Tenants[i] != nil {
+
+			if swag.IsZero(m.Tenants[i]) { // not required
+				return nil
+			}
+
 			if err := m.Tenants[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tenants" + "." + strconv.Itoa(i))

--- a/models/login_details.go
+++ b/models/login_details.go
@@ -160,6 +160,11 @@ func (m *LoginDetails) contextValidateRedirectRules(ctx context.Context, formats
 	for i := 0; i < len(m.RedirectRules); i++ {
 
 		if m.RedirectRules[i] != nil {
+
+			if swag.IsZero(m.RedirectRules[i]) { // not required
+				return nil
+			}
+
 			if err := m.RedirectRules[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("redirectRules" + "." + strconv.Itoa(i))

--- a/models/login_request.go
+++ b/models/login_request.go
@@ -98,6 +98,11 @@ func (m *LoginRequest) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *LoginRequest) contextValidateFeatures(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Features != nil {
+
+		if swag.IsZero(m.Features) { // not required
+			return nil
+		}
+
 		if err := m.Features.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features")

--- a/models/node_selector_term.go
+++ b/models/node_selector_term.go
@@ -137,6 +137,11 @@ func (m *NodeSelectorTerm) contextValidateMatchExpressions(ctx context.Context, 
 	for i := 0; i < len(m.MatchExpressions); i++ {
 
 		if m.MatchExpressions[i] != nil {
+
+			if swag.IsZero(m.MatchExpressions[i]) { // not required
+				return nil
+			}
+
 			if err := m.MatchExpressions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matchExpressions" + "." + strconv.Itoa(i))
@@ -157,6 +162,11 @@ func (m *NodeSelectorTerm) contextValidateMatchFields(ctx context.Context, forma
 	for i := 0; i < len(m.MatchFields); i++ {
 
 		if m.MatchFields[i] != nil {
+
+			if swag.IsZero(m.MatchFields[i]) { // not required
+				return nil
+			}
+
 			if err := m.MatchFields[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matchFields" + "." + strconv.Itoa(i))

--- a/models/pod_affinity_term.go
+++ b/models/pod_affinity_term.go
@@ -111,6 +111,11 @@ func (m *PodAffinityTerm) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *PodAffinityTerm) contextValidateLabelSelector(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LabelSelector != nil {
+
+		if swag.IsZero(m.LabelSelector) { // not required
+			return nil
+		}
+
 		if err := m.LabelSelector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("labelSelector")
@@ -213,6 +218,11 @@ func (m *PodAffinityTermLabelSelector) contextValidateMatchExpressions(ctx conte
 	for i := 0; i < len(m.MatchExpressions); i++ {
 
 		if m.MatchExpressions[i] != nil {
+
+			if swag.IsZero(m.MatchExpressions[i]) { // not required
+				return nil
+			}
+
 			if err := m.MatchExpressions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("labelSelector" + "." + "matchExpressions" + "." + strconv.Itoa(i))

--- a/models/pool.go
+++ b/models/pool.go
@@ -253,6 +253,11 @@ func (m *Pool) ContextValidate(ctx context.Context, formats strfmt.Registry) err
 func (m *Pool) contextValidateAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Affinity != nil {
+
+		if swag.IsZero(m.Affinity) { // not required
+			return nil
+		}
+
 		if err := m.Affinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("affinity")
@@ -269,6 +274,11 @@ func (m *Pool) contextValidateAffinity(ctx context.Context, formats strfmt.Regis
 func (m *Pool) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Resources != nil {
+
+		if swag.IsZero(m.Resources) { // not required
+			return nil
+		}
+
 		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
@@ -285,6 +295,11 @@ func (m *Pool) contextValidateResources(ctx context.Context, formats strfmt.Regi
 func (m *Pool) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
+
+		if swag.IsZero(m.SecurityContext) { // not required
+			return nil
+		}
+
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -315,6 +330,7 @@ func (m *Pool) contextValidateTolerations(ctx context.Context, formats strfmt.Re
 func (m *Pool) contextValidateVolumeConfiguration(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.VolumeConfiguration != nil {
+
 		if err := m.VolumeConfiguration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("volume_configuration")

--- a/models/pool_affinity.go
+++ b/models/pool_affinity.go
@@ -151,6 +151,11 @@ func (m *PoolAffinity) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *PoolAffinity) contextValidateNodeAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.NodeAffinity != nil {
+
+		if swag.IsZero(m.NodeAffinity) { // not required
+			return nil
+		}
+
 		if err := m.NodeAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodeAffinity")
@@ -167,6 +172,11 @@ func (m *PoolAffinity) contextValidateNodeAffinity(ctx context.Context, formats 
 func (m *PoolAffinity) contextValidatePodAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAffinity != nil {
+
+		if swag.IsZero(m.PodAffinity) { // not required
+			return nil
+		}
+
 		if err := m.PodAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAffinity")
@@ -183,6 +193,11 @@ func (m *PoolAffinity) contextValidatePodAffinity(ctx context.Context, formats s
 func (m *PoolAffinity) contextValidatePodAntiAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAntiAffinity != nil {
+
+		if swag.IsZero(m.PodAntiAffinity) { // not required
+			return nil
+		}
+
 		if err := m.PodAntiAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAntiAffinity")
@@ -312,6 +327,11 @@ func (m *PoolAffinityNodeAffinity) contextValidatePreferredDuringSchedulingIgnor
 	for i := 0; i < len(m.PreferredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.PreferredDuringSchedulingIgnoredDuringExecution[i] != nil {
+
+			if swag.IsZero(m.PreferredDuringSchedulingIgnoredDuringExecution[i]) { // not required
+				return nil
+			}
+
 			if err := m.PreferredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodeAffinity" + "." + "preferredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -330,6 +350,11 @@ func (m *PoolAffinityNodeAffinity) contextValidatePreferredDuringSchedulingIgnor
 func (m *PoolAffinityNodeAffinity) contextValidateRequiredDuringSchedulingIgnoredDuringExecution(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+
+		if swag.IsZero(m.RequiredDuringSchedulingIgnoredDuringExecution) { // not required
+			return nil
+		}
+
 		if err := m.RequiredDuringSchedulingIgnoredDuringExecution.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodeAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution")
@@ -439,6 +464,7 @@ func (m *PoolAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
 func (m *PoolAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionItems0) contextValidatePreference(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Preference != nil {
+
 		if err := m.Preference.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("preference")
@@ -540,6 +566,11 @@ func (m *PoolAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution)
 	for i := 0; i < len(m.NodeSelectorTerms); i++ {
 
 		if m.NodeSelectorTerms[i] != nil {
+
+			if swag.IsZero(m.NodeSelectorTerms[i]) { // not required
+				return nil
+			}
+
 			if err := m.NodeSelectorTerms[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodeAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution" + "." + "nodeSelectorTerms" + "." + strconv.Itoa(i))
@@ -678,6 +709,11 @@ func (m *PoolAffinityPodAffinity) contextValidatePreferredDuringSchedulingIgnore
 	for i := 0; i < len(m.PreferredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.PreferredDuringSchedulingIgnoredDuringExecution[i] != nil {
+
+			if swag.IsZero(m.PreferredDuringSchedulingIgnoredDuringExecution[i]) { // not required
+				return nil
+			}
+
 			if err := m.PreferredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAffinity" + "." + "preferredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -698,6 +734,11 @@ func (m *PoolAffinityPodAffinity) contextValidateRequiredDuringSchedulingIgnored
 	for i := 0; i < len(m.RequiredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.RequiredDuringSchedulingIgnoredDuringExecution[i] != nil {
+
+			if swag.IsZero(m.RequiredDuringSchedulingIgnoredDuringExecution[i]) { // not required
+				return nil
+			}
+
 			if err := m.RequiredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -809,6 +850,7 @@ func (m *PoolAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionI
 func (m *PoolAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionItems0) contextValidatePodAffinityTerm(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAffinityTerm != nil {
+
 		if err := m.PodAffinityTerm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAffinityTerm")
@@ -945,6 +987,11 @@ func (m *PoolAffinityPodAntiAffinity) contextValidatePreferredDuringSchedulingIg
 	for i := 0; i < len(m.PreferredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.PreferredDuringSchedulingIgnoredDuringExecution[i] != nil {
+
+			if swag.IsZero(m.PreferredDuringSchedulingIgnoredDuringExecution[i]) { // not required
+				return nil
+			}
+
 			if err := m.PreferredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAntiAffinity" + "." + "preferredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -965,6 +1012,11 @@ func (m *PoolAffinityPodAntiAffinity) contextValidateRequiredDuringSchedulingIgn
 	for i := 0; i < len(m.RequiredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.RequiredDuringSchedulingIgnoredDuringExecution[i] != nil {
+
+			if swag.IsZero(m.RequiredDuringSchedulingIgnoredDuringExecution[i]) { // not required
+				return nil
+			}
+
 			if err := m.RequiredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAntiAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -1076,6 +1128,7 @@ func (m *PoolAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecut
 func (m *PoolAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionItems0) contextValidatePodAffinityTerm(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAffinityTerm != nil {
+
 		if err := m.PodAffinityTerm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAffinityTerm")

--- a/models/pool_tolerations.go
+++ b/models/pool_tolerations.go
@@ -71,6 +71,11 @@ func (m PoolTolerations) ContextValidate(ctx context.Context, formats strfmt.Reg
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -160,6 +165,11 @@ func (m *PoolTolerationsItems0) ContextValidate(ctx context.Context, formats str
 func (m *PoolTolerationsItems0) contextValidateTolerationSeconds(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TolerationSeconds != nil {
+
+		if swag.IsZero(m.TolerationSeconds) { // not required
+			return nil
+		}
+
 		if err := m.TolerationSeconds.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tolerationSeconds")

--- a/models/pool_update_request.go
+++ b/models/pool_update_request.go
@@ -102,6 +102,11 @@ func (m *PoolUpdateRequest) contextValidatePools(ctx context.Context, formats st
 	for i := 0; i < len(m.Pools); i++ {
 
 		if m.Pools[i] != nil {
+
+			if swag.IsZero(m.Pools[i]) { // not required
+				return nil
+			}
+
 			if err := m.Pools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pools" + "." + strconv.Itoa(i))

--- a/models/projected_volume.go
+++ b/models/projected_volume.go
@@ -99,6 +99,11 @@ func (m *ProjectedVolume) contextValidateSources(ctx context.Context, formats st
 	for i := 0; i < len(m.Sources); i++ {
 
 		if m.Sources[i] != nil {
+
+			if swag.IsZero(m.Sources[i]) { // not required
+				return nil
+			}
+
 			if err := m.Sources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sources" + "." + strconv.Itoa(i))

--- a/models/projected_volume_source.go
+++ b/models/projected_volume_source.go
@@ -152,6 +152,11 @@ func (m *ProjectedVolumeSource) ContextValidate(ctx context.Context, formats str
 func (m *ProjectedVolumeSource) contextValidateConfigMap(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ConfigMap != nil {
+
+		if swag.IsZero(m.ConfigMap) { // not required
+			return nil
+		}
+
 		if err := m.ConfigMap.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("configMap")
@@ -168,6 +173,11 @@ func (m *ProjectedVolumeSource) contextValidateConfigMap(ctx context.Context, fo
 func (m *ProjectedVolumeSource) contextValidateSecret(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Secret != nil {
+
+		if swag.IsZero(m.Secret) { // not required
+			return nil
+		}
+
 		if err := m.Secret.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secret")
@@ -184,6 +194,11 @@ func (m *ProjectedVolumeSource) contextValidateSecret(ctx context.Context, forma
 func (m *ProjectedVolumeSource) contextValidateServiceAccountToken(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ServiceAccountToken != nil {
+
+		if swag.IsZero(m.ServiceAccountToken) { // not required
+			return nil
+		}
+
 		if err := m.ServiceAccountToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("serviceAccountToken")

--- a/models/resource_quota.go
+++ b/models/resource_quota.go
@@ -102,6 +102,11 @@ func (m *ResourceQuota) contextValidateElements(ctx context.Context, formats str
 	for i := 0; i < len(m.Elements); i++ {
 
 		if m.Elements[i] != nil {
+
+			if swag.IsZero(m.Elements[i]) { // not required
+				return nil
+			}
+
 			if err := m.Elements[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("elements" + "." + strconv.Itoa(i))

--- a/models/server_properties.go
+++ b/models/server_properties.go
@@ -120,6 +120,11 @@ func (m *ServerProperties) contextValidateDrives(ctx context.Context, formats st
 	for i := 0; i < len(m.Drives); i++ {
 
 		if m.Drives[i] != nil {
+
+			if swag.IsZero(m.Drives[i]) { // not required
+				return nil
+			}
+
 			if err := m.Drives[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))

--- a/models/tenant.go
+++ b/models/tenant.go
@@ -75,6 +75,9 @@ type Tenant struct {
 	// pools
 	Pools []*Pool `json:"pools"`
 
+	// sftp exposed
+	SftpExposed bool `json:"sftpExposed,omitempty"`
+
 	// status
 	Status *TenantStatus `json:"status,omitempty"`
 

--- a/models/tenant.go
+++ b/models/tenant.go
@@ -287,6 +287,11 @@ func (m *Tenant) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 func (m *Tenant) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
+
+		if swag.IsZero(m.Domains) { // not required
+			return nil
+		}
+
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")
@@ -303,6 +308,11 @@ func (m *Tenant) contextValidateDomains(ctx context.Context, formats strfmt.Regi
 func (m *Tenant) contextValidateEndpoints(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Endpoints != nil {
+
+		if swag.IsZero(m.Endpoints) { // not required
+			return nil
+		}
+
 		if err := m.Endpoints.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("endpoints")
@@ -321,6 +331,11 @@ func (m *Tenant) contextValidatePools(ctx context.Context, formats strfmt.Regist
 	for i := 0; i < len(m.Pools); i++ {
 
 		if m.Pools[i] != nil {
+
+			if swag.IsZero(m.Pools[i]) { // not required
+				return nil
+			}
+
 			if err := m.Pools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pools" + "." + strconv.Itoa(i))
@@ -339,6 +354,11 @@ func (m *Tenant) contextValidatePools(ctx context.Context, formats strfmt.Regist
 func (m *Tenant) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
@@ -355,6 +375,11 @@ func (m *Tenant) contextValidateStatus(ctx context.Context, formats strfmt.Regis
 func (m *Tenant) contextValidateSubnetLicense(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SubnetLicense != nil {
+
+		if swag.IsZero(m.SubnetLicense) { // not required
+			return nil
+		}
+
 		if err := m.SubnetLicense.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("subnet_license")
@@ -373,6 +398,11 @@ func (m *Tenant) contextValidateTiers(ctx context.Context, formats strfmt.Regist
 	for i := 0; i < len(m.Tiers); i++ {
 
 		if m.Tiers[i] != nil {
+
+			if swag.IsZero(m.Tiers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Tiers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tiers" + "." + strconv.Itoa(i))

--- a/models/tenant_configuration_response.go
+++ b/models/tenant_configuration_response.go
@@ -99,6 +99,11 @@ func (m *TenantConfigurationResponse) contextValidateEnvironmentVariables(ctx co
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
+
+			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
+				return nil
+			}
+
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))

--- a/models/tenant_configuration_response.go
+++ b/models/tenant_configuration_response.go
@@ -38,6 +38,9 @@ type TenantConfigurationResponse struct {
 
 	// environment variables
 	EnvironmentVariables []*EnvironmentVariable `json:"environmentVariables"`
+
+	// sftp exposed
+	SftpExposed bool `json:"sftpExposed,omitempty"`
 }
 
 // Validate validates this tenant configuration response

--- a/models/tenant_list.go
+++ b/models/tenant_list.go
@@ -169,6 +169,11 @@ func (m *TenantList) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *TenantList) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
+
+		if swag.IsZero(m.Domains) { // not required
+			return nil
+		}
+
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")
@@ -187,6 +192,11 @@ func (m *TenantList) contextValidateTiers(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m.Tiers); i++ {
 
 		if m.Tiers[i] != nil {
+
+			if swag.IsZero(m.Tiers[i]) { // not required
+				return nil
+			}
+
 			if err := m.Tiers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tiers" + "." + strconv.Itoa(i))

--- a/models/tenant_security_response.go
+++ b/models/tenant_security_response.go
@@ -123,6 +123,11 @@ func (m *TenantSecurityResponse) ContextValidate(ctx context.Context, formats st
 func (m *TenantSecurityResponse) contextValidateCustomCertificates(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CustomCertificates != nil {
+
+		if swag.IsZero(m.CustomCertificates) { // not required
+			return nil
+		}
+
 		if err := m.CustomCertificates.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customCertificates")
@@ -139,6 +144,11 @@ func (m *TenantSecurityResponse) contextValidateCustomCertificates(ctx context.C
 func (m *TenantSecurityResponse) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
+
+		if swag.IsZero(m.SecurityContext) { // not required
+			return nil
+		}
+
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -312,6 +322,11 @@ func (m *TenantSecurityResponseCustomCertificates) contextValidateClient(ctx con
 	for i := 0; i < len(m.Client); i++ {
 
 		if m.Client[i] != nil {
+
+			if swag.IsZero(m.Client[i]) { // not required
+				return nil
+			}
+
 			if err := m.Client[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "client" + "." + strconv.Itoa(i))
@@ -332,6 +347,11 @@ func (m *TenantSecurityResponseCustomCertificates) contextValidateMinio(ctx cont
 	for i := 0; i < len(m.Minio); i++ {
 
 		if m.Minio[i] != nil {
+
+			if swag.IsZero(m.Minio[i]) { // not required
+				return nil
+			}
+
 			if err := m.Minio[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minio" + "." + strconv.Itoa(i))
@@ -352,6 +372,11 @@ func (m *TenantSecurityResponseCustomCertificates) contextValidateMinioCAs(ctx c
 	for i := 0; i < len(m.MinioCAs); i++ {
 
 		if m.MinioCAs[i] != nil {
+
+			if swag.IsZero(m.MinioCAs[i]) { // not required
+				return nil
+			}
+
 			if err := m.MinioCAs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minioCAs" + "." + strconv.Itoa(i))

--- a/models/tenant_status.go
+++ b/models/tenant_status.go
@@ -104,6 +104,11 @@ func (m *TenantStatus) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *TenantStatus) contextValidateUsage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Usage != nil {
+
+		if swag.IsZero(m.Usage) { // not required
+			return nil
+		}
+
 		if err := m.Usage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")

--- a/models/tls_configuration.go
+++ b/models/tls_configuration.go
@@ -139,6 +139,11 @@ func (m *TLSConfiguration) contextValidateMinioClientCertificates(ctx context.Co
 	for i := 0; i < len(m.MinioClientCertificates); i++ {
 
 		if m.MinioClientCertificates[i] != nil {
+
+			if swag.IsZero(m.MinioClientCertificates[i]) { // not required
+				return nil
+			}
+
 			if err := m.MinioClientCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("minioClientCertificates" + "." + strconv.Itoa(i))
@@ -159,6 +164,11 @@ func (m *TLSConfiguration) contextValidateMinioServerCertificates(ctx context.Co
 	for i := 0; i < len(m.MinioServerCertificates); i++ {
 
 		if m.MinioServerCertificates[i] != nil {
+
+			if swag.IsZero(m.MinioServerCertificates[i]) { // not required
+				return nil
+			}
+
 			if err := m.MinioServerCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("minioServerCertificates" + "." + strconv.Itoa(i))

--- a/models/update_domains_request.go
+++ b/models/update_domains_request.go
@@ -89,6 +89,11 @@ func (m *UpdateDomainsRequest) ContextValidate(ctx context.Context, formats strf
 func (m *UpdateDomainsRequest) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
+
+		if swag.IsZero(m.Domains) { // not required
+			return nil
+		}
+
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")

--- a/models/update_tenant_configuration_request.go
+++ b/models/update_tenant_configuration_request.go
@@ -41,6 +41,9 @@ type UpdateTenantConfigurationRequest struct {
 
 	// keys to be deleted
 	KeysToBeDeleted []string `json:"keysToBeDeleted"`
+
+	// sftp exposed
+	SftpExposed bool `json:"sftpExposed,omitempty"`
 }
 
 // Validate validates this update tenant configuration request

--- a/models/update_tenant_configuration_request.go
+++ b/models/update_tenant_configuration_request.go
@@ -102,6 +102,11 @@ func (m *UpdateTenantConfigurationRequest) contextValidateEnvironmentVariables(c
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
+
+			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
+				return nil
+			}
+
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))

--- a/models/update_tenant_request.go
+++ b/models/update_tenant_request.go
@@ -113,6 +113,11 @@ func (m *UpdateTenantRequest) ContextValidate(ctx context.Context, formats strfm
 func (m *UpdateTenantRequest) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ImageRegistry != nil {
+
+		if swag.IsZero(m.ImageRegistry) { // not required
+			return nil
+		}
+
 		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image_registry")

--- a/models/update_tenant_request.go
+++ b/models/update_tenant_request.go
@@ -45,6 +45,9 @@ type UpdateTenantRequest struct {
 
 	// image registry
 	ImageRegistry *ImageRegistry `json:"image_registry,omitempty"`
+
+	// sftp exposed
+	SftpExposed bool `json:"sftpExposed,omitempty"`
 }
 
 // Validate validates this update tenant request

--- a/models/update_tenant_security_request.go
+++ b/models/update_tenant_security_request.go
@@ -123,6 +123,11 @@ func (m *UpdateTenantSecurityRequest) ContextValidate(ctx context.Context, forma
 func (m *UpdateTenantSecurityRequest) contextValidateCustomCertificates(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CustomCertificates != nil {
+
+		if swag.IsZero(m.CustomCertificates) { // not required
+			return nil
+		}
+
 		if err := m.CustomCertificates.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customCertificates")
@@ -139,6 +144,11 @@ func (m *UpdateTenantSecurityRequest) contextValidateCustomCertificates(ctx cont
 func (m *UpdateTenantSecurityRequest) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
+
+		if swag.IsZero(m.SecurityContext) { // not required
+			return nil
+		}
+
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -281,6 +291,11 @@ func (m *UpdateTenantSecurityRequestCustomCertificates) contextValidateMinioClie
 	for i := 0; i < len(m.MinioClientCertificates); i++ {
 
 		if m.MinioClientCertificates[i] != nil {
+
+			if swag.IsZero(m.MinioClientCertificates[i]) { // not required
+				return nil
+			}
+
 			if err := m.MinioClientCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minioClientCertificates" + "." + strconv.Itoa(i))
@@ -301,6 +316,11 @@ func (m *UpdateTenantSecurityRequestCustomCertificates) contextValidateMinioServ
 	for i := 0; i < len(m.MinioServerCertificates); i++ {
 
 		if m.MinioServerCertificates[i] != nil {
+
+			if swag.IsZero(m.MinioServerCertificates[i]) { // not required
+				return nil
+			}
+
 			if err := m.MinioServerCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minioServerCertificates" + "." + strconv.Itoa(i))

--- a/models/vault_configuration.go
+++ b/models/vault_configuration.go
@@ -148,6 +148,7 @@ func (m *VaultConfiguration) ContextValidate(ctx context.Context, formats strfmt
 func (m *VaultConfiguration) contextValidateApprole(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Approle != nil {
+
 		if err := m.Approle.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("approle")
@@ -164,6 +165,11 @@ func (m *VaultConfiguration) contextValidateApprole(ctx context.Context, formats
 func (m *VaultConfiguration) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/models/vault_configuration_response.go
+++ b/models/vault_configuration_response.go
@@ -148,6 +148,7 @@ func (m *VaultConfigurationResponse) ContextValidate(ctx context.Context, format
 func (m *VaultConfigurationResponse) contextValidateApprole(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Approle != nil {
+
 		if err := m.Approle.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("approle")
@@ -164,6 +165,11 @@ func (m *VaultConfigurationResponse) contextValidateApprole(ctx context.Context,
 func (m *VaultConfigurationResponse) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
+
+		if swag.IsZero(m.Status) { // not required
+			return nil
+		}
+
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/models/volume.go
+++ b/models/volume.go
@@ -122,6 +122,11 @@ func (m *Volume) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 func (m *Volume) contextValidateProjected(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Projected != nil {
+
+		if swag.IsZero(m.Projected) { // not required
+			return nil
+		}
+
 		if err := m.Projected.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("projected")
@@ -138,6 +143,11 @@ func (m *Volume) contextValidateProjected(ctx context.Context, formats strfmt.Re
 func (m *Volume) contextValidatePvc(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Pvc != nil {
+
+		if swag.IsZero(m.Pvc) { // not required
+			return nil
+		}
+
 		if err := m.Pvc.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pvc")

--- a/swagger.yml
+++ b/swagger.yml
@@ -1867,6 +1867,8 @@ definitions:
         type: boolean
       expose_console:
         type: boolean
+      expose_sftp:
+        type: boolean
       domains:
         type: object
         $ref: "#/definitions/domainsConfiguration"

--- a/swagger.yml
+++ b/swagger.yml
@@ -1560,6 +1560,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/environmentVariable"
+      sftpExposed:
+        type: boolean
 
   updateTenantConfigurationRequest:
     type: object
@@ -1572,6 +1574,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/environmentVariable"
+      sftpExposed:
+        type: boolean
 
   tenantSecurityResponse:
     type: object
@@ -1686,6 +1690,8 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/tenantTierElement"
+      sftpExposed:
+        type: boolean
 
   tenantUsage:
     type: object
@@ -1763,6 +1769,8 @@ definitions:
         $ref: "#/definitions/imageRegistry"
       image_pull_secret:
         type: string
+      sftpExposed:
+        type: boolean
 
   imageRegistry:
     type: object

--- a/web-app/src/api/operatorApi.ts
+++ b/web-app/src/api/operatorApi.ts
@@ -242,6 +242,7 @@ export interface CreateTenantRequest {
   encryption?: EncryptionConfiguration;
   expose_minio?: boolean;
   expose_console?: boolean;
+  expose_sftp?: boolean;
   domains?: DomainsConfiguration;
   environmentVariables?: EnvironmentVariable[];
 }

--- a/web-app/src/api/operatorApi.ts
+++ b/web-app/src/api/operatorApi.ts
@@ -90,11 +90,13 @@ export interface TenantStatus {
 
 export interface TenantConfigurationResponse {
   environmentVariables?: EnvironmentVariable[];
+  sftpExposed?: boolean;
 }
 
 export interface UpdateTenantConfigurationRequest {
   keysToBeDeleted?: string[];
   environmentVariables?: EnvironmentVariable[];
+  sftpExposed?: boolean;
 }
 
 export interface TenantSecurityResponse {
@@ -147,6 +149,7 @@ export interface Tenant {
   minioTLS?: boolean;
   domains?: DomainsConfiguration;
   tiers?: TenantTierElement[];
+  sftpExposed?: boolean;
 }
 
 export interface TenantUsage {
@@ -194,6 +197,7 @@ export interface UpdateTenantRequest {
   image?: string;
   image_registry?: ImageRegistry;
   image_pull_secret?: string;
+  sftpExposed?: boolean;
 }
 
 export interface ImageRegistry {

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/Configure.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/Configure.tsx
@@ -152,6 +152,9 @@ const Configure = ({ classes }: IConfigureProps) => {
   const exposeConsole = useSelector(
     (state: AppState) => state.createTenant.fields.configure.exposeConsole,
   );
+  const exposeSFTP = useSelector(
+    (state: AppState) => state.createTenant.fields.configure.exposeSFTP,
+  );
   const setDomains = useSelector(
     (state: AppState) => state.createTenant.fields.configure.setDomains,
   );
@@ -325,6 +328,21 @@ const Configure = ({ classes }: IConfigureProps) => {
             updateField("exposeConsole", checked);
           }}
           label={"Expose Console Service"}
+        />
+      </Grid>
+      <Grid item xs={12} className={classes.configSectionItem}>
+        <FormSwitchWrapper
+          value="expose_sftp"
+          id="expose_sftp"
+          name="expose_sftp"
+          checked={exposeSFTP}
+          onChange={(e) => {
+            const targetD = e.target;
+            const checked = targetD.checked;
+
+            updateField("exposeSFTP", checked);
+          }}
+          label={"Expose SFTP Service"}
         />
       </Grid>
       <Grid item xs={12} className={classes.configSectionItem}>

--- a/web-app/src/screens/Console/Tenants/AddTenant/createTenantSlice.ts
+++ b/web-app/src/screens/Console/Tenants/AddTenant/createTenantSlice.ts
@@ -102,6 +102,7 @@ const initialState: ICreateTenant = {
       imageRegistryPassword: "",
       exposeMinIO: true,
       exposeConsole: true,
+      exposeSFTP: false,
       tenantCustom: false,
       customRuntime: false,
       runtimeClassName: "",

--- a/web-app/src/screens/Console/Tenants/AddTenant/thunks/createTenantThunk.ts
+++ b/web-app/src/screens/Console/Tenants/AddTenant/thunks/createTenantThunk.ts
@@ -40,6 +40,7 @@ export const createTenantAsync = createAsyncThunk(
     const imageRegistryPassword = fields.configure.imageRegistryPassword;
     const exposeMinIO = fields.configure.exposeMinIO;
     const exposeConsole = fields.configure.exposeConsole;
+    const exposeSFTP = fields.configure.exposeSFTP;
     const idpSelection = fields.identityProvider.idpSelection;
     const openIDConfigurationURL =
       fields.identityProvider.openIDConfigurationURL;
@@ -171,6 +172,7 @@ export const createTenantAsync = createAsyncThunk(
       image: imageName,
       expose_minio: exposeMinIO,
       expose_console: exposeConsole,
+      expose_sftp: exposeSFTP,
       pools: [
         {
           name: poolName,

--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantConfiguration.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantConfiguration.tsx
@@ -17,6 +17,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { connect, useSelector } from "react-redux";
 import { Theme } from "@mui/material/styles";
+import FormSwitchWrapper from "../../Common/FormComponents/FormSwitchWrapper/FormSwitchWrapper";
 import { DialogContentText, IconButton } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import { Button, ConfirmModalIcon, Loader, RemoveIcon } from "mds";
@@ -121,6 +122,7 @@ const TenantConfiguration = ({ classes }: ITenantConfiguration) => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [envVars, setEnvVars] = useState<LabelKeyPair[]>([]);
   const [envVarsToBeDeleted, setEnvVarsToBeDeleted] = useState<string[]>([]);
+  const [sftpExposed, setSftpEnabled] = useState<boolean>(false);
 
   const getTenantConfigurationInfo = useCallback(() => {
     api
@@ -131,6 +133,7 @@ const TenantConfiguration = ({ classes }: ITenantConfiguration) => {
       .then((res: ITenantConfigurationResponse) => {
         if (res.environmentVariables) {
           setEnvVars(res.environmentVariables);
+          setSftpEnabled(res.sftpExposed);
         }
       })
       .catch((err: ErrorResponseHandler) => {
@@ -149,6 +152,7 @@ const TenantConfiguration = ({ classes }: ITenantConfiguration) => {
     let payload: ITenantConfigurationRequest = {
       environmentVariables: envVars.filter((env) => env.key !== ""),
       keysToBeDeleted: envVarsToBeDeleted,
+      sftpExposed: sftpExposed,
     };
     api
       .invoke(
@@ -285,6 +289,28 @@ const TenantConfiguration = ({ classes }: ITenantConfiguration) => {
                 </Grid>
               </Grid>
             ))}
+          </Grid>
+          <Grid container spacing={1}>
+            <Grid
+              item
+              xs={12}
+              justifyContent={"end"}
+              textAlign={"right"}
+              className={classes.configSectionItem}
+            >
+              <FormSwitchWrapper
+                label={"SFTP"}
+                indicatorLabels={["Enabled", "Disabled"]}
+                checked={sftpExposed}
+                value={"expose_sftp"}
+                id="expose-sftp"
+                name="expose-sftp"
+                onChange={() => {
+                  setSftpEnabled(!sftpExposed);
+                }}
+                description=""
+              />
+            </Grid>
           </Grid>
           <Grid
             item

--- a/web-app/src/screens/Console/Tenants/types.ts
+++ b/web-app/src/screens/Console/Tenants/types.ts
@@ -43,11 +43,13 @@ export interface ICustomCertificates {
 
 export interface ITenantConfigurationResponse {
   environmentVariables: LabelKeyPair[];
+  sftpExposed: boolean;
 }
 
 export interface ITenantConfigurationRequest {
   environmentVariables: LabelKeyPair[];
   keysToBeDeleted: string[];
+  sftpExposed: boolean;
 }
 
 export interface ITenantSecurityResponse {

--- a/web-app/src/screens/Console/Tenants/types.ts
+++ b/web-app/src/screens/Console/Tenants/types.ts
@@ -147,6 +147,7 @@ export interface IConfigureFields {
   imageRegistryPassword: string;
   exposeMinIO: boolean;
   exposeConsole: boolean;
+  exposeSFTP: boolean;
   tenantCustom: boolean;
   customRuntime: boolean;
   runtimeClassName: string;


### PR DESCRIPTION
Added console changes for enabling SFTP while tenant creation

## How to verify the changes
Steps-1: Create a kind cluster with below details
```
$ cat kind-config.yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
  - role: worker
  - role: worker
  - role: worker
  - role: worker

$ kind create cluster --config kind-config.yaml
```

Step-2: Build the operator image and load to the kind cluster
```
$ TAG=minio/operator:sftp make all
$ kind load docker-image docker.io/minio/operator:sftp
```

Step-3: Prepare the operator.yaml as below
```
$ kubectl kustomize . > operator-test.yaml
```

Step-4: Update the operator-test.yaml file and set the operator image names as `docker.io/minio/operatpr:sftp`
```
$ sed -i "s/minio\/operator:v5.0.6/docker.io\/minio\/operator:sftp/g" operator-test.yaml 
```

Step-5: Deploy the operator
```
$ kubectl apply -f operator-test.yaml
```

Step-6: Port forward to operator and open operator console
```
$ kubectl minio proxy
```

Step-7: Create tenant as per below details
![image](https://github.com/minio/operator/assets/6771252/cffcf663-7a48-4b70-9828-1bf174f4c40f)

![image](https://github.com/minio/operator/assets/6771252/8147481c-3194-452e-98ed-b994bc850108)

![image](https://github.com/minio/operator/assets/6771252/e5bf9663-c503-4f65-adb1-bba42bcb4bba)

Step-8: You should be able to see `<tenant-name>-hl` service as below
```
$ kubectl get svc -A
NAMESPACE        NAME               TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                  AGE
default          kubernetes         ClusterIP      10.96.0.1       <none>        443/TCP                  2d2h
kube-system      kube-dns           ClusterIP      10.96.0.10      <none>        53/UDP,53/TCP,9153/TCP   2d2h
minio-operator   console            ClusterIP      10.96.209.137   <none>        9090/TCP,9443/TCP        5h38m
minio-operator   operator           ClusterIP      10.96.44.57     <none>        4221/TCP                 5h38m
minio-operator   sts                ClusterIP      10.96.155.144   <none>        4223/TCP                 5h38m
tenant-ns        minio              LoadBalancer   10.96.236.190   <pending>     443:30693/TCP            5h35m
tenant-ns        tenant-1-console   LoadBalancer   10.96.243.4     <pending>     9443:30643/TCP           5h35m
tenant-ns        tenant-1-hl        ClusterIP      None            <none>        9000/TCP,8022/TCP        5h35m
```

Step-9: Port forward to services as below to access through sftp
```
$ kubectl port-forward service/tenant-1-hl -n tenant-ns 8022
$ kubectl port-forward service/minio -n tenant-ns 9443:443
```

Step-10: Use sftp to access MinIO bucket/objects
```
$ kubectl get secrets/tenant-1-user-0 -n tenant-ns -oyaml | yq '.data."CONSOLE_ACCESS_KEY"' | base64 -d
WZaBqLMGYViJ0Sba

$ kubectl get secrets/tenant-1-user-0 -n tenant-ns -oyaml | yq '.data."CONSOLE_SECRET_KEY"' | base64 -d
XMPAlfUUM4rnaAnGTxPKzeYYcBiRlUVr

$ mc alias set m1 https://localhost:9443 WZaBqLMGYViJ0Sba XMPAlfUUM4rnaAnGTxPKzeYYcBiRlUVr --insecure
Added `m1` successfully.

$ mc mb m1/test-bucket --insecure
Bucket created successfully `m1/test-bucket`.

$ mc cp /etc/issue m1/test-bucket --insecure
/etc/issue:                     28 B / 28 B ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.00 KiB/s 0s

$ sftp -P 8022 WZaBqLMGYViJ0Sba@localhost
The authenticity of host '[localhost]:8022 ([::1]:8022)' can't be established.
ECDSA key fingerprint is SHA256:wvTkjD8weTabgPkcsl+z1V1WOiKhsHzdtkdtpm3s7Fw.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[localhost]:8022' (ECDSA) to the list of known hosts.
WZaBqLMGYViJ0Sba@localhost's password: 
Connected to localhost.
sftp> ls test-bucket/
test-bucket/issue  
sftp> ls test-bucket/issue 
test-bucket/issue    
sftp> 
```