### PR TITLE
add `-y` argument to microdnf

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -23,12 +23,12 @@ jobs:
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Set up swagger
         run: |
           go install github.com/go-swagger/go-swagger/cmd/swagger@latest
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --skip-publish --rm-dist --snapshot
+          args: release --skip-publish --clean --snapshot

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,4 +35,4 @@ issues:
         - deadcode
 
 service:
-  golangci-lint-version: 1.49.0 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.51.2 # use the fixed version to not introduce new linters unexpectedly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
 
-RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs
+RUN microdnf update -y --nodocs && microdnf install ca-certificates -y --nodocs
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 


### PR DESCRIPTION
Turns out microdnf now requires the `-y` flag otherwise gets stuck in interactive mode waiting, causing all the timeouts

```
=> [build 2/2] RUN microdnf update --nodocs && microdnf install ca-certificates --nodocs                                                             7.6s
 => => #  Reinstalling:      0 packages                                                                                                                   
 => => #  Upgrading:        38 packages                                                                                                                   
 => => #  Obsoleting:        0 packages                                                                                                                   
 => => #  Removing:          0 packages                                                                                                                   
 => => #  Downgrading:       0 packages                                                                                                                   
 => => # Is this ok [y/N]:
```

* Updating some of the runners versions:
docker/setup-buildx-action@v3
goreleaser/goreleaser-action@v5

* Removing deprecated option `--rm-dis` in favor of `--clean` in `goreleaser release` command
