### PR TITLE
Support k8s secrets in console pod

### DIFF
--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -173,11 +173,21 @@ func NewConfigDirFromCtx(ctx *cli.Context, option string, getDefaultDir func() s
 }
 
 func getPublicCertFile() string {
-	return filepath.Join(GlobalCertsDir.Get(), PublicCertFile)
+	publicCertFile := filepath.Join(GlobalCertsDir.Get(), PublicCertFile)
+	TLSCertFile := filepath.Join(GlobalCertsDir.Get(), TLSCertFile)
+	if isFile(publicCertFile) {
+		return publicCertFile
+	}
+	return TLSCertFile
 }
 
 func getPrivateKeyFile() string {
-	return filepath.Join(GlobalCertsDir.Get(), PrivateKeyFile)
+	privateKeyFile := filepath.Join(GlobalCertsDir.Get(), PrivateKeyFile)
+	TLSPrivateKey := filepath.Join(GlobalCertsDir.Get(), TLSKeyFile)
+	if isFile(privateKeyFile) {
+		return privateKeyFile
+	}
+	return TLSPrivateKey
 }
 
 // EnvCertPassword is the environment variable which contains the password used

--- a/pkg/certs/const.go
+++ b/pkg/certs/const.go
@@ -29,6 +29,12 @@ const (
 	// PublicCertFile Public certificate file for HTTPS.
 	PublicCertFile = "public.crt"
 
+	// TLSCertFile Public certificate file for HTTPS.
+	TLSCertFile = "tls.crt"
+
 	// PrivateKeyFile Private key file for HTTPS.
 	PrivateKeyFile = "private.key"
+
+	// TLSKeyFile Private key file for HTTPS.
+	TLSKeyFile = "tls.key"
 )


### PR DESCRIPTION
To fix: https://github.com/minio/operator/issues/1439

### Explanation:

In the certificate path we only look for `public.crt` and `private.key` to serve console in 9443. But in k8s we have other type of secrets with different file names like `cert-manager` secrets or `k8s` secrets, hence we should also support `tls.crt` and `tls.key` to allow people to use `cert-manager` or other methods not just our self-signed cert.

### How to test:

1. `k proxy`
2. IntelliJ or other tool with this run/debug config:

<img width="1372" alt="Screenshot 2023-10-06 at 9 09 20 PM" src="https://github.com/minio/operator/assets/6667358/3f16d765-b939-4fe4-91e2-7c28b1afc17f">

### How it looks:

```sh
$ pwd
/Users/cniackz/.console/certs
```

```sh
$ ls
CAs		tls.crt		tls.key
```

```sh
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/cniackz/go #gosetup
/usr/local/go/bin/go build -trimpath -o /Users/cniackz/operator/go_build_github_com_minio_operator_cmd_operator . #gosetup
/Users/cniackz/operator/go_build_github_com_minio_operator_cmd_operator ui
Serving operator at http://[::]:9090
Serving operator at https://[::]:9443
```

### Expected:

```
Serving operator at https://[::]:9443 <---- Meaning you are serving on HTTPS on that particular pod.
```
