### PR TITLE
Automation to add the 'spec.replaces' annotation

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -70,6 +70,14 @@ for catalog in "${redhatCatalogs[@]}"; do
   yq -i ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image |= (\"${operatorImageDigest}\")" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
   yq -i ".spec.install.spec.deployments[1].spec.template.spec.containers[0].image |= (\"${operatorImageDigest}\")" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
 
+  # To provide channel for upgrade where we tell what versions can be replaced by the new version we offer
+  # You can read the documentation at link below:
+  # https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/understanding-the-operator-lifecycle-manager-olm#olm-upgrades_olm-understanding-olm
+  echo "To provide replacement for upgrading Operator..."
+  PREV_VERSION=$(curl -s "https://catalog.redhat.com/api/containers/v1/operators/bundles?channel_name=stable&package=${package}&organization=${catalog}&include=data.version,data.csv_name,data.ocp_version" | jq '.data | max_by(.version).csv_name' -r)
+  echo "replaces: $PREV_VERSION"
+  yq -i e ".spec.replaces |= \"${PREV_VERSION}\"" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
+
   # Now promote the latest release to the root of the repository
   rm -Rf manifests
   rm -Rf metadata


### PR DESCRIPTION
This allows to have an update graph in Openshift Marketplace Operator updates.

During release we will query the readhat catalog API to get the latest published Operator and set that version as the one to be replaced.

With this no more manual intervention to set the version we are replacing

Example output:

```sh
RELEASE=5.0.8 ./olm.sh
operator-sdk version: "v1.22.2", commit: "da3346113a8a75e11225f586482934000504a60f", kubernetes version: "1.24.1", go version: "go1.18.4", GOOS: "darwin", GOARCH: "arm64"
minioVersionInExample: quay.io/minio/minio:RELEASE.2023-07-21T21-12-44Z
minioVersionDigest: quay.io/minio/minio@sha256:8e5e9490cd50018457d53a447e9881eaef6a327b320991347c2ea01db5f3c784
 
certified-operators
package: minio-operator
Generating bundle manifests
WARN[0000] ClusterServiceVersion validation: [OperationFailed] provided API should have an example annotation 
pinning image versions to digests instead of tags
...
To provide replacement for upgrading Operator...
replaces: minio-operator.v5.0.7
clean released annotations
clean root level annotations.yaml
```

example `bundles/certified-operators/5.0.8/manifests/minio-operator.clusterserviceversion.yaml`
```yaml
piVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  annotations:
    name: minio-operator.v5.0.8
...
  version: 5.0.8
  replaces: minio-operator.v5.0.7
```


example `bundles/redhat-marketplace/5.0.8/manifests/minio-operator-rhmp.clusterserviceversion.yaml`
```yaml
piVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  annotations:
    name: minio-operator-rhmp.v5.0.8
...
  version: 5.0.8
  replaces: minio-operator.v5.0.7
```