### PR TITLE
fix: avoid the NewPool will change the tenant's label

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -467,7 +467,7 @@ type NewPoolArgs struct {
 
 // NewPool creates a new StatefulSet for the given Cluster.
 func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
-	t := args.Tenant
+	t := args.Tenant.DeepCopy()
 	skipEnvVars := args.SkipEnvVars
 	pool := args.Pool
 	poolStatus := args.PoolStatus


### PR DESCRIPTION
fix: avoid the NewPool will change the tenant's label
```golang
	t := args.Tenant
...
	ssMeta.Labels = t.ObjectMeta.Labels
	ssMeta.Annotations = t.ObjectMeta.Annotations
...
	if ssMeta.Labels == nil {
		ssMeta.Labels = make(map[string]string)
	}

	// Add information labels, such as which pool we are building this pod about
	ssMeta.Labels[miniov2.PoolLabel] = pool.Name
	ssMeta.Labels[miniov2.TenantLabel] = t.Name

```
Reuse the tenant's labels map.