### PR TITLE
To ignore the creationTimestamp unknown field when performing tenant upgrade

### DIFF
--- a/kubectl-minio/cmd/tenant-upgrade.go
+++ b/kubectl-minio/cmd/tenant-upgrade.go
@@ -146,7 +146,7 @@ func (u *upgradeCmd) upgradeTenant(client *operatorv1.Clientset, t *miniov2.Tena
 		fmt.Printf(Bold(fmt.Sprintf("\nUpgrading Tenant '%s/%s'\n\n", t.ObjectMeta.Name, t.ObjectMeta.Namespace)))
 		// update the image
 		t.Spec.Image = u.tenantOpts.Image
-		if _, err := client.MinioV2().Tenants(t.Namespace).Update(context.Background(), t, v1.UpdateOptions{}); err != nil {
+		if _, err := client.MinioV2().Tenants(t.Namespace).Update(context.Background(), t, v1.UpdateOptions{FieldValidation: "Ignore"}); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
How to test:

1) checkout PR
2) build binary
3) `./kubectl-minio/kubectl-minio tenant upgrade minio-tenant-1 --image minio/minio:RELEASE.2023-10-16T04-13-43Z`

```
Upgrade is a one way process. Are you sure to upgrade Tenant 'minio-tenant-1/minio-tenant-1' from version minio/minio:RELEASE.2023-10-16T04-13-43Z to minio/minio:RELEASE.2023-10-16T04-13-43Z: y
Upgrade is a one way process. Are you sure to upgrade Tenant 'minio-tenant-1/minio-tenant-1' from version minio/minio:RELEASE.2023-10-16T04-13-43Z to minio/minio:RELEASE.2023-10-16T04-13-43Z: y

Upgrading Tenant 'minio-tenant-1/minio-tenant-1'
```

Closes [1778](https://github.com/minio/operator/issues/1778)
