### PR TITLE
Create buckets upon tenant creation or after tenant creation

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1359,7 +1359,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 	}
 
 	// Ensure we are only creating the bucket
-	if !tenant.Status.ProvisionedBuckets && len(tenant.Spec.Buckets) > 0 {
+	if len(tenant.Spec.Buckets) > 0 {
 		if err := c.createBuckets(ctx, tenant, tenantConfiguration); err != nil {
 			klog.V(2).Infof("Unable to create MinIO buckets: %v", err)
 			c.RegisterEvent(ctx, tenant, corev1.EventTypeWarning, "BucketsCreatedFailed", fmt.Sprintf("Buckets creation failed: %s", err))


### PR DESCRIPTION
### Objective:

To be able to create a bucket after the tenant is created.

### Reasoning:

We have customers who wants to create buckets once tenant is created by just changing GitOps Tenant Spec YAML. This will save them time as they will not need to create additional Jobs or containers to add buckets and all is needed is to change the tenant spec in their GitOps/ArgoCD flow.

### Testing:

![image](https://github.com/minio/operator/assets/6667358/8d04b99f-355c-4407-bf79-56c1fd9f935b)


By doing this, we can keep creating as many buckets as needed after tenant is deployed. And we are protected against any failure because we have the code already in place to detect when bucket is created:

* File: `operator/pkg/apis/minio.min.io/v2/helper.go`

```go
		}); err != nil {
			switch minio.ToErrorResponse(err).Code {
			case "BucketAlreadyOwnedByYou", "BucketAlreadyExists":
				klog.Infof(err.Error())
				continue
```

As a result we get in the logs:

```
I0919 20:21:59.241643   81813 helper.go:779] Your previous request to create the named bucket succeeded and you already own it.
```

### Question is:

* If this is not approved, why we want to create bucket just upon tenant creation?: https://github.com/minio/operator/pull/820

* If we can create buckets on the fly, should we do it? what is the advantage or disadvantage of not doing it?. Please let's discuss this internally for me to understand better the reasons behind 820 PR.