### PR TITLE
mounting Operator CA in minio not longer required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ examples/.DS_Store
 testing/openshift/bundle/*
 examples/**/obj/
 .idea
+public.crt
+go_build_operator_
+operator.iml

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -476,7 +476,6 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 	serviceName := args.ServiceName
 	hostsTemplate := args.HostsTemplate
 	operatorVersion := args.OperatorVersion
-	operatorCATLS := args.OperatorCATLS
 	operatorImage := args.OperatorImage
 
 	var podVolumes []corev1.Volume
@@ -673,22 +672,6 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 		})
 	}
 
-	if operatorCATLS {
-		// Mount Operator CA TLS certificate to MinIO ~/cert/CAs
-		operatorCATLSSecretName := "operator-ca-tls"
-		certVolumeSources = append(certVolumeSources, []corev1.VolumeProjection{
-			{
-				Secret: &corev1.SecretProjection{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: operatorCATLSSecretName,
-					},
-					Items: []corev1.KeyToPath{
-						{Key: "public.crt", Path: "CAs/operator-ca.crt"},
-					},
-				},
-			},
-		}...)
-	}
 	// If KES is enable mount TLS certificate secrets
 	if t.HasKESEnabled() {
 		// External Client certificates will have priority over AutoCert generated certificates


### PR DESCRIPTION
### Objective:

To avoid mounting Operator's CA into MinIO if not required.

### Explanation:

This is the continuation of https://github.com/minio/operator/pull/1437 because of those changes, Tenants no longer need to communicate with Operator webservers over TLS to get startup arguments or create bucket DNS. Also when using `cert-manager` we don't need to use this CA certificate in the tenant as `cert-manager` is already doing this for us; so this is redundant, look:

<img width="1840" alt="Screenshot 2023-11-02 at 1 39 10 PM" src="https://github.com/minio/operator/assets/6667358/c1cd5c99-c2e4-4577-974b-f27f8fbbf518">

### Related PRs:

* https://github.com/minio/operator/pull/1515
* https://github.com/minio/operator/pull/1437

### Related issues:

* https://github.com/minio/operator/issues/1839 it will partially fix this issue as MinIO container will not mount the CA anymore but another code fix is needed to avoid propagating the secret with the CA, we can handle that in a different PR.

### Question:

And if it is required, why? and where? as I can't find a reason for these lines anymore.