### PR TITLE
update container base image to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
 
 RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.8
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
 ARG TAG
 


### PR DESCRIPTION
This commit updates the container base image
to ubi9/ubi-9.2. It is ~4 MB smaller than ubi-8.