### PR TITLE
Remove duplicate ref=op on License page buttons

### DIFF
--- a/web-app/src/screens/Console/License/LicensePlans.tsx
+++ b/web-app/src/screens/Console/License/LicensePlans.tsx
@@ -329,8 +329,6 @@ const LicensePlans = ({ licenseInfo, operatorMode }: IRegisterStatus) => {
     }
   }, [isSmallScreen, currentPlan]);
 
-  const linkTracker = `?ref=${operatorMode ? "op" : "con"}`;
-
   const featureList = FEATURE_ITEMS;
   return (
     <Fragment>
@@ -613,7 +611,7 @@ const LicensePlans = ({ licenseInfo, operatorMode }: IRegisterStatus) => {
               })}
               <Box className="button-box">
                 {getButton(
-                  `https://slack.min.io${linkTracker}`,
+                  `https://slack.min.io`,
                   "Join Slack",
                   "regular",
                   LICENSE_PLANS.COMMUNITY,
@@ -657,7 +655,7 @@ const LicensePlans = ({ licenseInfo, operatorMode }: IRegisterStatus) => {
 
             <Box className="button-box">
               {getButton(
-                `https://min.io/signup${linkTracker}`,
+                `https://min.io/signup`,
                 !PAID_PLANS.includes(currentPlan)
                   ? "Subscribe"
                   : "Login to SUBNET",
@@ -712,7 +710,7 @@ const LicensePlans = ({ licenseInfo, operatorMode }: IRegisterStatus) => {
             })}
             <Box className="button-box">
               {getButton(
-                `https://min.io/signup${linkTracker}`,
+                `https://min.io/signup`,
                 !PAID_PLANS.includes(currentPlan)
                   ? "Subscribe"
                   : "Login to SUBNET",


### PR DESCRIPTION
The getButton function already handles appending the query parameters,
therefore the linkTracker variable isn't needed