### PR TITLE
Fix https containerPort for console-ui in various manifests

### DIFF
--- a/certified-operators/manifests/minio-operator.clusterserviceversion.yaml
+++ b/certified-operators/manifests/minio-operator.clusterserviceversion.yaml
@@ -476,7 +476,7 @@ spec:
                     ports:
                       - containerPort: 9090
                         name: http
-                      - containerPort: 9433
+                      - containerPort: 9443
                         name: https
                     resources: {}
                     securityContext:

--- a/community-operators/manifests/minio-operator.clusterserviceversion.yaml
+++ b/community-operators/manifests/minio-operator.clusterserviceversion.yaml
@@ -476,7 +476,7 @@ spec:
                     ports:
                       - containerPort: 9090
                         name: http
-                      - containerPort: 9433
+                      - containerPort: 9443
                         name: https
                     resources: {}
                     securityContext: {}

--- a/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -478,7 +478,7 @@ spec:
                     ports:
                       - containerPort: 9090
                         name: http
-                      - containerPort: 9433
+                      - containerPort: 9443
                         name: https
                     resources: {}
                     securityContext:

--- a/redhat-marketplace/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/redhat-marketplace/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -478,7 +478,7 @@ spec:
                     ports:
                       - containerPort: 9090
                         name: http
-                      - containerPort: 9433
+                      - containerPort: 9443
                         name: https
                     resources: {}
                     securityContext:

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -299,7 +299,7 @@ spec:
           ports:
             - containerPort: 9090
               name: http
-            - containerPort: 9433
+            - containerPort: 9443
               name: https
           volumeMounts:
             - mountPath: /tmp/certs


### PR DESCRIPTION
From the implementation and the relevant part of helm charts, I believe `https` container port in console-ui should be `9443`. I also tested that the console-ui listens to `9443` and it doesn't listen to `9433`.