### PR TITLE
feature: option to add volumes and volumeMounts to minio-operator pod

### DIFF
--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -52,3 +52,9 @@ spec:
           {{- with .Values.operator.containerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.operator.volumeMounts }}
+          volumeMounts: {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.operator.volumes }}
+      volumes: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -29,6 +29,8 @@ operator:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+  volumes: [ ]
+  volumeMounts: [ ]
   nodeSelector: { }
   priorityClassName: ""
   affinity:


### PR DESCRIPTION
## Problem
I want to run my minio instance (operator and console) with the `readOnlyRootFilesystem: true` option. Unfortunately, this isn't possible for the operator pod, since I don't have an option to mount an emptyDir (like I did with the console pod).

So I'm currently getting the following error:

```bash
panic: mkdir /tmp/operator: read-only file system
```

## Solution
As with the console pod, I can now optionally use a volume for the operator pod.

values.yaml
```yaml
  volumes: [ ]
  volumeMounts: [ ]
```

operator-deployment.yaml
```yaml
          {{- with .Values.operator.volumeMounts }}
          volumeMounts: {{- toYaml . | nindent 12 }}
          {{- end }}
      {{- with .Values.operator.volumes }}
      volumes: {{- toYaml . | nindent 8 }}
      {{- end }}
```