### PR TITLE
Avoid flooding Operator log

### DIFF
--- a/pkg/runtime/sync.go
+++ b/pkg/runtime/sync.go
@@ -145,7 +145,11 @@ func (s *ObjectSyncer) Sync(ctx context.Context) (SyncResult, error) {
 	default:
 		result.SetEventData(eventNormal, EventReason(s.Obj, err),
 			fmt.Sprintf("%s %s %s successfully", s.objectTypeName(s.Obj), key, result.Operation))
-		klog.Infof("%s key %s kind %s diff %s", string(result.Operation), key, s.objectTypeName(s.Obj), diff)
+		// Only print this log if there is a difference to show for the sync
+		// otherwise keep it like this to avoid flooding the Operator log with unchanged difference.
+		if diff != nil {
+			klog.Infof("%s key %s kind %s diff %s", string(result.Operation), key, s.objectTypeName(s.Obj), diff)
+		}
 	}
 
 	return result, err


### PR DESCRIPTION
### Objective:

To avoid flooding the Operator log with unchanged difference.

### Issue:

```
I0915 13:40:25.386265       1 controller.go:71] Starting MinIO Operator
I0915 13:40:25.397879       1 main-controller.go:278] Setting up event handlers
I0915 13:40:25.410762       1 main-controller.go:502] Using Kubernetes CSR Version: v1
I0915 13:40:25.410807       1 main-controller.go:522] STS Api server is not enabled, not starting
I0915 13:40:25.410855       1 leaderelection.go:248] attempting to acquire leader lease minio-operator/minio-operator-lock...
I0915 13:40:25.413455       1 leaderelection.go:258] successfully acquired lease minio-operator/minio-operator-lock
I0915 13:40:25.413526       1 main-controller.go:551] minio-operator-5dd8576f78-g4zvk: I am the leader, applying leader labels on myself
I0915 13:40:25.413589       1 main-controller.go:397] Waiting for Upgrade Server to start
I0915 13:40:25.413597       1 main-controller.go:401] Starting Tenant controller
I0915 13:40:25.413599       1 main-controller.go:404] Waiting for informer caches to sync
I0915 13:40:25.413605       1 main-controller.go:409] Starting workers
I0915 13:40:25.413610       1 main-controller.go:442] Console TLS is not enabled
I0915 13:40:25.413648       1 main-controller.go:353] Starting HTTP Upgrade Tenant Image server
I0915 13:40:25.440780       1 status.go:89] Hit conflict issue, getting latest version of tenant
I0915 13:40:26.001436       1 monitoring.go:159] '/' Can't update tenant status: Operation cannot be fulfilled on tenants.minio.min.io "myminio": the object has been modified; please apply your changes to the latest version and try again
I0915 13:40:26.004429       1 monitoring.go:215] '/' Can't update tenant status: resource name may not be empty
I0915 13:40:30.450857       1 pdb.go:180] PodDisruptionBudget: v1
I0915 13:40:30.452345       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:40:35.457559       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:40:40.466084       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:40:45.480076       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:40:50.503217       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:40:55.515381       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:00.539780       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:05.560779       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:10.574543       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:15.586333       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:20.606252       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:25.623667       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:30.643865       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:35.671285       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:40.707524       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:45.732055       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:50.770662       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:41:55.788824       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:00.816216       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:05.851089       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:10.890617       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:15.925877       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:20.950156       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:25.968224       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:31.011399       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:36.023852       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:41.061650       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:46.076984       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:51.116211       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
I0915 13:42:56.155916       1 sync.go:148] unchanged key tenant-lite/myminio-pool-0 kind policy/v1, Kind=PodDisruptionBudget diff []
```
