### PR TITLE
fix: Effect must be 'NoExecute' when tolerationSeconds is set

### DIFF
--- a/api/tenant-handlers.go
+++ b/api/tenant-handlers.go
@@ -976,6 +976,12 @@ func parseTenantPoolRequest(poolParams *models.Pool) (*miniov2.Pool, error) {
 		if elem.TolerationSeconds != nil {
 			// elem.TolerationSeconds.Seconds is allowed to be nil
 			tolerationSeconds = elem.TolerationSeconds.Seconds
+
+			if tolerationSeconds != nil {
+				if corev1.TaintEffect(elem.Effect) != corev1.TaintEffectNoExecute {
+					return nil, fmt.Errorf(`Invalid value: "%s": effect must be 'NoExecute' when tolerationSeconds is set`, elem.Effect)
+				}
+			}
 		}
 
 		toleration := corev1.Toleration{


### PR DESCRIPTION
fix: https://github.com/minio/operator/issues/1735
K8S Minio Operator, Tenant Create, Taints NoSchedule can't work, because it generates with seconds field.
For effect must be 'NoExecute' when tolerationSeconds is set