### PR TITLE
Adding back Usable Capacity and Internal

### DIFF
--- a/pkg/controller/monitoring.go
+++ b/pkg/controller/monitoring.go
@@ -168,6 +168,18 @@ func (c *Controller) updateHealthStatusForTenant(tenant *miniov2.Tenant) error {
 		return nil
 	}
 
+	// Add back "Usable Capacity" & "Internal" values in Tenant Status and in the UI
+	// How much is available: "Usable Capacity" in UI comes from "tenant.Status.Usage.Capacity"
+	// How much is used: "Internal" in UI comes from "tenant.Status.Usage.Usage"
+	UsedSpace := int64(0)      // How much is used
+	AvailableSpace := int64(0) // How much is available
+	for _, disk := range storageInfo.Disks {
+		UsedSpace = UsedSpace + int64(disk.UsedSpace)
+		AvailableSpace = AvailableSpace + int64(disk.AvailableSpace)
+	}
+	tenant.Status.Usage.Usage = UsedSpace
+	tenant.Status.Usage.Capacity = AvailableSpace
+
 	var rawUsage uint64
 
 	var onlineDisks int32
@@ -236,10 +248,6 @@ func (c *Controller) updateHealthStatusForTenant(tenant *miniov2.Tenant) error {
 			klog.Infof("'%s/%s' Can't update tenant status with tiers: %v", tenant.Namespace, tenant.Name, err)
 		}
 	}
-
-	// TODO: add usage and usableCapacity
-	// tenant.Status.Usage.Usage = metrics.Usage
-	// tenant.Status.Usage.Capacity = metrics.UsableCapacity
 
 	return nil
 }


### PR DESCRIPTION
### Objective:

To give values to `Usable Capacity` and `Internal` in the UI by populating back our Status in the Tenant as suggested by Harsha: `adminClnt.StorageInfo(srvInfoCtx)`

![image](https://github.com/minio/operator/assets/6667358/81a70f4a-17b1-4930-b2a1-8ff0dc161827)

### Reasoning:

Back in [Remove Log Search API and Prometheus](https://github.com/minio/operator/pull/1512) PR we removed `metrics` hence leaving these fields unpopulated breaking the feature. For legacy Tenants, numbers will remain constant and for new tenants it will be `n/a` but with this change we can get those number back from our internal minio client.
