### PR TITLE
fix: readonly system and console tls secretName

### DIFF
--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -94,7 +94,9 @@ operator:
   # An array of `Volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`__ which the Operator can mount to pods.
   #
   # The volumes must exist *and* be accessible to the Operator pods.
-  volumes: [ ]
+  volumes:
+    - name: tmp
+      emptyDir: {}
   ###
   # An array of volume mount points associated to each Operator container.
   # 
@@ -107,7 +109,10 @@ operator:
   #      mountPath: /path/to/mount
   #
   # The ``name`` field must correspond to an entry in the ``volumes`` array.
-  volumeMounts: [ ]
+  volumeMounts:
+    - name: tmp
+      readOnly: false
+      mountPath: /tmp
   ###
   # Any `Node Selectors <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/>`__ to apply to Operator pods.
   #

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -94,9 +94,7 @@ operator:
   # An array of `Volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`__ which the Operator can mount to pods.
   #
   # The volumes must exist *and* be accessible to the Operator pods.
-  volumes:
-    - name: tmp
-      emptyDir: {}
+  volumes: [ ]
   ###
   # An array of volume mount points associated to each Operator container.
   # 
@@ -109,10 +107,7 @@ operator:
   #      mountPath: /path/to/mount
   #
   # The ``name`` field must correspond to an entry in the ``volumes`` array.
-  volumeMounts:
-    - name: tmp
-      readOnly: false
-      mountPath: /tmp
+  volumeMounts: [ ]
   ###
   # Any `Node Selectors <https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/>`__ to apply to Operator pods.
   #
@@ -296,7 +291,9 @@ console:
   # An array of `Volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`__ which the Operator Console can mount to pods.
   #
   # The volumes must exist *and* be accessible to the Console pods.
-  volumes: [ ]
+  volumes:
+    - name: tmp
+      emptyDir: {}
   ###
   # An array of volume mount points associated to each Operator Console container.
   # 
@@ -309,4 +306,7 @@ console:
   #      mountPath: /path/to/mount
   #
   # The ``name`` field must correspond to an entry in the ``volumes`` array.
-  volumeMounts: [ ]
+  volumeMounts:
+    - name: tmp
+      readOnly: false
+      mountPath: /tmp/certs/CAs

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -322,6 +322,6 @@ spec:
                       path: CAs/tls.crt
                     - key: tls.key
                       path: tls.key
-                  name: operator-console-tls
+                  name: console-tls
                   optional: true
       serviceAccountName: console-sa

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -304,6 +304,8 @@ spec:
           volumeMounts:
             - mountPath: /tmp/certs
               name: tls-certificates
+            - mountPath: /tmp/certs/CAs
+              name: tmp
       volumes:
         - name: tls-certificates
           projected:
@@ -324,4 +326,6 @@ spec:
                       path: tls.key
                   name: console-tls
                   optional: true
+        - name: tmp
+          emptyDir: {}
       serviceAccountName: console-sa

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -41,6 +41,13 @@ spec:
               value: "off"
             - name: OPERATOR_STS_ENABLED
               value: "on"
+          volumeMounts:
+            - name: tmp
+              readOnly: false
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -41,13 +41,6 @@ spec:
               value: "off"
             - name: OPERATOR_STS_ENABLED
               value: "on"
-          volumeMounts:
-            - name: tmp
-              readOnly: false
-              mountPath: /tmp
-      volumes:
-        - name: tmp
-          emptyDir: {}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
fix https://github.com/minio/operator/issues/1859
fix: readonly system and console tls secretName
according to this https://github.com/allanrogerr/public/wiki/minio-%E2%80%90-operator-%E2%80%90-Unable-to-load-certs-...-read%E2%80%90only-file-system-%7C-secrets-incorrectly-named-as-operator%E2%80%90console%E2%80%90tls