### PR TITLE
feat: add support pvc deletion when need

### DIFF
--- a/docs/tenant-storage-deletion.md
+++ b/docs/tenant-storage-deletion.md
@@ -4,7 +4,7 @@ There are times when we need to do tests, and once the tests are done, we need t
 
 ```$xslt
  - name: pool-0
-   storageDeletion: true
+   reclaimStorage: true
 ```
 
 When a tenant is deleted, the associated pvc is also deleted immediately.

--- a/docs/tenant-storage-deletion.md
+++ b/docs/tenant-storage-deletion.md
@@ -1,0 +1,10 @@
+# When one-time storage is required
+
+There are times when we need to do tests, and once the tests are done, we need to clean up the storage immediately. We can do the following configuration
+
+```$xslt
+ - name: pool-0
+   storageDeletion: true
+```
+
+When a tenant is deleted, the associated pvc is also deleted immediately.

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -444,7 +444,7 @@ Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a 
 |*Optional* + 
  If provided, each pod on the Statefulset will run with the specified RuntimeClassName, for more info https://kubernetes.io/docs/concepts/containers/runtime-class/
 
-|*`storageDeletion`* __boolean__ 
+|*`reclaimStorage`* __boolean__ 
 |*Optional* + 
  If true. Will delete the storage when tenant has been deleted.
 

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -101,16 +101,6 @@ CertificateStatus keeps track of all the certificates managed by the operator
 |===
 
 
