### PR TITLE
Remove deprecated field on tenant creation

### DIFF
--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/IdentityProvider/IDPOpenID.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/IdentityProvider/IDPOpenID.tsx
@@ -82,10 +82,6 @@ const IDPOpenID = () => {
     (state: AppState) =>
       state.createTenant.fields.identityProvider.openIDSecretID,
   );
-  const openIDCallbackURL = useSelector(
-    (state: AppState) =>
-      state.createTenant.fields.identityProvider.openIDCallbackURL,
-  );
   const openIDClaimName = useSelector(
     (state: AppState) =>
       state.createTenant.fields.identityProvider.openIDClaimName,
@@ -206,20 +202,6 @@ const IDPOpenID = () => {
           value={openIDSecretID}
           error={validationErrors["openID_secretID"] || ""}
           required
-        />
-      </Grid>
-      <Grid item xs={12} className={classes.formFieldRow}>
-        <InputBoxWrapper
-          id="openID_callbackURL"
-          name="openID_callbackURL"
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            updateField("openIDCallbackURL", e.target.value);
-            cleanValidation("openID_callbackURL");
-          }}
-          label="Callback URL"
-          value={openIDCallbackURL}
-          placeholder="https://your-console-endpoint:9443/oauth_callback"
-          error={validationErrors["openID_callbackURL"] || ""}
         />
       </Grid>
       <Grid item xs={12} className={classes.formFieldRow}>


### PR DESCRIPTION
### Objective:

To remove `Callback URL` field because it is deprecated.

<img width="1840" alt="image" src="https://github.com/minio/operator/assets/6667358/2fdbd7dd-b6b4-43cf-a357-c16b47c87391">

### Documentation:

* https://min.io/docs/minio/linux/reference/minio-server/minio-server.html#envvar.MINIO_IDENTITY_OPENID_REDIRECT_URI

### Related:

* https://github.com/minio/operator/pull/1726 [this was when tenant was already created]