### PR TITLE
feat:plugin version will show the operator's version

### DIFF
--- a/kubectl-minio/cmd/version.go
+++ b/kubectl-minio/cmd/version.go
@@ -102,7 +102,12 @@ func (o *operatorVersionCmd) run() error {
 			}
 		}
 		if image != "" {
-			fmt.Printf("Minio-Operator Version: %s/%s:%s \r\n", item.Namespace, item.Name, strings.SplitN(image, ":", 2)[1])
+			if item.Name == "console" {
+				fmt.Printf("Minio-Operator Console Version: %s/%s:%s \r\n", item.Namespace, item.Name, strings.SplitN(image, ":", 2)[1])
+			}
+			if item.Name == "minio-operator" {
+				fmt.Printf("Minio-Operator Controller Version: %s/%s:%s \r\n", item.Namespace, item.Name, strings.SplitN(image, ":", 2)[1])
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
For now:
Just the version come out:
`v5.0.9` for example.
For this pr, will show like:
```log
Kubectl-Plugin Version: DEVELOPMENT.GOGET
Minio-Operator Console Version: mcamel-system/console:v5.0.6 
Minio-Operator Controller Version: mcamel-system/minio-operator:v5.0.6 
```
test steps:
1. go build -o k
2. ./k version --kubeconfig="yourkubeconfig"