### PR TITLE
fix: PROMETHEUS_NAME env variable seems to be not correctly integrated

### DIFF
--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -206,6 +206,9 @@ const DefaultMonitoringInterval = 3
 // PrometheusNamespace is the namespace of the prometheus
 const PrometheusNamespace = "PROMETHEUS_NAMESPACE"
 
+// PrometheusName is the name of the prometheus
+const PrometheusName = "PROMETHEUS_NAME"
+
 // DefaultPrometheusNamespace is the default namespace for prometheus
 const DefaultPrometheusNamespace = "default"
 

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -1090,7 +1090,7 @@ func GetPrometheusNamespace() string {
 // GetPrometheusName returns namespace of the prometheus managed by prometheus operator
 func GetPrometheusName() string {
 	prometheusNameOnce.Do(func() {
-		prometheusName = envGet(prometheusName, "")
+		prometheusName = envGet(PrometheusName, "")
 	})
 	return prometheusName
 }


### PR DESCRIPTION
fix: https://github.com/minio/operator/issues/1760
PROMETHEUS_NAME now it's not really from env.