### PR TITLE
Helm: Adding digest option in Operator image

### DIFF
--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.console.image.repository }}:{{ .Values.console.image.tag }}"
+          image: "{{ .Values.console.image.repository }}:{{ .Values.console.image.digest | default .Values.console.image.tag }}"
           imagePullPolicy: {{ .Values.console.image.pullPolicy }}
           ports:
             - containerPort: 9090

--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
+          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.digest | default .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:
             - controller

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -11,6 +11,18 @@ operator:
   #     value: ""
   #   - name: MINIO_OPERATOR_RUNTIME
   #     value: "OpenShift"
+  #
+  ### Image field:
+  ## Image from tag (original behaviour), for example:
+  # image:
+  #   repository: quay.io/minio/operator
+  #   tag: v5.0.6
+  #   pullPolicy: IfNotPresent
+  ## Image from digest (added after original behaviour), for example:
+  # image:
+  #   repository: quay.io/minio/operator@sha256
+  #   digest: 28c80b379c75242c6fe793dfbf212f43c602140a0de5ebe3d9c2a3a7b9f9f983
+  #   pullPolicy: IfNotPresent
   image:
     repository: quay.io/minio/operator
     tag: v5.0.6

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -19,7 +19,7 @@ scheduler:
   name: {{ dig "scheduler" "name" "" . }}
 {{- end }}
 spec:
-  image: {{ dig "image" "repository" "minio/minio" . }}:{{ dig "image" "tag" "RELEASE.2022-01-08T03-11-54Z" . }}
+  image: "{{ .image.repository }}:{{ .image.digest | default .image.tag }}"
   imagePullPolicy: {{ dig "image" "pullPolicy" "IfNotPresent" . }}
   {{- if dig "imagePullSecret" "name" "" . }}
   imagePullSecret:
@@ -132,7 +132,7 @@ spec:
   {{- end }}
   {{- if dig "kes" "configuration" false . }}
   kes:
-    image: {{ .kes.image | quote }}
+    image: "{{ .kes.image.repository }}:{{ .kes.image.digest | default .kes.image.tag }}"
     {{- with (dig "kes" "env" (list) .) }}
     env: {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -11,7 +11,17 @@ secrets:
 tenant:
   # Tenant name
   name: myminio
-  ## Registry location and Tag to download MinIO Server image
+  ### Registry location and Tag or Digest to download MinIO Server image, options:
+  ## Option 1: Image from tag (original behaviour):
+  # image:
+  #    repository: quay.io/minio/minio
+  #    tag: RELEASE.2023-06-23T20-26-00Z
+  #    pullPolicy: IfNotPresent
+  ## Option 2: Image from digest (added after original):
+  # image:
+  #    repository: quay.io/minio/minio@sha256
+  #    digest: 28c80b379c75242c6fe793dfbf212f43c602140a0de5ebe3d9c2a3a7b9f9f983
+  #    pullPolicy: IfNotPresent
   image:
     repository: quay.io/minio/minio
     tag: RELEASE.2023-06-23T20-26-00Z
@@ -159,7 +169,19 @@ tenant:
   ## Define configuration for KES (stateless and distributed key-management system)
   ## Refer https://github.com/minio/kes
   #kes:
-  #  image: "" # minio/kes:2023-05-02T22-48-10Z
+  #  ### Image field:
+  #  ## Image from tag (original behaviour), for example:
+  #  # image:
+  #  #   repository: quay.io/minio/kes
+  #  #   tag: 2023-07-26T11-13-07Z
+  #  ## Image from digest (added after original behaviour), for example:
+  #  # image:
+  #  #   repository: quay.io/minio/kes@sha256
+  #  #   digest: fb15af611149892f357a8a99d1bcd8bf5dae713bd64c15e6eb27fbdb88fc208b
+  #  image:
+  #    repository: quay.io/minio/kes
+  #    tag: 2023-07-26T11-13-07Z
+  #    pullPolicy: IfNotPresent
   #  env: [ ]
   #  replicas: 2
   #  configuration: |-


### PR DESCRIPTION
### Objective:

To support digest in our Operator Helm Image.

### Additional information:

To fix: https://github.com/minio/operator/issues/1599

### How to test:

1. Create a cluster in kind

2. Deploy Operator via Helm with the changes:

* For the operator

```sh
helm install \
     --namespace minio-operator \
     --create-namespace \
     minio-operator ./operator
```

* For the tenant:
 
```sh
helm install \
  --namespace tenant-ns \
  --create-namespace \
  tenant-ns ./tenant
```

### Values to test: 

* Values for `digest`

```yaml
operator:
  image:
    repository: quay.io/minio/operator@sha256
    digest: 28c80b379c75242c6fe793dfbf212f43c602140a0de5ebe3d9c2a3a7b9f9f983
    pullPolicy: IfNotPresent
```

* Values for `tag`

```yaml
operator:
  image:
    repository: quay.io/minio/operator
    tag: v5.0.6
    pullPolicy: IfNotPresent
```