### PR TITLE
Fix shellcheck go version

### DIFF
--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -10,10 +10,14 @@ jobs:
     timeout-minutes: 30
     name: Shellcheck
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 1.21.x ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
-
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         env:


### PR DESCRIPTION
Fix false positive warning github action shellcheck, used go version is now 1.21.x

![Screenshot 2023-08-30 at 4 48 52 PM](https://github.com/minio/operator/assets/1334362/2e06507c-30a4-43f4-9895-321020e5fbda)
