### PR TITLE
Get tenant configured region and set on STS Options

### DIFF
--- a/pkg/controller/sts.go
+++ b/pkg/controller/sts.go
@@ -314,7 +314,7 @@ func GetPolicy(ctx context.Context, adminClient *madmin.AdminClient, policyName 
 }
 
 // AssumeRole invokes the AssumeRole method in the Minio Tenant
-func AssumeRole(ctx context.Context, c *Controller, tenant *miniov2.Tenant, sessionPolicy string, duration int) (*credentials.Value, error) {
+func AssumeRole(ctx context.Context, c *Controller, tenant *miniov2.Tenant, region string, sessionPolicy string, duration int) (*credentials.Value, error) {
 	client, accessKey, secretKey, err := getTenantClient(ctx, c, tenant)
 	if err != nil {
 		return nil, err
@@ -330,6 +330,7 @@ func AssumeRole(ctx context.Context, c *Controller, tenant *miniov2.Tenant, sess
 		SecretKey:       secretKey,
 		Policy:          sessionPolicy,
 		DurationSeconds: duration,
+		Location:        region,
 	}
 
 	stsAssumeRole := &credentials.STSAssumeRole{

--- a/pkg/controller/sts_handlers.go
+++ b/pkg/controller/sts_handlers.go
@@ -178,6 +178,13 @@ func (c *Controller) AssumeRoleWithWebIdentityHandler(w http.ResponseWriter, r *
 		return
 	}
 
+	info, err := adminClient.ServerInfo(ctx)
+	if err != nil {
+		writeSTSErrorResponse(w, true, ErrSTSInternalError, fmt.Errorf("Error communicating with tenant '%s': %s", tenant.Name, err))
+		return
+	}
+	region := info.Region
+
 	// Session Policy
 	sessionPolicyStr := r.Form.Get(stsPolicy)
 	var compactedSessionPolicy string
@@ -252,7 +259,7 @@ func (c *Controller) AssumeRoleWithWebIdentityHandler(w http.ResponseWriter, r *
 		durationInSeconds = duration
 	}
 
-	stsCredentials, err := AssumeRole(ctx, c, &tenant, bfCompact, durationInSeconds)
+	stsCredentials, err := AssumeRole(ctx, c, &tenant, region, bfCompact, durationInSeconds)
 	if err != nil {
 		writeSTSErrorResponse(w, true, ErrSTSInternalError, err)
 		return


### PR DESCRIPTION
Bugfix: when a region is set on tenant, the STS Handler fails because of missing region with the following error:

```
Error retrieving STS credentials: The authorization header is malformed; the region is wrong; 
expecting 'us-east-1'. 
```

On this example case the tenant was set to region `no-region-1`

```
mc admin info ALIAS --json | yq .info.region
no-region-1
```

Bugfix retrieves set region with madmin client and sets it in `credentials.STSAssumeRoleOptions`