### PR TITLE
Kustomize: Skip recursive permission change

### DIFF
--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -200,12 +200,16 @@ spec:
               storage: 1Ti
           storageClassName: standard
         status: { }
-      ## Configure security context
+      ## Configure Pod's security context
+      ## We recommend to skip the recursive permission change by using
+      ## fsGroupChangePolicy as OnRootMismatch because it can be pretty
+      ## expensive for larger volumes with lots of small files.
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
         fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       ## Configure container security context
       containerSecurityContext:
         runAsUser: 1000


### PR DESCRIPTION
### Objective:

To skip recursive permission change.

### Reasoning:

When having large volumes with lots of small files, it can be very expensive the recursive permission change. And it can be skipped by setting `fsGroupChangePolicy` to `"OnRootMismatch"`

### Documentation:

* [Allow users to skip recursive permission changes on mount](https://kubernetes.io/blog/2020/12/14/kubernetes-release-1.20-fsgroupchangepolicy-fsgrouppolicy/#allow-users-to-skip-recursive-permission-changes-on-mount)