### PR TITLE
docker: use ubi-micro base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+
+RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
 
 ARG TAG
 
@@ -10,12 +14,13 @@ LABEL name="MinIO" \
       summary="MinIO Operator brings native support for MinIO, Console, and Encryption to Kubernetes." \
       description="MinIO object storage is fundamentally different. Designed for performance and the S3 API, it is 100% open-source. MinIO is ideal for large, private cloud environments with stringent security requirements and delivers mission-critical availability across a diverse range of workloads."
 
+# On RHEL the certificate bundle is located at:
+# - /etc/pki/tls/certs/ca-bundle.crt (RHEL 6)
+# - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (RHEL 7)
+COPY --from=build /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/
+
 COPY CREDITS /licenses/CREDITS
 COPY LICENSE /licenses/LICENSE
-
-RUN \
-    microdnf update --nodocs && \
-    microdnf install curl ca-certificates shadow-utils --nodocs
 
 COPY minio-operator /minio-operator
 


### PR DESCRIPTION
This commit replaces the ubi-minimal with ubi-micro as a base image. The micro base image is smaller
and contains less components. Hence, it gets less
often flagged by security scanners, aside of shorter pull times.