### PR TITLE
Remove MINIO_IDENTITY_OPENID_REDIRECT_URI - Deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ examples/.DS_Store
 testing/openshift/bundle/*
 examples/**/obj/
 .idea
+operator.iml
+

--- a/api/embedded_spec.go
+++ b/api/embedded_spec.go
@@ -3081,9 +3081,6 @@ func init() {
             "claim_name"
           ],
           "properties": {
-            "callback_url": {
-              "type": "string"
-            },
             "claim_name": {
               "type": "string"
             },
@@ -7223,9 +7220,6 @@ func init() {
         "claim_name"
       ],
       "properties": {
-        "callback_url": {
-          "type": "string"
-        },
         "claim_name": {
           "type": "string"
         },
@@ -8609,9 +8603,6 @@ func init() {
             "claim_name"
           ],
           "properties": {
-            "callback_url": {
-              "type": "string"
-            },
             "claim_name": {
               "type": "string"
             },

--- a/api/operations/operator_api.go
+++ b/api/operations/operator_api.go
@@ -1041,6 +1041,6 @@ func (o *OperatorAPI) AddMiddlewareFor(method, path string, builder middleware.B
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[um][path] = builder(h)
+		o.handlers[method][path] = builder(h)
 	}
 }

--- a/api/tenant-handlers.go
+++ b/api/tenant-handlers.go
@@ -406,7 +406,6 @@ func getTenantIdentityProvider(ctx context.Context, clientSet K8sClientI, tenant
 
 	if tenantConfiguration["MINIO_IDENTITY_OPENID_CONFIG_URL"] != "" {
 
-		callbackURL := tenantConfiguration["MINIO_IDENTITY_OPENID_REDIRECT_URI"]
 		claimName := tenantConfiguration["MINIO_IDENTITY_OPENID_CLAIM_NAME"]
 		clientID := tenantConfiguration["MINIO_IDENTITY_OPENID_CLIENT_ID"]
 		configurationURL := tenantConfiguration["MINIO_IDENTITY_OPENID_CONFIG_URL"]
@@ -415,7 +414,6 @@ func getTenantIdentityProvider(ctx context.Context, clientSet K8sClientI, tenant
 
 		idpConfiguration = &models.IdpConfiguration{
 			Oidc: &models.IdpConfigurationOidc{
-				CallbackURL:      callbackURL,
 				ClaimName:        &claimName,
 				ClientID:         &clientID,
 				ConfigurationURL: &configurationURL,
@@ -476,13 +474,11 @@ func updateTenantIdentityProvider(ctx context.Context, operatorClient OperatorCl
 		secretID := *oidcConfig.SecretID
 		claimName := *oidcConfig.ClaimName
 		scopes := oidcConfig.Scopes
-		callbackURL := oidcConfig.CallbackURL
 		// oidc config
 		tenantConfiguration["MINIO_IDENTITY_OPENID_CONFIG_URL"] = configurationURL
 		tenantConfiguration["MINIO_IDENTITY_OPENID_CLIENT_ID"] = clientID
 		tenantConfiguration["MINIO_IDENTITY_OPENID_CLIENT_SECRET"] = secretID
 		tenantConfiguration["MINIO_IDENTITY_OPENID_CLAIM_NAME"] = claimName
-		tenantConfiguration["MINIO_IDENTITY_OPENID_REDIRECT_URI"] = callbackURL
 		if scopes == "" {
 			scopes = "openid,profile,email"
 		}
@@ -494,7 +490,7 @@ func updateTenantIdentityProvider(ctx context.Context, operatorClient OperatorCl
 		delete(tenantConfiguration, "MINIO_IDENTITY_OPENID_CONFIG_URL")
 		delete(tenantConfiguration, "MINIO_IDENTITY_OPENID_SCOPES")
 		delete(tenantConfiguration, "MINIO_IDENTITY_OPENID_CLIENT_SECRET")
-		delete(tenantConfiguration, "MINIO_IDENTITY_OPENID_REDIRECT_URI")
+		delete(tenantConfiguration, "MINIO_BROWSER_REDIRECT_URL")
 	}
 	ldapConfig := params.Body.ActiveDirectory
 	// set new active directory configuration fields

--- a/examples/kustomization/tenant-external-idp-oidc/tenant.yaml
+++ b/examples/kustomization/tenant-external-idp-oidc/tenant.yaml
@@ -16,5 +16,3 @@ spec:
       value: "openid,profile,email"
     - name: MINIO_IDENTITY_OPENID_CLAIM_NAME
       value: "https://min.io/policy"
-    - name: MINIO_IDENTITY_OPENID_REDIRECT_URI
-      value: "https://your-console-endpoint.com/oauth_callback"

--- a/models/allocatable_resources_response.go
+++ b/models/allocatable_resources_response.go
@@ -125,11 +125,6 @@ func (m *AllocatableResourcesResponse) ContextValidate(ctx context.Context, form
 func (m *AllocatableResourcesResponse) contextValidateCPUPriority(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CPUPriority != nil {
-
-		if swag.IsZero(m.CPUPriority) { // not required
-			return nil
-		}
-
 		if err := m.CPUPriority.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("cpu_priority")
@@ -146,11 +141,6 @@ func (m *AllocatableResourcesResponse) contextValidateCPUPriority(ctx context.Co
 func (m *AllocatableResourcesResponse) contextValidateMemPriority(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MemPriority != nil {
-
-		if swag.IsZero(m.MemPriority) { // not required
-			return nil
-		}
-
 		if err := m.MemPriority.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("mem_priority")

--- a/models/aws_configuration.go
+++ b/models/aws_configuration.go
@@ -92,7 +92,6 @@ func (m *AwsConfiguration) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *AwsConfiguration) contextValidateSecretsmanager(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Secretsmanager != nil {
-
 		if err := m.Secretsmanager.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretsmanager")
@@ -222,7 +221,6 @@ func (m *AwsConfigurationSecretsmanager) ContextValidate(ctx context.Context, fo
 func (m *AwsConfigurationSecretsmanager) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
-
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretsmanager" + "." + "credentials")

--- a/models/azure_configuration.go
+++ b/models/azure_configuration.go
@@ -92,7 +92,6 @@ func (m *AzureConfiguration) ContextValidate(ctx context.Context, formats strfmt
 func (m *AzureConfiguration) contextValidateKeyvault(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Keyvault != nil {
-
 		if err := m.Keyvault.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyvault")
@@ -200,11 +199,6 @@ func (m *AzureConfigurationKeyvault) ContextValidate(ctx context.Context, format
 func (m *AzureConfigurationKeyvault) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
-
-		if swag.IsZero(m.Credentials) { // not required
-			return nil
-		}
-
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keyvault" + "." + "credentials")

--- a/models/container.go
+++ b/models/container.go
@@ -223,11 +223,6 @@ func (m *Container) contextValidateEnvironmentVariables(ctx context.Context, for
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
-
-			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
-				return nil
-			}
-
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))
@@ -246,11 +241,6 @@ func (m *Container) contextValidateEnvironmentVariables(ctx context.Context, for
 func (m *Container) contextValidateLastState(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LastState != nil {
-
-		if swag.IsZero(m.LastState) { // not required
-			return nil
-		}
-
 		if err := m.LastState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("lastState")
@@ -269,11 +259,6 @@ func (m *Container) contextValidateMounts(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m.Mounts); i++ {
 
 		if m.Mounts[i] != nil {
-
-			if swag.IsZero(m.Mounts[i]) { // not required
-				return nil
-			}
-
 			if err := m.Mounts[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("mounts" + "." + strconv.Itoa(i))
@@ -292,11 +277,6 @@ func (m *Container) contextValidateMounts(ctx context.Context, formats strfmt.Re
 func (m *Container) contextValidateState(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.State != nil {
-
-		if swag.IsZero(m.State) { // not required
-			return nil
-		}
-
 		if err := m.State.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("state")

--- a/models/create_tenant_request.go
+++ b/models/create_tenant_request.go
@@ -365,11 +365,6 @@ func (m *CreateTenantRequest) ContextValidate(ctx context.Context, formats strfm
 func (m *CreateTenantRequest) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
-
-		if swag.IsZero(m.Domains) { // not required
-			return nil
-		}
-
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")
@@ -386,11 +381,6 @@ func (m *CreateTenantRequest) contextValidateDomains(ctx context.Context, format
 func (m *CreateTenantRequest) contextValidateEncryption(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Encryption != nil {
-
-		if swag.IsZero(m.Encryption) { // not required
-			return nil
-		}
-
 		if err := m.Encryption.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("encryption")
@@ -409,11 +399,6 @@ func (m *CreateTenantRequest) contextValidateEnvironmentVariables(ctx context.Co
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
-
-			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
-				return nil
-			}
-
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))
@@ -432,11 +417,6 @@ func (m *CreateTenantRequest) contextValidateEnvironmentVariables(ctx context.Co
 func (m *CreateTenantRequest) contextValidateIdp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Idp != nil {
-
-		if swag.IsZero(m.Idp) { // not required
-			return nil
-		}
-
 		if err := m.Idp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("idp")
@@ -453,11 +433,6 @@ func (m *CreateTenantRequest) contextValidateIdp(ctx context.Context, formats st
 func (m *CreateTenantRequest) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ImageRegistry != nil {
-
-		if swag.IsZero(m.ImageRegistry) { // not required
-			return nil
-		}
-
 		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image_registry")
@@ -476,11 +451,6 @@ func (m *CreateTenantRequest) contextValidatePools(ctx context.Context, formats 
 	for i := 0; i < len(m.Pools); i++ {
 
 		if m.Pools[i] != nil {
-
-			if swag.IsZero(m.Pools[i]) { // not required
-				return nil
-			}
-
 			if err := m.Pools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pools" + "." + strconv.Itoa(i))
@@ -499,11 +469,6 @@ func (m *CreateTenantRequest) contextValidatePools(ctx context.Context, formats 
 func (m *CreateTenantRequest) contextValidateTLS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TLS != nil {
-
-		if swag.IsZero(m.TLS) { // not required
-			return nil
-		}
-
 		if err := m.TLS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tls")

--- a/models/create_tenant_response.go
+++ b/models/create_tenant_response.go
@@ -102,11 +102,6 @@ func (m *CreateTenantResponse) contextValidateConsole(ctx context.Context, forma
 	for i := 0; i < len(m.Console); i++ {
 
 		if m.Console[i] != nil {
-
-			if swag.IsZero(m.Console[i]) { // not required
-				return nil
-			}
-
 			if err := m.Console[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("console" + "." + strconv.Itoa(i))

--- a/models/csr_element.go
+++ b/models/csr_element.go
@@ -120,11 +120,6 @@ func (m *CsrElement) contextValidateAnnotations(ctx context.Context, formats str
 	for i := 0; i < len(m.Annotations); i++ {
 
 		if m.Annotations[i] != nil {
-
-			if swag.IsZero(m.Annotations[i]) { // not required
-				return nil
-			}
-
 			if err := m.Annotations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("annotations" + "." + strconv.Itoa(i))

--- a/models/csr_elements.go
+++ b/models/csr_elements.go
@@ -99,11 +99,6 @@ func (m *CsrElements) contextValidateCsrElement(ctx context.Context, formats str
 	for i := 0; i < len(m.CsrElement); i++ {
 
 		if m.CsrElement[i] != nil {
-
-			if swag.IsZero(m.CsrElement[i]) { // not required
-				return nil
-			}
-
 			if err := m.CsrElement[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("csrElement" + "." + strconv.Itoa(i))

--- a/models/describe_p_v_c_wrapper.go
+++ b/models/describe_p_v_c_wrapper.go
@@ -163,11 +163,6 @@ func (m *DescribePVCWrapper) contextValidateAnnotations(ctx context.Context, for
 	for i := 0; i < len(m.Annotations); i++ {
 
 		if m.Annotations[i] != nil {
-
-			if swag.IsZero(m.Annotations[i]) { // not required
-				return nil
-			}
-
 			if err := m.Annotations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("annotations" + "." + strconv.Itoa(i))
@@ -188,11 +183,6 @@ func (m *DescribePVCWrapper) contextValidateLabels(ctx context.Context, formats 
 	for i := 0; i < len(m.Labels); i++ {
 
 		if m.Labels[i] != nil {
-
-			if swag.IsZero(m.Labels[i]) { // not required
-				return nil
-			}
-
 			if err := m.Labels[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("labels" + "." + strconv.Itoa(i))

--- a/models/describe_pod_wrapper.go
+++ b/models/describe_pod_wrapper.go
@@ -363,11 +363,6 @@ func (m *DescribePodWrapper) contextValidateAnnotations(ctx context.Context, for
 	for i := 0; i < len(m.Annotations); i++ {
 
 		if m.Annotations[i] != nil {
-
-			if swag.IsZero(m.Annotations[i]) { // not required
-				return nil
-			}
-
 			if err := m.Annotations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("annotations" + "." + strconv.Itoa(i))
@@ -388,11 +383,6 @@ func (m *DescribePodWrapper) contextValidateConditions(ctx context.Context, form
 	for i := 0; i < len(m.Conditions); i++ {
 
 		if m.Conditions[i] != nil {
-
-			if swag.IsZero(m.Conditions[i]) { // not required
-				return nil
-			}
-
 			if err := m.Conditions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("conditions" + "." + strconv.Itoa(i))
@@ -413,11 +403,6 @@ func (m *DescribePodWrapper) contextValidateContainers(ctx context.Context, form
 	for i := 0; i < len(m.Containers); i++ {
 
 		if m.Containers[i] != nil {
-
-			if swag.IsZero(m.Containers[i]) { // not required
-				return nil
-			}
-
 			if err := m.Containers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("containers" + "." + strconv.Itoa(i))
@@ -438,11 +423,6 @@ func (m *DescribePodWrapper) contextValidateLabels(ctx context.Context, formats 
 	for i := 0; i < len(m.Labels); i++ {
 
 		if m.Labels[i] != nil {
-
-			if swag.IsZero(m.Labels[i]) { // not required
-				return nil
-			}
-
 			if err := m.Labels[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("labels" + "." + strconv.Itoa(i))
@@ -463,11 +443,6 @@ func (m *DescribePodWrapper) contextValidateNodeSelector(ctx context.Context, fo
 	for i := 0; i < len(m.NodeSelector); i++ {
 
 		if m.NodeSelector[i] != nil {
-
-			if swag.IsZero(m.NodeSelector[i]) { // not required
-				return nil
-			}
-
 			if err := m.NodeSelector[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodeSelector" + "." + strconv.Itoa(i))
@@ -488,11 +463,6 @@ func (m *DescribePodWrapper) contextValidateTolerations(ctx context.Context, for
 	for i := 0; i < len(m.Tolerations); i++ {
 
 		if m.Tolerations[i] != nil {
-
-			if swag.IsZero(m.Tolerations[i]) { // not required
-				return nil
-			}
-
 			if err := m.Tolerations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tolerations" + "." + strconv.Itoa(i))
@@ -513,11 +483,6 @@ func (m *DescribePodWrapper) contextValidateVolumes(ctx context.Context, formats
 	for i := 0; i < len(m.Volumes); i++ {
 
 		if m.Volumes[i] != nil {
-
-			if swag.IsZero(m.Volumes[i]) { // not required
-				return nil
-			}
-
 			if err := m.Volumes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("volumes" + "." + strconv.Itoa(i))

--- a/models/encryption_configuration.go
+++ b/models/encryption_configuration.go
@@ -513,11 +513,6 @@ func (m *EncryptionConfiguration) ContextValidate(ctx context.Context, formats s
 func (m *EncryptionConfiguration) contextValidateAws(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Aws != nil {
-
-		if swag.IsZero(m.Aws) { // not required
-			return nil
-		}
-
 		if err := m.Aws.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("aws")
@@ -534,11 +529,6 @@ func (m *EncryptionConfiguration) contextValidateAws(ctx context.Context, format
 func (m *EncryptionConfiguration) contextValidateAzure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Azure != nil {
-
-		if swag.IsZero(m.Azure) { // not required
-			return nil
-		}
-
 		if err := m.Azure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azure")
@@ -555,11 +545,6 @@ func (m *EncryptionConfiguration) contextValidateAzure(ctx context.Context, form
 func (m *EncryptionConfiguration) contextValidateGcp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gcp != nil {
-
-		if swag.IsZero(m.Gcp) { // not required
-			return nil
-		}
-
 		if err := m.Gcp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gcp")
@@ -576,11 +561,6 @@ func (m *EncryptionConfiguration) contextValidateGcp(ctx context.Context, format
 func (m *EncryptionConfiguration) contextValidateGemalto(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gemalto != nil {
-
-		if swag.IsZero(m.Gemalto) { // not required
-			return nil
-		}
-
 		if err := m.Gemalto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gemalto")
@@ -597,11 +577,6 @@ func (m *EncryptionConfiguration) contextValidateGemalto(ctx context.Context, fo
 func (m *EncryptionConfiguration) contextValidateKmsMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.KmsMtls != nil {
-
-		if swag.IsZero(m.KmsMtls) { // not required
-			return nil
-		}
-
 		if err := m.KmsMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls")
@@ -618,11 +593,6 @@ func (m *EncryptionConfiguration) contextValidateKmsMtls(ctx context.Context, fo
 func (m *EncryptionConfiguration) contextValidateMinioMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MinioMtls != nil {
-
-		if swag.IsZero(m.MinioMtls) { // not required
-			return nil
-		}
-
 		if err := m.MinioMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minio_mtls")
@@ -639,11 +609,6 @@ func (m *EncryptionConfiguration) contextValidateMinioMtls(ctx context.Context, 
 func (m *EncryptionConfiguration) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -660,11 +625,6 @@ func (m *EncryptionConfiguration) contextValidateSecurityContext(ctx context.Con
 func (m *EncryptionConfiguration) contextValidateServerTLS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ServerTLS != nil {
-
-		if swag.IsZero(m.ServerTLS) { // not required
-			return nil
-		}
-
 		if err := m.ServerTLS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("server_tls")
@@ -681,11 +641,6 @@ func (m *EncryptionConfiguration) contextValidateServerTLS(ctx context.Context, 
 func (m *EncryptionConfiguration) contextValidateVault(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Vault != nil {
-
-		if swag.IsZero(m.Vault) { // not required
-			return nil
-		}
-
 		if err := m.Vault.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vault")

--- a/models/encryption_configuration_response.go
+++ b/models/encryption_configuration_response.go
@@ -502,11 +502,6 @@ func (m *EncryptionConfigurationResponse) ContextValidate(ctx context.Context, f
 func (m *EncryptionConfigurationResponse) contextValidateAws(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Aws != nil {
-
-		if swag.IsZero(m.Aws) { // not required
-			return nil
-		}
-
 		if err := m.Aws.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("aws")
@@ -523,11 +518,6 @@ func (m *EncryptionConfigurationResponse) contextValidateAws(ctx context.Context
 func (m *EncryptionConfigurationResponse) contextValidateAzure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Azure != nil {
-
-		if swag.IsZero(m.Azure) { // not required
-			return nil
-		}
-
 		if err := m.Azure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("azure")
@@ -544,11 +534,6 @@ func (m *EncryptionConfigurationResponse) contextValidateAzure(ctx context.Conte
 func (m *EncryptionConfigurationResponse) contextValidateGcp(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gcp != nil {
-
-		if swag.IsZero(m.Gcp) { // not required
-			return nil
-		}
-
 		if err := m.Gcp.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gcp")
@@ -565,11 +550,6 @@ func (m *EncryptionConfigurationResponse) contextValidateGcp(ctx context.Context
 func (m *EncryptionConfigurationResponse) contextValidateGemalto(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Gemalto != nil {
-
-		if swag.IsZero(m.Gemalto) { // not required
-			return nil
-		}
-
 		if err := m.Gemalto.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("gemalto")
@@ -586,11 +566,6 @@ func (m *EncryptionConfigurationResponse) contextValidateGemalto(ctx context.Con
 func (m *EncryptionConfigurationResponse) contextValidateKmsMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.KmsMtls != nil {
-
-		if swag.IsZero(m.KmsMtls) { // not required
-			return nil
-		}
-
 		if err := m.KmsMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls")
@@ -607,11 +582,6 @@ func (m *EncryptionConfigurationResponse) contextValidateKmsMtls(ctx context.Con
 func (m *EncryptionConfigurationResponse) contextValidateMinioMtls(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.MinioMtls != nil {
-
-		if swag.IsZero(m.MinioMtls) { // not required
-			return nil
-		}
-
 		if err := m.MinioMtls.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("minio_mtls")
@@ -628,11 +598,6 @@ func (m *EncryptionConfigurationResponse) contextValidateMinioMtls(ctx context.C
 func (m *EncryptionConfigurationResponse) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -649,11 +614,6 @@ func (m *EncryptionConfigurationResponse) contextValidateSecurityContext(ctx con
 func (m *EncryptionConfigurationResponse) contextValidateServerTLS(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ServerTLS != nil {
-
-		if swag.IsZero(m.ServerTLS) { // not required
-			return nil
-		}
-
 		if err := m.ServerTLS.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("server_tls")
@@ -670,11 +630,6 @@ func (m *EncryptionConfigurationResponse) contextValidateServerTLS(ctx context.C
 func (m *EncryptionConfigurationResponse) contextValidateVault(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Vault != nil {
-
-		if swag.IsZero(m.Vault) { // not required
-			return nil
-		}
-
 		if err := m.Vault.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("vault")
@@ -795,11 +750,6 @@ func (m *EncryptionConfigurationResponseAO1KmsMtls) ContextValidate(ctx context.
 func (m *EncryptionConfigurationResponseAO1KmsMtls) contextValidateCa(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Ca != nil {
-
-		if swag.IsZero(m.Ca) { // not required
-			return nil
-		}
-
 		if err := m.Ca.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls" + "." + "ca")
@@ -816,11 +766,6 @@ func (m *EncryptionConfigurationResponseAO1KmsMtls) contextValidateCa(ctx contex
 func (m *EncryptionConfigurationResponseAO1KmsMtls) contextValidateCrt(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Crt != nil {
-
-		if swag.IsZero(m.Crt) { // not required
-			return nil
-		}
-
 		if err := m.Crt.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("kms_mtls" + "." + "crt")

--- a/models/event_list_wrapper.go
+++ b/models/event_list_wrapper.go
@@ -71,11 +71,6 @@ func (m EventListWrapper) ContextValidate(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
-
-			if swag.IsZero(m[i]) { // not required
-				return nil
-			}
-
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))

--- a/models/gcp_configuration.go
+++ b/models/gcp_configuration.go
@@ -92,7 +92,6 @@ func (m *GcpConfiguration) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *GcpConfiguration) contextValidateSecretmanager(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Secretmanager != nil {
-
 		if err := m.Secretmanager.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretmanager")
@@ -203,11 +202,6 @@ func (m *GcpConfigurationSecretmanager) ContextValidate(ctx context.Context, for
 func (m *GcpConfigurationSecretmanager) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
-
-		if swag.IsZero(m.Credentials) { // not required
-			return nil
-		}
-
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secretmanager" + "." + "credentials")

--- a/models/gemalto_configuration.go
+++ b/models/gemalto_configuration.go
@@ -92,7 +92,6 @@ func (m *GemaltoConfiguration) ContextValidate(ctx context.Context, formats strf
 func (m *GemaltoConfiguration) contextValidateKeysecure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Keysecure != nil {
-
 		if err := m.Keysecure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure")
@@ -202,7 +201,6 @@ func (m *GemaltoConfigurationKeysecure) ContextValidate(ctx context.Context, for
 func (m *GemaltoConfigurationKeysecure) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
-
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure" + "." + "credentials")

--- a/models/gemalto_configuration_response.go
+++ b/models/gemalto_configuration_response.go
@@ -92,7 +92,6 @@ func (m *GemaltoConfigurationResponse) ContextValidate(ctx context.Context, form
 func (m *GemaltoConfigurationResponse) contextValidateKeysecure(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Keysecure != nil {
-
 		if err := m.Keysecure.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure")
@@ -202,7 +201,6 @@ func (m *GemaltoConfigurationResponseKeysecure) ContextValidate(ctx context.Cont
 func (m *GemaltoConfigurationResponseKeysecure) contextValidateCredentials(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Credentials != nil {
-
 		if err := m.Credentials.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("keysecure" + "." + "credentials")

--- a/models/idp_configuration.go
+++ b/models/idp_configuration.go
@@ -158,11 +158,6 @@ func (m *IdpConfiguration) ContextValidate(ctx context.Context, formats strfmt.R
 func (m *IdpConfiguration) contextValidateActiveDirectory(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ActiveDirectory != nil {
-
-		if swag.IsZero(m.ActiveDirectory) { // not required
-			return nil
-		}
-
 		if err := m.ActiveDirectory.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("active_directory")
@@ -181,11 +176,6 @@ func (m *IdpConfiguration) contextValidateKeys(ctx context.Context, formats strf
 	for i := 0; i < len(m.Keys); i++ {
 
 		if m.Keys[i] != nil {
-
-			if swag.IsZero(m.Keys[i]) { // not required
-				return nil
-			}
-
 			if err := m.Keys[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("keys" + "." + strconv.Itoa(i))
@@ -204,11 +194,6 @@ func (m *IdpConfiguration) contextValidateKeys(ctx context.Context, formats strf
 func (m *IdpConfiguration) contextValidateOidc(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Oidc != nil {
-
-		if swag.IsZero(m.Oidc) { // not required
-			return nil
-		}
-
 		if err := m.Oidc.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("oidc")
@@ -417,9 +402,6 @@ func (m *IdpConfigurationKeysItems0) UnmarshalBinary(b []byte) error {
 //
 // swagger:model IdpConfigurationOidc
 type IdpConfigurationOidc struct {
-
-	// callback url
-	CallbackURL string `json:"callback_url,omitempty"`
 
 	// claim name
 	// Required: true

--- a/models/list_p_v_cs_response.go
+++ b/models/list_p_v_cs_response.go
@@ -99,11 +99,6 @@ func (m *ListPVCsResponse) contextValidatePvcs(ctx context.Context, formats strf
 	for i := 0; i < len(m.Pvcs); i++ {
 
 		if m.Pvcs[i] != nil {
-
-			if swag.IsZero(m.Pvcs[i]) { // not required
-				return nil
-			}
-
 			if err := m.Pvcs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pvcs" + "." + strconv.Itoa(i))

--- a/models/list_tenants_response.go
+++ b/models/list_tenants_response.go
@@ -102,11 +102,6 @@ func (m *ListTenantsResponse) contextValidateTenants(ctx context.Context, format
 	for i := 0; i < len(m.Tenants); i++ {
 
 		if m.Tenants[i] != nil {
-
-			if swag.IsZero(m.Tenants[i]) { // not required
-				return nil
-			}
-
 			if err := m.Tenants[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tenants" + "." + strconv.Itoa(i))

--- a/models/login_details.go
+++ b/models/login_details.go
@@ -160,11 +160,6 @@ func (m *LoginDetails) contextValidateRedirectRules(ctx context.Context, formats
 	for i := 0; i < len(m.RedirectRules); i++ {
 
 		if m.RedirectRules[i] != nil {
-
-			if swag.IsZero(m.RedirectRules[i]) { // not required
-				return nil
-			}
-
 			if err := m.RedirectRules[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("redirectRules" + "." + strconv.Itoa(i))

--- a/models/login_request.go
+++ b/models/login_request.go
@@ -98,11 +98,6 @@ func (m *LoginRequest) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *LoginRequest) contextValidateFeatures(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Features != nil {
-
-		if swag.IsZero(m.Features) { // not required
-			return nil
-		}
-
 		if err := m.Features.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("features")

--- a/models/node_selector_term.go
+++ b/models/node_selector_term.go
@@ -137,11 +137,6 @@ func (m *NodeSelectorTerm) contextValidateMatchExpressions(ctx context.Context, 
 	for i := 0; i < len(m.MatchExpressions); i++ {
 
 		if m.MatchExpressions[i] != nil {
-
-			if swag.IsZero(m.MatchExpressions[i]) { // not required
-				return nil
-			}
-
 			if err := m.MatchExpressions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matchExpressions" + "." + strconv.Itoa(i))
@@ -162,11 +157,6 @@ func (m *NodeSelectorTerm) contextValidateMatchFields(ctx context.Context, forma
 	for i := 0; i < len(m.MatchFields); i++ {
 
 		if m.MatchFields[i] != nil {
-
-			if swag.IsZero(m.MatchFields[i]) { // not required
-				return nil
-			}
-
 			if err := m.MatchFields[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("matchFields" + "." + strconv.Itoa(i))

--- a/models/pod_affinity_term.go
+++ b/models/pod_affinity_term.go
@@ -111,11 +111,6 @@ func (m *PodAffinityTerm) ContextValidate(ctx context.Context, formats strfmt.Re
 func (m *PodAffinityTerm) contextValidateLabelSelector(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.LabelSelector != nil {
-
-		if swag.IsZero(m.LabelSelector) { // not required
-			return nil
-		}
-
 		if err := m.LabelSelector.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("labelSelector")
@@ -218,11 +213,6 @@ func (m *PodAffinityTermLabelSelector) contextValidateMatchExpressions(ctx conte
 	for i := 0; i < len(m.MatchExpressions); i++ {
 
 		if m.MatchExpressions[i] != nil {
-
-			if swag.IsZero(m.MatchExpressions[i]) { // not required
-				return nil
-			}
-
 			if err := m.MatchExpressions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("labelSelector" + "." + "matchExpressions" + "." + strconv.Itoa(i))

--- a/models/pool.go
+++ b/models/pool.go
@@ -253,11 +253,6 @@ func (m *Pool) ContextValidate(ctx context.Context, formats strfmt.Registry) err
 func (m *Pool) contextValidateAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Affinity != nil {
-
-		if swag.IsZero(m.Affinity) { // not required
-			return nil
-		}
-
 		if err := m.Affinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("affinity")
@@ -274,11 +269,6 @@ func (m *Pool) contextValidateAffinity(ctx context.Context, formats strfmt.Regis
 func (m *Pool) contextValidateResources(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Resources != nil {
-
-		if swag.IsZero(m.Resources) { // not required
-			return nil
-		}
-
 		if err := m.Resources.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("resources")
@@ -295,11 +285,6 @@ func (m *Pool) contextValidateResources(ctx context.Context, formats strfmt.Regi
 func (m *Pool) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -330,7 +315,6 @@ func (m *Pool) contextValidateTolerations(ctx context.Context, formats strfmt.Re
 func (m *Pool) contextValidateVolumeConfiguration(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.VolumeConfiguration != nil {
-
 		if err := m.VolumeConfiguration.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("volume_configuration")

--- a/models/pool_affinity.go
+++ b/models/pool_affinity.go
@@ -151,11 +151,6 @@ func (m *PoolAffinity) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *PoolAffinity) contextValidateNodeAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.NodeAffinity != nil {
-
-		if swag.IsZero(m.NodeAffinity) { // not required
-			return nil
-		}
-
 		if err := m.NodeAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodeAffinity")
@@ -172,11 +167,6 @@ func (m *PoolAffinity) contextValidateNodeAffinity(ctx context.Context, formats 
 func (m *PoolAffinity) contextValidatePodAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAffinity != nil {
-
-		if swag.IsZero(m.PodAffinity) { // not required
-			return nil
-		}
-
 		if err := m.PodAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAffinity")
@@ -193,11 +183,6 @@ func (m *PoolAffinity) contextValidatePodAffinity(ctx context.Context, formats s
 func (m *PoolAffinity) contextValidatePodAntiAffinity(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAntiAffinity != nil {
-
-		if swag.IsZero(m.PodAntiAffinity) { // not required
-			return nil
-		}
-
 		if err := m.PodAntiAffinity.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAntiAffinity")
@@ -327,11 +312,6 @@ func (m *PoolAffinityNodeAffinity) contextValidatePreferredDuringSchedulingIgnor
 	for i := 0; i < len(m.PreferredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.PreferredDuringSchedulingIgnoredDuringExecution[i] != nil {
-
-			if swag.IsZero(m.PreferredDuringSchedulingIgnoredDuringExecution[i]) { // not required
-				return nil
-			}
-
 			if err := m.PreferredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodeAffinity" + "." + "preferredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -350,11 +330,6 @@ func (m *PoolAffinityNodeAffinity) contextValidatePreferredDuringSchedulingIgnor
 func (m *PoolAffinityNodeAffinity) contextValidateRequiredDuringSchedulingIgnoredDuringExecution(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-
-		if swag.IsZero(m.RequiredDuringSchedulingIgnoredDuringExecution) { // not required
-			return nil
-		}
-
 		if err := m.RequiredDuringSchedulingIgnoredDuringExecution.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodeAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution")
@@ -464,7 +439,6 @@ func (m *PoolAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecution
 func (m *PoolAffinityNodeAffinityPreferredDuringSchedulingIgnoredDuringExecutionItems0) contextValidatePreference(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Preference != nil {
-
 		if err := m.Preference.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("preference")
@@ -566,11 +540,6 @@ func (m *PoolAffinityNodeAffinityRequiredDuringSchedulingIgnoredDuringExecution)
 	for i := 0; i < len(m.NodeSelectorTerms); i++ {
 
 		if m.NodeSelectorTerms[i] != nil {
-
-			if swag.IsZero(m.NodeSelectorTerms[i]) { // not required
-				return nil
-			}
-
 			if err := m.NodeSelectorTerms[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodeAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution" + "." + "nodeSelectorTerms" + "." + strconv.Itoa(i))
@@ -709,11 +678,6 @@ func (m *PoolAffinityPodAffinity) contextValidatePreferredDuringSchedulingIgnore
 	for i := 0; i < len(m.PreferredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.PreferredDuringSchedulingIgnoredDuringExecution[i] != nil {
-
-			if swag.IsZero(m.PreferredDuringSchedulingIgnoredDuringExecution[i]) { // not required
-				return nil
-			}
-
 			if err := m.PreferredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAffinity" + "." + "preferredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -734,11 +698,6 @@ func (m *PoolAffinityPodAffinity) contextValidateRequiredDuringSchedulingIgnored
 	for i := 0; i < len(m.RequiredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.RequiredDuringSchedulingIgnoredDuringExecution[i] != nil {
-
-			if swag.IsZero(m.RequiredDuringSchedulingIgnoredDuringExecution[i]) { // not required
-				return nil
-			}
-
 			if err := m.RequiredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -850,7 +809,6 @@ func (m *PoolAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionI
 func (m *PoolAffinityPodAffinityPreferredDuringSchedulingIgnoredDuringExecutionItems0) contextValidatePodAffinityTerm(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAffinityTerm != nil {
-
 		if err := m.PodAffinityTerm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAffinityTerm")
@@ -987,11 +945,6 @@ func (m *PoolAffinityPodAntiAffinity) contextValidatePreferredDuringSchedulingIg
 	for i := 0; i < len(m.PreferredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.PreferredDuringSchedulingIgnoredDuringExecution[i] != nil {
-
-			if swag.IsZero(m.PreferredDuringSchedulingIgnoredDuringExecution[i]) { // not required
-				return nil
-			}
-
 			if err := m.PreferredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAntiAffinity" + "." + "preferredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -1012,11 +965,6 @@ func (m *PoolAffinityPodAntiAffinity) contextValidateRequiredDuringSchedulingIgn
 	for i := 0; i < len(m.RequiredDuringSchedulingIgnoredDuringExecution); i++ {
 
 		if m.RequiredDuringSchedulingIgnoredDuringExecution[i] != nil {
-
-			if swag.IsZero(m.RequiredDuringSchedulingIgnoredDuringExecution[i]) { // not required
-				return nil
-			}
-
 			if err := m.RequiredDuringSchedulingIgnoredDuringExecution[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("podAntiAffinity" + "." + "requiredDuringSchedulingIgnoredDuringExecution" + "." + strconv.Itoa(i))
@@ -1128,7 +1076,6 @@ func (m *PoolAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecut
 func (m *PoolAffinityPodAntiAffinityPreferredDuringSchedulingIgnoredDuringExecutionItems0) contextValidatePodAffinityTerm(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.PodAffinityTerm != nil {
-
 		if err := m.PodAffinityTerm.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("podAffinityTerm")

--- a/models/pool_tolerations.go
+++ b/models/pool_tolerations.go
@@ -71,11 +71,6 @@ func (m PoolTolerations) ContextValidate(ctx context.Context, formats strfmt.Reg
 	for i := 0; i < len(m); i++ {
 
 		if m[i] != nil {
-
-			if swag.IsZero(m[i]) { // not required
-				return nil
-			}
-
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -165,11 +160,6 @@ func (m *PoolTolerationsItems0) ContextValidate(ctx context.Context, formats str
 func (m *PoolTolerationsItems0) contextValidateTolerationSeconds(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.TolerationSeconds != nil {
-
-		if swag.IsZero(m.TolerationSeconds) { // not required
-			return nil
-		}
-
 		if err := m.TolerationSeconds.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tolerationSeconds")

--- a/models/pool_update_request.go
+++ b/models/pool_update_request.go
@@ -102,11 +102,6 @@ func (m *PoolUpdateRequest) contextValidatePools(ctx context.Context, formats st
 	for i := 0; i < len(m.Pools); i++ {
 
 		if m.Pools[i] != nil {
-
-			if swag.IsZero(m.Pools[i]) { // not required
-				return nil
-			}
-
 			if err := m.Pools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pools" + "." + strconv.Itoa(i))

--- a/models/projected_volume.go
+++ b/models/projected_volume.go
@@ -99,11 +99,6 @@ func (m *ProjectedVolume) contextValidateSources(ctx context.Context, formats st
 	for i := 0; i < len(m.Sources); i++ {
 
 		if m.Sources[i] != nil {
-
-			if swag.IsZero(m.Sources[i]) { // not required
-				return nil
-			}
-
 			if err := m.Sources[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("sources" + "." + strconv.Itoa(i))

--- a/models/projected_volume_source.go
+++ b/models/projected_volume_source.go
@@ -152,11 +152,6 @@ func (m *ProjectedVolumeSource) ContextValidate(ctx context.Context, formats str
 func (m *ProjectedVolumeSource) contextValidateConfigMap(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ConfigMap != nil {
-
-		if swag.IsZero(m.ConfigMap) { // not required
-			return nil
-		}
-
 		if err := m.ConfigMap.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("configMap")
@@ -173,11 +168,6 @@ func (m *ProjectedVolumeSource) contextValidateConfigMap(ctx context.Context, fo
 func (m *ProjectedVolumeSource) contextValidateSecret(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Secret != nil {
-
-		if swag.IsZero(m.Secret) { // not required
-			return nil
-		}
-
 		if err := m.Secret.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("secret")
@@ -194,11 +184,6 @@ func (m *ProjectedVolumeSource) contextValidateSecret(ctx context.Context, forma
 func (m *ProjectedVolumeSource) contextValidateServiceAccountToken(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ServiceAccountToken != nil {
-
-		if swag.IsZero(m.ServiceAccountToken) { // not required
-			return nil
-		}
-
 		if err := m.ServiceAccountToken.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("serviceAccountToken")

--- a/models/resource_quota.go
+++ b/models/resource_quota.go
@@ -102,11 +102,6 @@ func (m *ResourceQuota) contextValidateElements(ctx context.Context, formats str
 	for i := 0; i < len(m.Elements); i++ {
 
 		if m.Elements[i] != nil {
-
-			if swag.IsZero(m.Elements[i]) { // not required
-				return nil
-			}
-
 			if err := m.Elements[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("elements" + "." + strconv.Itoa(i))

--- a/models/server_properties.go
+++ b/models/server_properties.go
@@ -120,11 +120,6 @@ func (m *ServerProperties) contextValidateDrives(ctx context.Context, formats st
 	for i := 0; i < len(m.Drives); i++ {
 
 		if m.Drives[i] != nil {
-
-			if swag.IsZero(m.Drives[i]) { // not required
-				return nil
-			}
-
 			if err := m.Drives[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("drives" + "." + strconv.Itoa(i))

--- a/models/tenant.go
+++ b/models/tenant.go
@@ -290,11 +290,6 @@ func (m *Tenant) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 func (m *Tenant) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
-
-		if swag.IsZero(m.Domains) { // not required
-			return nil
-		}
-
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")
@@ -311,11 +306,6 @@ func (m *Tenant) contextValidateDomains(ctx context.Context, formats strfmt.Regi
 func (m *Tenant) contextValidateEndpoints(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Endpoints != nil {
-
-		if swag.IsZero(m.Endpoints) { // not required
-			return nil
-		}
-
 		if err := m.Endpoints.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("endpoints")
@@ -334,11 +324,6 @@ func (m *Tenant) contextValidatePools(ctx context.Context, formats strfmt.Regist
 	for i := 0; i < len(m.Pools); i++ {
 
 		if m.Pools[i] != nil {
-
-			if swag.IsZero(m.Pools[i]) { // not required
-				return nil
-			}
-
 			if err := m.Pools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("pools" + "." + strconv.Itoa(i))
@@ -357,11 +342,6 @@ func (m *Tenant) contextValidatePools(ctx context.Context, formats strfmt.Regist
 func (m *Tenant) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
@@ -378,11 +358,6 @@ func (m *Tenant) contextValidateStatus(ctx context.Context, formats strfmt.Regis
 func (m *Tenant) contextValidateSubnetLicense(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SubnetLicense != nil {
-
-		if swag.IsZero(m.SubnetLicense) { // not required
-			return nil
-		}
-
 		if err := m.SubnetLicense.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("subnet_license")
@@ -401,11 +376,6 @@ func (m *Tenant) contextValidateTiers(ctx context.Context, formats strfmt.Regist
 	for i := 0; i < len(m.Tiers); i++ {
 
 		if m.Tiers[i] != nil {
-
-			if swag.IsZero(m.Tiers[i]) { // not required
-				return nil
-			}
-
 			if err := m.Tiers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tiers" + "." + strconv.Itoa(i))

--- a/models/tenant_configuration_response.go
+++ b/models/tenant_configuration_response.go
@@ -102,11 +102,6 @@ func (m *TenantConfigurationResponse) contextValidateEnvironmentVariables(ctx co
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
-
-			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
-				return nil
-			}
-
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))

--- a/models/tenant_list.go
+++ b/models/tenant_list.go
@@ -169,11 +169,6 @@ func (m *TenantList) ContextValidate(ctx context.Context, formats strfmt.Registr
 func (m *TenantList) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
-
-		if swag.IsZero(m.Domains) { // not required
-			return nil
-		}
-
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")
@@ -192,11 +187,6 @@ func (m *TenantList) contextValidateTiers(ctx context.Context, formats strfmt.Re
 	for i := 0; i < len(m.Tiers); i++ {
 
 		if m.Tiers[i] != nil {
-
-			if swag.IsZero(m.Tiers[i]) { // not required
-				return nil
-			}
-
 			if err := m.Tiers[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("tiers" + "." + strconv.Itoa(i))

--- a/models/tenant_security_response.go
+++ b/models/tenant_security_response.go
@@ -123,11 +123,6 @@ func (m *TenantSecurityResponse) ContextValidate(ctx context.Context, formats st
 func (m *TenantSecurityResponse) contextValidateCustomCertificates(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CustomCertificates != nil {
-
-		if swag.IsZero(m.CustomCertificates) { // not required
-			return nil
-		}
-
 		if err := m.CustomCertificates.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customCertificates")
@@ -144,11 +139,6 @@ func (m *TenantSecurityResponse) contextValidateCustomCertificates(ctx context.C
 func (m *TenantSecurityResponse) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -322,11 +312,6 @@ func (m *TenantSecurityResponseCustomCertificates) contextValidateClient(ctx con
 	for i := 0; i < len(m.Client); i++ {
 
 		if m.Client[i] != nil {
-
-			if swag.IsZero(m.Client[i]) { // not required
-				return nil
-			}
-
 			if err := m.Client[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "client" + "." + strconv.Itoa(i))
@@ -347,11 +332,6 @@ func (m *TenantSecurityResponseCustomCertificates) contextValidateMinio(ctx cont
 	for i := 0; i < len(m.Minio); i++ {
 
 		if m.Minio[i] != nil {
-
-			if swag.IsZero(m.Minio[i]) { // not required
-				return nil
-			}
-
 			if err := m.Minio[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minio" + "." + strconv.Itoa(i))
@@ -372,11 +352,6 @@ func (m *TenantSecurityResponseCustomCertificates) contextValidateMinioCAs(ctx c
 	for i := 0; i < len(m.MinioCAs); i++ {
 
 		if m.MinioCAs[i] != nil {
-
-			if swag.IsZero(m.MinioCAs[i]) { // not required
-				return nil
-			}
-
 			if err := m.MinioCAs[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minioCAs" + "." + strconv.Itoa(i))

--- a/models/tenant_status.go
+++ b/models/tenant_status.go
@@ -104,11 +104,6 @@ func (m *TenantStatus) ContextValidate(ctx context.Context, formats strfmt.Regis
 func (m *TenantStatus) contextValidateUsage(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Usage != nil {
-
-		if swag.IsZero(m.Usage) { // not required
-			return nil
-		}
-
 		if err := m.Usage.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("usage")

--- a/models/tls_configuration.go
+++ b/models/tls_configuration.go
@@ -139,11 +139,6 @@ func (m *TLSConfiguration) contextValidateMinioClientCertificates(ctx context.Co
 	for i := 0; i < len(m.MinioClientCertificates); i++ {
 
 		if m.MinioClientCertificates[i] != nil {
-
-			if swag.IsZero(m.MinioClientCertificates[i]) { // not required
-				return nil
-			}
-
 			if err := m.MinioClientCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("minioClientCertificates" + "." + strconv.Itoa(i))
@@ -164,11 +159,6 @@ func (m *TLSConfiguration) contextValidateMinioServerCertificates(ctx context.Co
 	for i := 0; i < len(m.MinioServerCertificates); i++ {
 
 		if m.MinioServerCertificates[i] != nil {
-
-			if swag.IsZero(m.MinioServerCertificates[i]) { // not required
-				return nil
-			}
-
 			if err := m.MinioServerCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("minioServerCertificates" + "." + strconv.Itoa(i))

--- a/models/update_domains_request.go
+++ b/models/update_domains_request.go
@@ -89,11 +89,6 @@ func (m *UpdateDomainsRequest) ContextValidate(ctx context.Context, formats strf
 func (m *UpdateDomainsRequest) contextValidateDomains(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Domains != nil {
-
-		if swag.IsZero(m.Domains) { // not required
-			return nil
-		}
-
 		if err := m.Domains.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("domains")

--- a/models/update_tenant_configuration_request.go
+++ b/models/update_tenant_configuration_request.go
@@ -105,11 +105,6 @@ func (m *UpdateTenantConfigurationRequest) contextValidateEnvironmentVariables(c
 	for i := 0; i < len(m.EnvironmentVariables); i++ {
 
 		if m.EnvironmentVariables[i] != nil {
-
-			if swag.IsZero(m.EnvironmentVariables[i]) { // not required
-				return nil
-			}
-
 			if err := m.EnvironmentVariables[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("environmentVariables" + "." + strconv.Itoa(i))

--- a/models/update_tenant_request.go
+++ b/models/update_tenant_request.go
@@ -116,11 +116,6 @@ func (m *UpdateTenantRequest) ContextValidate(ctx context.Context, formats strfm
 func (m *UpdateTenantRequest) contextValidateImageRegistry(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.ImageRegistry != nil {
-
-		if swag.IsZero(m.ImageRegistry) { // not required
-			return nil
-		}
-
 		if err := m.ImageRegistry.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("image_registry")

--- a/models/update_tenant_security_request.go
+++ b/models/update_tenant_security_request.go
@@ -123,11 +123,6 @@ func (m *UpdateTenantSecurityRequest) ContextValidate(ctx context.Context, forma
 func (m *UpdateTenantSecurityRequest) contextValidateCustomCertificates(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.CustomCertificates != nil {
-
-		if swag.IsZero(m.CustomCertificates) { // not required
-			return nil
-		}
-
 		if err := m.CustomCertificates.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("customCertificates")
@@ -144,11 +139,6 @@ func (m *UpdateTenantSecurityRequest) contextValidateCustomCertificates(ctx cont
 func (m *UpdateTenantSecurityRequest) contextValidateSecurityContext(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.SecurityContext != nil {
-
-		if swag.IsZero(m.SecurityContext) { // not required
-			return nil
-		}
-
 		if err := m.SecurityContext.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("securityContext")
@@ -291,11 +281,6 @@ func (m *UpdateTenantSecurityRequestCustomCertificates) contextValidateMinioClie
 	for i := 0; i < len(m.MinioClientCertificates); i++ {
 
 		if m.MinioClientCertificates[i] != nil {
-
-			if swag.IsZero(m.MinioClientCertificates[i]) { // not required
-				return nil
-			}
-
 			if err := m.MinioClientCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minioClientCertificates" + "." + strconv.Itoa(i))
@@ -316,11 +301,6 @@ func (m *UpdateTenantSecurityRequestCustomCertificates) contextValidateMinioServ
 	for i := 0; i < len(m.MinioServerCertificates); i++ {
 
 		if m.MinioServerCertificates[i] != nil {
-
-			if swag.IsZero(m.MinioServerCertificates[i]) { // not required
-				return nil
-			}
-
 			if err := m.MinioServerCertificates[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("customCertificates" + "." + "minioServerCertificates" + "." + strconv.Itoa(i))

--- a/models/vault_configuration.go
+++ b/models/vault_configuration.go
@@ -148,7 +148,6 @@ func (m *VaultConfiguration) ContextValidate(ctx context.Context, formats strfmt
 func (m *VaultConfiguration) contextValidateApprole(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Approle != nil {
-
 		if err := m.Approle.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("approle")
@@ -165,11 +164,6 @@ func (m *VaultConfiguration) contextValidateApprole(ctx context.Context, formats
 func (m *VaultConfiguration) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/models/vault_configuration_response.go
+++ b/models/vault_configuration_response.go
@@ -148,7 +148,6 @@ func (m *VaultConfigurationResponse) ContextValidate(ctx context.Context, format
 func (m *VaultConfigurationResponse) contextValidateApprole(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Approle != nil {
-
 		if err := m.Approle.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("approle")
@@ -165,11 +164,6 @@ func (m *VaultConfigurationResponse) contextValidateApprole(ctx context.Context,
 func (m *VaultConfigurationResponse) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Status != nil {
-
-		if swag.IsZero(m.Status) { // not required
-			return nil
-		}
-
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")

--- a/models/volume.go
+++ b/models/volume.go
@@ -122,11 +122,6 @@ func (m *Volume) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 func (m *Volume) contextValidateProjected(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Projected != nil {
-
-		if swag.IsZero(m.Projected) { // not required
-			return nil
-		}
-
 		if err := m.Projected.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("projected")
@@ -143,11 +138,6 @@ func (m *Volume) contextValidateProjected(ctx context.Context, formats strfmt.Re
 func (m *Volume) contextValidatePvc(ctx context.Context, formats strfmt.Registry) error {
 
 	if m.Pvc != nil {
-
-		if swag.IsZero(m.Pvc) { // not required
-			return nil
-		}
-
 		if err := m.Pvc.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("pvc")

--- a/swagger.yml
+++ b/swagger.yml
@@ -1958,8 +1958,6 @@ definitions:
             type: string
           secret_id:
             type: string
-          callback_url:
-            type: string
           claim_name:
             type: string
           scopes:

--- a/web-app/src/api/operatorApi.ts
+++ b/web-app/src/api/operatorApi.ts
@@ -278,7 +278,6 @@ export interface IdpConfiguration {
     configuration_url: string;
     client_id: string;
     secret_id: string;
-    callback_url?: string;
     claim_name: string;
     scopes?: string;
   };

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/IdentityProvider/IDPOpenID.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/IdentityProvider/IDPOpenID.tsx
@@ -82,10 +82,6 @@ const IDPOpenID = () => {
     (state: AppState) =>
       state.createTenant.fields.identityProvider.openIDSecretID,
   );
-  const openIDCallbackURL = useSelector(
-    (state: AppState) =>
-      state.createTenant.fields.identityProvider.openIDCallbackURL,
-  );
   const openIDClaimName = useSelector(
     (state: AppState) =>
       state.createTenant.fields.identityProvider.openIDClaimName,
@@ -206,20 +202,6 @@ const IDPOpenID = () => {
           value={openIDSecretID}
           error={validationErrors["openID_secretID"] || ""}
           required
-        />
-      </Grid>
-      <Grid item xs={12} className={classes.formFieldRow}>
-        <InputBoxWrapper
-          id="openID_callbackURL"
-          name="openID_callbackURL"
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            updateField("openIDCallbackURL", e.target.value);
-            cleanValidation("openID_callbackURL");
-          }}
-          label="Callback URL"
-          value={openIDCallbackURL}
-          placeholder="https://your-console-endpoint:9443/oauth_callback"
-          error={validationErrors["openID_callbackURL"] || ""}
         />
       </Grid>
       <Grid item xs={12} className={classes.formFieldRow}>

--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantIdentityProvider.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantIdentityProvider.tsx
@@ -117,7 +117,6 @@ const TenantIdentityProvider = ({ classes }: ITenantIdentityProvider) => {
   const [openIDClientID, setOpenIDClientID] = useState<string>("");
   const [openIDSecretID, setOpenIDSecretID] = useState<string>("");
   const [showOIDCSecretID, setShowOIDCSecretID] = useState<boolean>(false);
-  const [openIDCallbackURL, setOpenIDCallbackURL] = useState<string>("");
   const [openIDClaimName, setOpenIDClaimName] = useState<string>("");
   const [openIDScopes, setOpenIDScopes] = useState<string>("");
   const [ADURL, setADURL] = useState<string>("");
@@ -214,7 +213,6 @@ const TenantIdentityProvider = ({ classes }: ITenantIdentityProvider) => {
             setOpenIDConfigurationURL(res.oidc.configuration_url);
             setOpenIDClientID(res.oidc.client_id);
             setOpenIDSecretID(res.oidc.secret_id);
-            setOpenIDCallbackURL(res.oidc.callback_url);
             setOpenIDClaimName(res.oidc.claim_name);
             setOpenIDScopes(res.oidc.scopes);
           } else if (res.active_directory) {
@@ -268,7 +266,6 @@ const TenantIdentityProvider = ({ classes }: ITenantIdentityProvider) => {
           configuration_url: openIDConfigurationURL,
           client_id: openIDClientID,
           secret_id: openIDSecretID,
-          callback_url: openIDCallbackURL,
           claim_name: openIDClaimName,
           scopes: openIDScopes,
         };
@@ -429,20 +426,6 @@ const TenantIdentityProvider = ({ classes }: ITenantIdentityProvider) => {
                     )
                   }
                   overlayAction={() => setShowOIDCSecretID(!showOIDCSecretID)}
-                />
-              </Grid>
-              <Grid item xs={12} className={classes.formFieldRow}>
-                <InputBoxWrapper
-                  id="openID_callbackURL"
-                  name="openID_callbackURL"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setOpenIDCallbackURL(e.target.value);
-                    cleanValidation("openID_callbackURL");
-                  }}
-                  label="Callback URL"
-                  value={openIDCallbackURL}
-                  placeholder="https://your-console-endpoint:9443/oauth_callback"
-                  error={validationErrors["openID_callbackURL"] || ""}
                 />
               </Grid>
               <Grid item xs={12} className={classes.formFieldRow}>

--- a/web-app/src/screens/Console/Tenants/types.ts
+++ b/web-app/src/screens/Console/Tenants/types.ts
@@ -168,7 +168,6 @@ export interface IIdentityProviderFields {
   openIDConfigurationURL: string;
   openIDClientID: string;
   openIDSecretID: string;
-  openIDCallbackURL: string;
   openIDClaimName: string;
   openIDScopes: string;
   ADURL: string;
@@ -302,7 +301,6 @@ export interface IPoolConfiguration {
 
 export interface ITenantIdentityProviderResponse {
   oidc?: {
-    callback_url: string;
     claim_name: string;
     client_id: string;
     configuration_url: string;


### PR DESCRIPTION
### Objective:

To remove deprecated var from our example: `MINIO_IDENTITY_OPENID_REDIRECT_URI `

### Related:

* https://github.com/minio/console/issues/2918

### Documentation:

* https://min.io/docs/minio/linux/reference/minio-server/minio-server.html#envvar.MINIO_IDENTITY_OPENID_REDIRECT_URI