### PR TITLE
Remove deprecated field

### DIFF
--- a/web-app/src/screens/Console/Tenants/TenantDetails/TenantIdentityProvider.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/TenantIdentityProvider.tsx
@@ -433,20 +433,6 @@ const TenantIdentityProvider = ({ classes }: ITenantIdentityProvider) => {
               </Grid>
               <Grid item xs={12} className={classes.formFieldRow}>
                 <InputBoxWrapper
-                  id="openID_callbackURL"
-                  name="openID_callbackURL"
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setOpenIDCallbackURL(e.target.value);
-                    cleanValidation("openID_callbackURL");
-                  }}
-                  label="Callback URL"
-                  value={openIDCallbackURL}
-                  placeholder="https://your-console-endpoint:9443/oauth_callback"
-                  error={validationErrors["openID_callbackURL"] || ""}
-                />
-              </Grid>
-              <Grid item xs={12} className={classes.formFieldRow}>
-                <InputBoxWrapper
                   id="openID_claimName"
                   name="openID_claimName"
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
### Reason:

`Callback URL` field is no longer needed

<img width="1840" alt="image" src="https://github.com/minio/operator/assets/6667358/b4d88ca0-bc79-48c0-925e-44acc89441c5">

### Documentation:

https://min.io/docs/minio/linux/reference/minio-server/minio-server.html#envvar.MINIO_IDENTITY_OPENID_REDIRECT_URI

### Related:

* https://github.com/minio/operator/pull/1722