### PR TITLE
Warn to use XFS as File system type in AWS EBS

### DIFF
--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -49,6 +49,10 @@ tenant:
       ## size specifies the capacity per volume
       size: 10Gi
       ## storageClass specifies the storage class name to be used for this pool
+      ### If using Amazon Elastic Block Store (EBS) CSI driver
+      ### Please make sure to set xfs for "csi.storage.k8s.io/fstype" parameter
+      ### under StorageClass.parameters.
+      ### Docs: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md
       storageClassName: standard
       ## Used to specify annotations for pods
       annotations: { }


### PR DESCRIPTION
### Objective:

To warn users to use XFS as File system type for MinIO Tenant.

### Docs:

* [CreateVolume Parameters](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/parameters.md)

`"csi.storage.k8s.io/fstype"` should be `xfs` NOT `ext4`