### PR TITLE
Updating cert-manager instructions

### DIFF
--- a/docs/cert-manager.md
+++ b/docs/cert-manager.md
@@ -61,13 +61,13 @@ Then it creates a new tenant including the new `tenant-certmanager-tls` secret i
 Copy the cert-manager CA from the tenant certificate, this will allow Operator to trust the cert-manager CA and allow Operator to trust the Tenant certificate
 
 ```sh
-kubectl get secrets -n tenant-certmanager tenant-certmanager-tls -o=jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+kubectl get secrets -n tenant-certmanager tenant-certmanager-tls -o=jsonpath='{.data.tls\.crt}' | base64 -d > public.crt
 ```
 
 Create the secret
 
 ```sh
-kubectl create secret generic operator-ca-tls --from-file=ca.crt -n minio-operator
+kubectl create secret generic operator-ca-tls --from-file=public.crt -n minio-operator
 ```
 
 Restart the minio-operator


### PR DESCRIPTION
To fix: https://github.com/minio/operator/issues/1839

### Explanation:

Our pods are expecting `operator-ca-tls` secret to contain `public.crt` but in our instructions we are passing down `ca.crt` instead and hence we see this error:

<img width="695" alt="Screenshot 2023-10-31 at 10 40 59 AM" src="https://github.com/minio/operator/assets/6667358/cb6cc8c4-1d57-4b47-8132-029c8591a596">

### Solution:

Remove the secret from both namespaces and re-generate with proper and expected name `public.crt` and then all is back to normal with our cert-manager example we offer in our repo.

### Additional Information:

`cert-manager` example got broken in Operator's version `5.0.8` under PR https://github.com/minio/operator/pull/1716
```
Bugfix reload CA cert in `operator-ca-tls` secret (#1716)
```
About 2 months ago, since then `cert-manager` example isn't working.
back then the issue was: 
```
E1031 17:03:21.136276       1 main-controller.go:697] error syncing 'tenant-certmanager/myminio': missing 'public.crt' in minio-operator/operator-ca-tls secret
```
Then that issue got fixed but new one introduced: 
```
MountVolume.SetUp failed for volume "myminio-tls" : references non-existent secret key: public.crt
```
And solution is this PR
