### PR TITLE
Parse tenant config properly

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -1021,20 +1021,20 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 			Skip: true,
 		}, nil
 	}
-	const envSeparator = "="
-	envTokens := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(envEntry, "export")), envSeparator, 2)
-	if len(envTokens) != 2 {
-		return envKV{}, fmt.Errorf("envEntry malformed; %s, expected to be of form 'KEY=value'", envEntry)
-	}
-	key := envTokens[0]
-	val := envTokens[1]
-
-	if strings.HasPrefix(key, "#") {
+	if strings.HasPrefix(envEntry, "#") {
 		// Skip commented lines
 		return envKV{
 			Skip: true,
 		}, nil
 	}
+	const envSeparator = "="
+	envTokens := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(envEntry, "export")), envSeparator, 2)
+	if len(envTokens) != 2 {
+		return envKV{}, fmt.Errorf("envEntry malformed; %s, expected to be of form 'KEY=value'", envEntry)
+	}
+
+	key := envTokens[0]
+	val := envTokens[1]
 
 	// Remove quotes from the value if found
 	if len(val) >= 2 {
@@ -1043,6 +1043,7 @@ func parsEnvEntry(envEntry string) (envKV, error) {
 			val = val[1 : len(val)-1]
 		}
 	}
+
 	return envKV{
 		Key:   key,
 		Value: val,


### PR DESCRIPTION
avoid parsing error on comments without equal sign

Copied from https://github.com/minio/minio/blob/96ec8fcba1570d0c60efa77615a184b80960be64/cmd/common-main.go#L475C1-L509C2