-[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificateconfig"]
-==== CustomCertificateConfig 
-
-CustomCertificateConfig (`customCertificateConfig`) provides attributes associated of the TLS certificates manually added to the Operator as part of tenant creation. These fields contain no data if there are no custom TLS certificates.
-
-.Appears In:
-****
-- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificates[$$CustomCertificates$$]
-****
-
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificates"]
@@ -453,6 +443,10 @@ Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a 
 |*`runtimeClassName`* __string__ 
 |*Optional* + 
  If provided, each pod on the Statefulset will run with the specified RuntimeClassName, for more info https://kubernetes.io/docs/concepts/containers/runtime-class/
+
+|*`storageDeletion`* __boolean__ 
+|*Optional* + 
+ If true. Will delete the storage when tenant has been deleted.
 
 |===
 

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -2868,7 +2868,7 @@ spec:
                     servers:
                       format: int32
                       type: integer
-                    stroageDeletion:
+                    storageDeletion:
                       type: boolean
                     tolerations:
                       items:

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -2868,6 +2868,8 @@ spec:
                     servers:
                       format: int32
                       type: integer
+                    stroageDeletion:
+                      type: boolean
                     tolerations:
                       items:
                         properties:

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -2768,6 +2768,8 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    reclaimStorage:
+                      type: boolean
                     resources:
                       properties:
                         claims:
@@ -2868,8 +2870,6 @@ spec:
                     servers:
                       format: int32
                       type: integer
-                    storageDeletion:
-                      type: boolean
                     tolerations:
                       items:
                         properties:

--- a/helm/operator/templates/operator-clusterrole.yaml
+++ b/helm/operator/templates/operator-clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
       - get
       - update
       - list
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/kubectl-minio/cmd/tenant-upgrade.go
+++ b/kubectl-minio/cmd/tenant-upgrade.go
@@ -146,7 +146,7 @@ func (u *upgradeCmd) upgradeTenant(client *operatorv1.Clientset, t *miniov2.Tena
 		fmt.Printf(Bold(fmt.Sprintf("\nUpgrading Tenant '%s/%s'\n\n", t.ObjectMeta.Name, t.ObjectMeta.Namespace)))
 		// update the image
 		t.Spec.Image = u.tenantOpts.Image
-		if _, err := client.MinioV2().Tenants(t.Namespace).Update(context.Background(), t, v1.UpdateOptions{}); err != nil {
+		if _, err := client.MinioV2().Tenants(t.Namespace).Update(context.Background(), t, v1.UpdateOptions{FieldValidation: "Ignore"}); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -704,7 +704,7 @@ type Pool struct {
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
 	// *Optional* +
 	//
-	// If true. Will delete the stroage when tenant has been deleted.
+	// If true. Will delete the storage when tenant has been deleted.
 	// +optional
 	StorageDeletion *bool `json:"storageDeletion,omitempty"`
 }

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -702,6 +702,11 @@ type Pool struct {
 	// If provided, each pod on the Statefulset will run with the specified RuntimeClassName, for more info https://kubernetes.io/docs/concepts/containers/runtime-class/
 	// +optional
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+	// *Optional* +
+	//
+	// If true. Will delete the stroage when tenant has been deleted.
+	// +optional
+	StorageDeletion *bool `json:"stroageDeletion,omitempty"`
 }
 
 // EqualImage returns true if config image and current input image are same

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -706,7 +706,7 @@ type Pool struct {
 	//
 	// If true. Will delete the storage when tenant has been deleted.
 	// +optional
-	StorageDeletion *bool `json:"storageDeletion,omitempty"`
+	ReclaimStorage *bool `json:"reclaimStorage,omitempty"`
 }
 
 // EqualImage returns true if config image and current input image are same

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -706,7 +706,7 @@ type Pool struct {
 	//
 	// If true. Will delete the stroage when tenant has been deleted.
 	// +optional
-	StorageDeletion *bool `json:"stroageDeletion,omitempty"`
+	StorageDeletion *bool `json:"storageDeletion,omitempty"`
 }
 
 // EqualImage returns true if config image and current input image are same

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -752,7 +752,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 				// Just output the error. Will not retry.
 				runtime.HandleError(fmt.Errorf("DeletePrometheusAddlConfig '%s/%s' error:%s", namespace, tenantName, err.Error()))
 			}
-			// try to delete pvc if set StroageDeletionLabel:true
+			// try to delete pvc if set StorageDeletionLabel:true
 			pvcList := corev1.PersistentVolumeClaimList{}
 			listOpt := client.ListOptions{
 				Namespace: namespace,
@@ -765,7 +765,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 				runtime.HandleError(fmt.Errorf("PersistentVolumeClaimList  '%s/%s' error:%s", namespace, tenantName, err.Error()))
 			}
 			for _, pvc := range pvcList.Items {
-				if pvc.Labels[statefulsets.StroageDeletionLabel] == "true" {
+				if pvc.Labels[statefulsets.StorageDeletionLabel] == "true" {
 					err := c.k8sClient.Delete(ctx, &pvc)
 					if err != nil {
 						runtime.HandleError(fmt.Errorf("Delete PersistentVolumeClaim '%s/%s/%s' error:%s", namespace, tenantName, pvc.Name, err.Error()))

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -752,6 +752,26 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 				// Just output the error. Will not retry.
 				runtime.HandleError(fmt.Errorf("DeletePrometheusAddlConfig '%s/%s' error:%s", namespace, tenantName, err.Error()))
 			}
+			// try to delete pvc if set StroageDeletionLabel:true
+			pvcList := corev1.PersistentVolumeClaimList{}
+			listOpt := client.ListOptions{
+				Namespace: namespace,
+			}
+			client.MatchingLabels{
+				"v1.min.io/tenant": tenantName,
+			}.ApplyToList(&listOpt)
+			err := c.k8sClient.List(ctx, &pvcList, &listOpt)
+			if err != nil {
+				runtime.HandleError(fmt.Errorf("PersistentVolumeClaimList  '%s/%s' error:%s", namespace, tenantName, err.Error()))
+			}
+			for _, pvc := range pvcList.Items {
+				if pvc.Labels[statefulsets.StroageDeletionLabel] == "true" {
+					err := c.k8sClient.Delete(ctx, &pvc)
+					if err != nil {
+						runtime.HandleError(fmt.Errorf("Delete PersistentVolumeClaim '%s/%s/%s' error:%s", namespace, tenantName, pvc.Name, err.Error()))
+					}
+				}
+			}
 			return WrapResult(Result{}, nil)
 		}
 		// will retry after 5sec

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -752,7 +752,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 				// Just output the error. Will not retry.
 				runtime.HandleError(fmt.Errorf("DeletePrometheusAddlConfig '%s/%s' error:%s", namespace, tenantName, err.Error()))
 			}
-			// try to delete pvc if set StorageDeletionLabel:true
+			// try to delete pvc if set ReclaimStorageLabel:true
 			pvcList := corev1.PersistentVolumeClaimList{}
 			listOpt := client.ListOptions{
 				Namespace: namespace,
@@ -765,7 +765,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 				runtime.HandleError(fmt.Errorf("PersistentVolumeClaimList  '%s/%s' error:%s", namespace, tenantName, err.Error()))
 			}
 			for _, pvc := range pvcList.Items {
-				if pvc.Labels[statefulsets.StorageDeletionLabel] == "true" {
+				if pvc.Labels[statefulsets.ReclaimStorageLabel] == "true" {
 					err := c.k8sClient.Delete(ctx, &pvc)
 					if err != nil {
 						runtime.HandleError(fmt.Errorf("Delete PersistentVolumeClaim '%s/%s/%s' error:%s", namespace, tenantName, pvc.Name, err.Error()))

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -34,8 +34,8 @@ import (
 
 const (
 	bucketDNSEnv = "MINIO_DNS_WEBHOOK_ENDPOINT"
-	// StorageDeletionLabel - pvc with this label and the value is `true` means when tenant is being deleted the pvc will be deleted.
-	StorageDeletionLabel = "storageDeletion"
+	// ReclaimStorageLabel - pvc with this label and the value is `true` means when tenant is being deleted the pvc will be deleted.
+	ReclaimStorageLabel = "reclaimStorage"
 )
 
 // Returns the MinIO environment variables set in configuration.
@@ -856,11 +856,11 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 
 	if pool.VolumeClaimTemplate != nil {
 		pvClaim := *pool.VolumeClaimTemplate
-		if pool.StorageDeletion != nil && *pool.StorageDeletion {
+		if pool.ReclaimStorage != nil && *pool.ReclaimStorage {
 			if len(pvClaim.Labels) == 0 {
 				pvClaim.Labels = make(map[string]string)
 			}
-			pvClaim.Labels[StorageDeletionLabel] = "true"
+			pvClaim.Labels[ReclaimStorageLabel] = "true"
 		}
 		name := pvClaim.Name
 		for i := 0; i < int(pool.VolumesPerServer); i++ {

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -34,8 +34,8 @@ import (
 
 const (
 	bucketDNSEnv = "MINIO_DNS_WEBHOOK_ENDPOINT"
-	// StroageDeletionLabel - pvc with this label and the value is `true` means when tenant is being deleted the pvc will be deleted.
-	StroageDeletionLabel = "stroageDeletion"
+	// StorageDeletionLabel - pvc with this label and the value is `true` means when tenant is being deleted the pvc will be deleted.
+	StorageDeletionLabel = "storageDeletion"
 )
 
 // Returns the MinIO environment variables set in configuration.
@@ -860,7 +860,7 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 			if len(pvClaim.Labels) == 0 {
 				pvClaim.Labels = make(map[string]string)
 			}
-			pvClaim.Labels[StroageDeletionLabel] = "true"
+			pvClaim.Labels[StorageDeletionLabel] = "true"
 		}
 		name := pvClaim.Name
 		for i := 0; i < int(pool.VolumesPerServer); i++ {

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	bucketDNSEnv = "MINIO_DNS_WEBHOOK_ENDPOINT"
+	bucketDNSEnv         = "MINIO_DNS_WEBHOOK_ENDPOINT"
+	StroageDeletionLabel = "stroageDeletion"
 )
 
 // Returns the MinIO environment variables set in configuration.
@@ -854,6 +855,12 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 
 	if pool.VolumeClaimTemplate != nil {
 		pvClaim := *pool.VolumeClaimTemplate
+		if pool.StorageDeletion != nil && *pool.StorageDeletion {
+			if len(pvClaim.Labels) == 0 {
+				pvClaim.Labels = make(map[string]string)
+			}
+			pvClaim.Labels[StroageDeletionLabel] = "true"
+		}
 		name := pvClaim.Name
 		for i := 0; i < int(pool.VolumesPerServer); i++ {
 			pvClaim.Name = name + strconv.Itoa(i)

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	bucketDNSEnv         = "MINIO_DNS_WEBHOOK_ENDPOINT"
+	bucketDNSEnv = "MINIO_DNS_WEBHOOK_ENDPOINT"
+	// StroageDeletionLabel - pvc with this label and the value is `true` means when tenant is being deleted the pvc will be deleted.
 	StroageDeletionLabel = "stroageDeletion"
 )
 

--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -18,6 +18,7 @@ rules:
       - get
       - update
       - list
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -2868,7 +2868,7 @@ spec:
                     servers:
                       format: int32
                       type: integer
-                    stroageDeletion:
+                    storageDeletion:
                       type: boolean
                     tolerations:
                       items:

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -2868,6 +2868,8 @@ spec:
                     servers:
                       format: int32
                       type: integer
+                    stroageDeletion:
+                      type: boolean
                     tolerations:
                       items:
                         properties:

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -2768,6 +2768,8 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    reclaimStorage:
+                      type: boolean
                     resources:
                       properties:
                         claims:
@@ -2868,8 +2870,6 @@ spec:
                     servers:
                       format: int32
                       type: integer
-                    storageDeletion:
-                      type: boolean
                     tolerations:
                       items:
                         properties:


### PR DESCRIPTION
fix: https://github.com/minio/operator/issues/1803
add support pvc deletion when need
```yaml
 - name: pool-0
   reclaimStorage: true
```
When tenant has gone. The pvc will been deleted.
That's false by default. Means will not delete the pvcs by default.