### PR TITLE
fix:minio operator should not use a fixed name while deployment.

### DIFF
--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -2,15 +2,19 @@
 
 operator:
   ## Setup environment variables for the Operator
-  # env:
-  #   - name: MINIO_CONSOLE_TLS_ENABLE
-  #     value: "off"
-  #   - name: CLUSTER_DOMAIN
-  #     value: "cluster.domain"
-  #   - name: WATCHED_NAMESPACE
-  #     value: ""
-  #   - name: MINIO_OPERATOR_RUNTIME
-  #     value: "OpenShift"
+#  env:
+#    - name: MINIO_OPERATOR_DEPLOYMENT_NAME
+#      valueFrom:
+#        fieldRef:
+#          fieldPath: metadata.labels['app.kubernetes.io/name']
+#    - name: MINIO_CONSOLE_TLS_ENABLE
+#      value: "off"
+#    - name: CLUSTER_DOMAIN
+#      value: "cluster.domain"
+#    - name: WATCHED_NAMESPACE
+#      value: ""
+#    - name: MINIO_OPERATOR_RUNTIME
+#      value: "OpenShift"
   #
   ### Image field:
   ## Image from tag (original behaviour), for example:

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -15,6 +15,7 @@ operator:
 #      value: ""
 #    - name: MINIO_OPERATOR_RUNTIME
 #      value: "OpenShift"
+  env: [ ]
   #
   ### Image field:
   ## Image from tag (original behaviour), for example:
@@ -34,7 +35,6 @@ operator:
   imagePullSecrets: [ ]
   runtimeClassName: ~
   initContainers: [ ]
-  env: [ ]
   replicaCount: 2
   securityContext:
     runAsUser: 1000

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -231,7 +231,7 @@ func NewController(podName string, namespacesToWatch set.StringSet, kubeClientSe
 	ns := miniov2.GetNSFromFile()
 	ctx := context.Background()
 	oprImg := DefaultOperatorImage
-	oprDep, err := kubeClientSet.AppsV1().Deployments(ns).Get(ctx, DefaultDeploymentName, metav1.GetOptions{})
+	oprDep, err := kubeClientSet.AppsV1().Deployments(ns).Get(ctx, getOperatorDeploymentName(), metav1.GetOptions{})
 	if err == nil && oprDep != nil {
 		// assume we are the first container, just in case they changed the default name
 		if len(oprDep.Spec.Template.Spec.Containers) > 0 {
@@ -523,6 +523,8 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	go func() {
+		leaderRun(ctx, c, threadiness, stopCh)
+		return
 		// start the leader election code loop
 		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 			Lock: lock,

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -523,8 +523,6 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	go func() {
-		leaderRun(ctx, c, threadiness, stopCh)
-		return
 		// start the leader election code loop
 		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 			Lock: lock,


### PR DESCRIPTION
Now we will get deployment by a fixed name `minio-operator`. We should get it from env first.
```go
// getOperatorDeploymentName Internal func returns the Operator deployment name from MINIO_OPERATOR_DEPLOYMENT_NAME ENV variable or the default name
func getOperatorDeploymentName() string {
	return env.Get(OperatorDeploymentNameEnv, DefaultDeploymentName)
}
```