### PR TITLE
Conditional deployment of minio operator console pro-grammatically

### DIFF
--- a/helm/operator/templates/console-clusterrole.yaml
+++ b/helm/operator/templates/console-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -235,3 +236,4 @@ rules:
       - get
       - list
       - watch
+{{- end }}

--- a/helm/operator/templates/console-clusterrolebinding.yaml
+++ b/helm/operator/templates/console-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
   - kind: ServiceAccount
     name: console-sa
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/operator/templates/console-configmap.yaml
+++ b/helm/operator/templates/console-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   CONSOLE_PORT: "9090"
   CONSOLE_TLS_PORT: "9443"
+{{- end }}

--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,3 +62,4 @@ spec:
       {{- with .Values.console.volumes }}
       volumes: {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/helm/operator/templates/console-ingress.yaml
+++ b/helm/operator/templates/console-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 {{- if .Values.console.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -34,4 +35,5 @@ spec:
                 name: "console"
                 port:
                   name: http
+{{- end }}
 {{- end }}

--- a/helm/operator/templates/console-secret.yaml
+++ b/helm/operator/templates/console-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: console-sa
 type: kubernetes.io/service-account-token
+{{- end }}

--- a/helm/operator/templates/console-service.yaml
+++ b/helm/operator/templates/console-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.console.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,3 +11,4 @@ spec:
   - name: https
     port: 9443
   selector: {{- include "minio-operator.console-selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/operator/templates/console-serviceaccount.yaml
+++ b/helm/operator/templates/console-serviceaccount.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.console.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: console-sa
+{{- end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -68,6 +68,7 @@ operator:
       ephemeral-storage: 500Mi
 
 console:
+  enabled: true
   image:
     repository: quay.io/minio/operator
     tag: v5.0.9


### PR DESCRIPTION
Fixes: https://github.com/minio/operator/issues/1598

Allow conditional deployment of operator console through helm.

Steps to verify the change
1. Set `.Values.operator.console` value as `false` in `helm/operator/values.yaml`
```
console:
  enabled: false
  image:
    repository: quay.io/minio/operator
    tag: v5.0.9
    pullPolicy: IfNotPresent
  env: [ ]
```
2. Install minio operator 
```
$ helm install --namespace minio-operator --create-namespace minio-operator ./helm/operator
```
3. Deploy a MinIO tenant
```
$ kubectl create ns tenant-ns
$ kubectl minio tenant create tenant1 --servers 4 --volumes 4 --capacity 2Gi --namespace tenant-ns
```
4. Create an alias to the MinIO tenant, create a bucket and load an object
```
$ kubectl get secrets/tenant1-user-1 -n tenant-ns -oyaml | yq '.data.CONSOLE_ACCESS_KEY' | base64 -d
JF9HAHTV2596PC6PGWPU
$ kubectl get secrets/tenant1-user-1 -n tenant-ns -oyaml | yq '.data.CONSOLE_SECRET_KEY' | base64 -d
j7ohF4tdcBvt3SdApxbhNbvldYMItJbVeDfrr0Gn

$ kubectl port-forward svc/minio -n tenant-ns 9443:443

$ mc alias set myminio https://localhost:9443 JF9HAHTV2596PC6PGWPU j7ohF4tdcBvt3SdApxbhNbvldYMItJbVeDfrr0Gn --insecure
$ mc mb myminio/test-bucket --insecure
$ mc cp /etc/issue myminio/test-bucket --insecure
```
5. Port forward to console service ad open MinIO object browser console and verify the bucket and object
```
$ kubectl port-forward svc/tenant1-console -n tenant-ns 9000:9443
```

![Screenshot from 2023-10-10 13-48-18](https://github.com/minio/operator/assets/6771252/9f4d7e86-f5c2-4c4d-8c8c-ffca63ceab82)

  