### PR TITLE
Revert change as field is actually needed

### DIFF
--- a/helm/operator/templates/console-configmap.yaml
+++ b/helm/operator/templates/console-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: console-env
+  namespace: {{ .Release.Namespace }}
 data:
   CONSOLE_PORT: "9090"
   CONSOLE_TLS_PORT: "9443"

--- a/helm/operator/templates/console-deployment.yaml
+++ b/helm/operator/templates/console-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: console
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.console.replicaCount }}

--- a/helm/operator/templates/console-ingress.yaml
+++ b/helm/operator/templates/console-ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "minio-operator.console-fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.console.ingress.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/operator/templates/console-secret.yaml
+++ b/helm/operator/templates/console-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: console-sa-secret
+  namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/service-account.name: console-sa
 type: kubernetes.io/service-account-token

--- a/helm/operator/templates/console-service.yaml
+++ b/helm/operator/templates/console-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: console
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio-operator.labels" . | nindent 4 }}
 spec:
   ports:

--- a/helm/operator/templates/console-serviceaccount.yaml
+++ b/helm/operator/templates/console-serviceaccount.yaml
@@ -3,4 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: console-sa
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: minio-operator
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.operator.replicaCount }}

--- a/helm/operator/templates/operator-service.yaml
+++ b/helm/operator/templates/operator-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: operator
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio-operator.labels" . | nindent 4 }}
 spec:
   type: ClusterIP

--- a/helm/operator/templates/operator-serviceaccount.yaml
+++ b/helm/operator/templates/operator-serviceaccount.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minio-operator
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio-operator.labels" . | nindent 4 }}

--- a/helm/operator/templates/sts-service.yaml
+++ b/helm/operator/templates/sts-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sts
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "minio-operator.labels" . | nindent 4 }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
### Objective:

To add back namespace field as is needed

### When is needed:

When installing Operator/Tenant via ArgoCD with a mix of Helm and Kustomization.

### Original Change:

* https://github.com/minio/operator/pull/1646

### Example when is needed:

```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - minio-operator/minio-operator-ns.yaml
helmCharts:
  - name: operator
    repo: https://operator.min.io/
    version: v5.0.9
    releaseName: minio-operator
    namespace: minio-operator
```

### Documentation:

* https://pet2cattle.com/2023/01/argocd-kustomize-enable-helm