### PR TITLE
Passing down the resources to init and sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ examples/.DS_Store
 testing/openshift/bundle/*
 examples/**/obj/
 .idea
+operator.iml

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -895,6 +895,7 @@ func getInitContainer(t *miniov2.Tenant, operatorImage string, pool *miniov2.Poo
 			CfgVolumeMount,
 		},
 		SecurityContext: poolContainerSecurityContext(pool),
+		Resources:       pool.Resources,
 	}
 	if t.HasConfigurationSecret() {
 		initContainer.VolumeMounts = append(initContainer.VolumeMounts, TmpCfgVolumeMount)
@@ -923,6 +924,7 @@ func getSideCarContainer(t *miniov2.Tenant, operatorImage string, pool *miniov2.
 			CfgVolumeMount,
 		},
 		SecurityContext: poolContainerSecurityContext(pool),
+		Resources:       pool.Resources,
 	}
 	if t.HasConfigurationSecret() {
 		sidecarContainer.VolumeMounts = append(sidecarContainer.VolumeMounts, TmpCfgVolumeMount)


### PR DESCRIPTION
### Objective:

To fix: https://github.com/minio/operator/issues/1543

### Additional Information or context:

Currently the `resources` are being passed down to minio container only but since we added sidecar and init container, we are missing these two.


