### PR TITLE
bugfix: empty securityContext breaks console process with nil

### DIFF
--- a/api/tenants_helper.go
+++ b/api/tenants_helper.go
@@ -64,11 +64,20 @@ func convertModelSCToK8sSC(sc *models.SecurityContext) (*corev1.PodSecurityConte
 
 // convertK8sSCToModelSC validates and converts from corev1.PodSecurityContext to models.SecurityContext
 func convertK8sSCToModelSC(sc *corev1.PodSecurityContext) *models.SecurityContext {
-	runAsUser := strconv.FormatInt(*sc.RunAsUser, 10)
-	runAsGroup := strconv.FormatInt(*sc.RunAsGroup, 10)
-	fsGroup := strconv.FormatInt(*sc.FSGroup, 10)
+	var runAsUser string
+	var runAsGroup string
+	var fsGroup string
 	fsGroupChangePolicy := "Always"
 
+	if sc.RunAsUser != nil && *sc.RunAsUser != 0 {
+		runAsUser = strconv.FormatInt(*sc.RunAsUser, 10)
+	}
+	if sc.RunAsGroup != nil && *sc.RunAsGroup != 0 {
+		runAsGroup = strconv.FormatInt(*sc.RunAsGroup, 10)
+	}
+	if sc.FSGroup != nil && *sc.FSGroup != 0 {
+		fsGroup = strconv.FormatInt(*sc.FSGroup, 10)
+	}
 	if sc.FSGroupChangePolicy != nil {
 		fsGroupChangePolicy = string(*sc.FSGroupChangePolicy)
 	}


### PR DESCRIPTION
##  What this fix?

If you set an empty `spec.securityContext: {}` in the tenant resource, the Operator console breaks with the error below and the process crashes when you click the `Security` tab.

The fix is simply about check for not nil values.

```
2023/08/21 23:22:58 server.go:3230: http: panic serving 10.217.0.1:44752: runtime error: invalid memory address or nil pointer dereference
goroutine 74 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1850 +0xbf
panic({0x22af760, 0x54ea0a0})
	runtime/panic.go:890 +0x262
github.com/minio/operator/api.convertK8sSCToModelSC(0xc0008eb1f0)
	github.com/minio/operator/api/tenants_helper.go:67 +0x39
github.com/minio/operator/api.getTenantSecurity({0x4222e70, 0xc00131f440}, {0x4233270, 0xc00012e0c0}, 0xc000251800)
	github.com/minio/operator/api/tenant-handlers.go:386 +0x18d
github.com/minio/operator/api.getTenantSecurityResponse(0xc0009589c0, {0xc000c0b700, {0xc0000550a7, 0xe}, {0xc0000550be, 0xe}})
	github.com/minio/operator/api/certificate-handlers.go:87 +0x3f9
github.com/minio/operator/api.registerCertificateHandlers.func1({0xc000c0b700, {0xc0000550a7, 0xe}, {0xc0000550be, 0xe}}, 0x0?)
	github.com/minio/operator/api/certificate-handlers.go:39 +0x4d
github.com/minio/operator/api/operations/operator_api.TenantSecurityHandlerFunc.Handle(0xc00016f380?, {0xc000c0b700, {0xc0000550a7, 0xe}, {0xc0000550be, 0xe}}, 0xf8?)
	github.com/minio/operator/api/operations/operator_api/tenant_security.go:38 +0x4d
github.com/minio/operator/api/operations/operator_api.(*TenantSecurity).ServeHTTP(0xc00013c9f0, {0x42131b8, 0xc0012b41b0}, 0xc000c0b700)
	github.com/minio/operator/api/operations/operator_api/tenant_security.go:85 +0x2c3
github.com/go-openapi/runtime/middleware.NewOperationExecutor.func1({0x42131b8, 0xc0012b41b0}, 0xc000c0b700)
	github.com/go-openapi/runtime@v0.25.0/middleware/operation.go:28 +0x59
net/http.HandlerFunc.ServeHTTP(0xc001351120?, {0x42131b8?, 0xc0012b41b0?}, 0x16?)
	net/http/server.go:2109 +0x2f
github.com/go-openapi/runtime/middleware.NewRouter.func1({0x42131b8, 0xc0012b41b0}, 0xc000c0b500)
	github.com/go-openapi/runtime@v0.25.0/middleware/router.go:78 +0x257
net/http.HandlerFunc.ServeHTTP(0xc0013512e8?, {0x42131b8?, 0xc0012b41b0?}, 0x21929c0?)
	net/http/server.go:2109 +0x2f
github.com/go-openapi/runtime/middleware.Redoc.func1({0x42131b8, 0xc0012b41b0}, 0x412de2?)
	github.com/go-openapi/runtime@v0.25.0/middleware/redoc.go:72 +0x242
net/http.HandlerFunc.ServeHTTP(0x0?, {0x42131b8?, 0xc0012b41b0?}, 0x0?)
	net/http/server.go:2109 +0x2f
github.com/go-openapi/runtime/middleware.Spec.func1({0x42131b8, 0xc0012b41b0}, 0xc000be4780?)
	github.com/go-openapi/runtime@v0.25.0/middleware/spec.go:46 +0x18c
net/http.HandlerFunc.ServeHTTP(0x54f12c0?, {0x42131b8?, 0xc0012b41b0?}, 0x4?)
	net/http/server.go:2109 +0x2f
github.com/klauspost/compress/gzhttp.NewWrapper.func1.1({0x4213518, 0xc000be4780}, 0x0?)
	github.com/klauspost/compress@v1.15.15/gzhttp/compress.go:409 +0x362
net/http.HandlerFunc.ServeHTTP(0x4221498?, {0x4213518?, 0xc000be4780?}, 0x19?)
	net/http/server.go:2109 +0x2f
github.com/minio/operator/api.AuditLogMiddleware.func1({0x4221498?, 0xc0006fe540?}, 0xc000c0b500)
	github.com/minio/operator/api/configure_operator.go:215 +0x82
net/http.HandlerFunc.ServeHTTP(0x7fe222305878?, {0x4221498?, 0xc0006fe540?}, 0xc001562f50?)
	net/http/server.go:2109 +0x2f
github.com/minio/operator/api.proxyMiddleware.func1({0x4221498?, 0xc0006fe540?}, 0xc000c0b500?)
	github.com/minio/operator/api/configure_operator.go:146 +0xcc
net/http.HandlerFunc.ServeHTTP(0x2456860?, {0x4221498?, 0xc0006fe540?}, 0x2634eff?)
	net/http/server.go:2109 +0x2f
github.com/minio/operator/api.FileServerMiddleware.func1({0x4221498, 0xc0006fe540}, 0xc000c0b500)
	github.com/minio/operator/api/configure_operator.go:390 +0x19e
net/http.HandlerFunc.ServeHTTP(0x4222f18?, {0x4221498?, 0xc0006fe540?}, 0x41f8e70?)
	net/http/server.go:2109 +0x2f
github.com/minio/operator/api.ContextMiddleware.func1({0x4221498, 0xc0006fe540}, 0xc000c0b400)
	github.com/minio/operator/api/configure_operator.go:207 +0x332
net/http.HandlerFunc.ServeHTTP(0x4222e70?, {0x4221498?, 0xc0006fe540?}, 0x41f8ea0?)
	net/http/server.go:2109 +0x2f
github.com/minio/operator/api.AuthenticationMiddleware.func1({0x4221498, 0xc0006fe540}, 0xc000c0b300)
	github.com/minio/operator/api/configure_operator.go:246 +0x55f
net/http.HandlerFunc.ServeHTTP(0xc0007ecf00?, {0x4221498?, 0xc0006fe540?}, 0x7fe1fae600b8?)
	net/http/server.go:2109 +0x2f
github.com/unrolled/secure.(*Secure).Handler.func1({0x4221498, 0xc0006fe540}, 0x7fe1faaaa548?)
	github.com/unrolled/secure@v1.13.0/secure.go:203 +0x98
net/http.HandlerFunc.ServeHTTP(0x0?, {0x4221498?, 0xc0006fe540?}, 0x46856e?)
	net/http/server.go:2109 +0x2f
net/http.serverHandler.ServeHTTP({0xc0008f0360?}, {0x4221498, 0xc0006fe540}, 0xc000c0b300)
	net/http/server.go:2947 +0x30c
net/http.(*conn).serve(0xc000be4280, {0x4222f18, 0xc000462120})
	net/http/server.go:1991 +0x607
created by net/http.(*Server).Serve
	net/http/server.go:3102 +0x4db
```

