### PR TITLE
Correcting the name of the Operator Console TLS Secret

### DIFF
--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -322,6 +322,6 @@ spec:
                       path: CAs/tls.crt
                     - key: tls.key
                       path: tls.key
-                  name: operator-console-tls
+                  name: console-tls
                   optional: true
       serviceAccountName: console-sa


### PR DESCRIPTION
In Deployment console, correcting the name of the Operator Console TLS Secret as it got changed in https://github.com/minio/operator/pull/1712/files:

<img width="1371" alt="Screenshot 2023-10-07 at 12 28 11 AM" src="https://github.com/minio/operator/assets/6667358/a8470265-ca17-483c-ad82-08381adecbc3">

and everytime is tested, manual modification is required in the deployment to use proper secret