### PR TITLE
Additional Volumes Support for Tenant Helm Chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -130,6 +130,12 @@ spec:
   {{- if dig "priorityClassName" "" . }}
   priorityClassName: {{ dig "priorityClassName" "" . }}
   {{- end }}
+  {{- with (dig "additionalVolumes" (list) .) }}
+  additionalVolumes: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with (dig "additionalVolumeMounts" (list) .) }}
+  additionalVolumeMounts: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if dig "kes" "configuration" false . }}
   kes:
     image: "{{ .kes.image.repository }}:{{ .kes.image.digest | default .kes.image.tag }}"

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -174,6 +174,10 @@ tenant:
   ## This is applied to MinIO pods only.
   ## Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass/
   priorityClassName: ""
+  ## additionalVolumes allows adding additional volumes to MinIO pods
+  additionalVolumes: [ ]
+  ## additionalVolumeMounts allows mounting additional volumes to MinIO pods
+  additionalVolumeMounts: [ ]
   ## Define configuration for KES (stateless and distributed key-management system)
   ## Refer https://github.com/minio/kes
   #kes:


### PR DESCRIPTION
This small change introduces support for the `additionalVolumes` and `additionalVolumeMounts` fields of the tenant CR to the helm chart. My intention is to use this to configure `MINIO_KMS_SECRET_KEY_FILE` instead of having the secret in an env var directly.

~~The second commit also enables encryption if `MINIO_KMS_SECRET_KEY_FILE` is passed and not just when `MINIO_KMS_SECRET_KEY` is passed. If necessary I can split that change into a separate PR.~~ See: https://github.com/minio/operator/pull/1789
