### PR TITLE
To enable the utilization of the KES API Key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ examples/**/obj/
 public.crt
 go_build_operator_
 operator.iml
+go_build_github_com_minio_operator_cmd_operator

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -142,13 +142,25 @@ func minioEnvironmentVars(t *miniov2.Tenant, skipEnvVars map[string][]byte, opVe
 			Name:  "MINIO_KMS_KES_ENDPOINT",
 			Value: t.KESServiceEndpoint(),
 		}
-		envVarsMap["MINIO_KMS_KES_CERT_FILE"] = corev1.EnvVar{
-			Name:  "MINIO_KMS_KES_CERT_FILE",
-			Value: miniov2.MinIOCertPath + "/client.crt",
+		// The API key supersedes the certificate.
+		// If MINIO_KMS_KES_API_KEY is set,
+		// MINIO_KMS_KES_KEY_FILE and MINIO_KMS_KES_CERT_FILE are unnecessary and mutually exclusive.
+		// You should either utilize the API Key or the Certificate, but not both simultaneously.
+		useCert := true
+		for _, variable := range t.GetEnvVars() {
+			if variable.Name == "MINIO_KMS_KES_API_KEY" {
+				useCert = false // KES API Key will be used
+			}
 		}
-		envVarsMap["MINIO_KMS_KES_KEY_FILE"] = corev1.EnvVar{
-			Name:  "MINIO_KMS_KES_KEY_FILE",
-			Value: miniov2.MinIOCertPath + "/client.key",
+		if useCert {
+			envVarsMap["MINIO_KMS_KES_CERT_FILE"] = corev1.EnvVar{
+				Name:  "MINIO_KMS_KES_CERT_FILE",
+				Value: miniov2.MinIOCertPath + "/client.crt",
+			}
+			envVarsMap["MINIO_KMS_KES_KEY_FILE"] = corev1.EnvVar{
+				Name:  "MINIO_KMS_KES_KEY_FILE",
+				Value: miniov2.MinIOCertPath + "/client.key",
+			}
 		}
 		envVarsMap["MINIO_KMS_KES_CA_PATH"] = corev1.EnvVar{
 			Name:  "MINIO_KMS_KES_CA_PATH",


### PR DESCRIPTION
### Problem:

Presently, integrating the KES API Key within our Operator is not feasible because we consistently define the certificate through environment variables. If the API Key is set, Minio raises an error due to the inherent mutual exclusivity between these two methods.

```
ERROR The environment contains "MINIO_KMS_KES_API_KEY" as well as "MINIO_KMS_KES_KEY_FILE": ambigious KMS configuration
```

```
8bfe972bab (Allan Roger Reid       2023-02-21 17:43:01 -0800  792) 		logger.Fatal(errors.New("ambigious KMS configuration"), fmt.Sprintf("The environment contains %q as well as %q", kms.EnvKMSSecretKey, kms.EnvKESEndpoint))
```

### Solution:

If the KES API Key is set via environment variables, we exclusively utilize the KES API Key and refrain from setting the environment variables for the certificate.

### Explanation

The API key supersedes the certificate. If MINIO_KMS_KES_API_KEY is set, MINIO_KMS_KES_KEY_FILE and MINIO_KMS_KES_CERT_FILE are unnecessary and mutually exclusive. You should either utilize the API Key or the Certificate, but not both simultaneously.

### Additionally:

Later on, we can utilize the KES Go SDK to retrieve the API Key from within the Operator. However, for the time being, we can at least directly extract it from the Environment Variable set by the user in our Tenant Spec.

### Testing:

<img width="507" alt="Screenshot 2023-11-14 at 8 42 56 AM" src="https://github.com/minio/operator/assets/6667358/39e1281b-994d-4ae6-9def-222be2031b99">

<img width="655" alt="Screenshot 2023-11-14 at 8 42 41 AM" src="https://github.com/minio/operator/assets/6667358/769fd6eb-dc46-40df-947d-2c71679cc3b9">

### Supported since:

```
KES: Commit 9bd31a Thu Feb 9 11:52:27 2023
```

```
MinIO: Commit 74887c73 Tue Feb 14 16:19:20 2023
```