### PR TITLE
feat: Allow the Helm release namespace to be overridden

### DIFF
--- a/helm/tenant/templates/NOTES.txt
+++ b/helm/tenant/templates/NOTES.txt
@@ -2,11 +2,11 @@
   To connect to the {{ .name }} tenant if it doesn't have a service exposed, you can port-forward to it by running:
   {{- if dig "certificate" "requestAutoCert" false . }}
 
-  kubectl --namespace {{ $.Release.Namespace }} port-forward svc/{{ .name }}-console 9443:9443
+  kubectl --namespace {{ template "minio-tenant.namespace" $ }} port-forward svc/{{ .name }}-console 9443:9443
 
   Then visit the MinIO Console at https://127.0.0.1:9443
   {{ else }}
-  kubectl --namespace {{ $.Release.Namespace }} port-forward svc/{{ .name }}-console 9090:9090
+  kubectl --namespace {{ template "minio-tenant.namespace" $ }} port-forward svc/{{ .name }}-console 9090:9090
 
   Then visit the MinIO Console at http://127.0.0.1:9090
   {{ end }}

--- a/helm/tenant/templates/_helpers.tpl
+++ b/helm/tenant/templates/_helpers.tpl
@@ -21,6 +21,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "minio-tenant.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the Operator Console.
 */}}
 {{- define "minio-operator.console-name" -}}

--- a/helm/tenant/templates/api-ingress.yaml
+++ b/helm/tenant/templates/api-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.tenant.name }}
+  namespace: {{ template "minio-tenant.namespace" $ }}
   {{- with .Values.ingress.api.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/tenant/templates/console-ingress.yaml
+++ b/helm/tenant/templates/console-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.tenant.name }}-console
+  namespace: {{ template "minio-tenant.namespace" $ }}
   {{- with .Values.ingress.console.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/tenant/templates/kes-configuration-secret.yaml
+++ b/helm/tenant/templates/kes-configuration-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kes-configuration
+  namespace: {{ template "minio-tenant.namespace" $ }}
 type: Opaque
 stringData:
   server-config.yaml: {{ .Values.tenant.kes.configuration | toYaml | indent 2 }}

--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ dig "secrets" "name" "" (.Values | merge (dict)) }}
+  namespace: {{ template "minio-tenant.namespace" $ }}
 type: Opaque
 stringData:
   config.env: |-

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -3,6 +3,7 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: {{ .name }}
+  namespace: {{ template "minio-tenant.namespace" $ }}
   ## Optionally pass labels to be applied to the statefulset pods
   labels:
     app: minio

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,3 +1,6 @@
+
+# Override the tenant namespace
+namespaceOverride: ""
 ## Secret with default environment variable configurations to be used by MinIO Tenant.
 ## Not recommended for production deployments! Create the secret manually instead.
 secrets:


### PR DESCRIPTION
for multi-namespace deployments in combined charts