### PR TITLE
Add policies for users

### DIFF
--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -799,8 +799,9 @@ TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. +
  An array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secrets] to use for generating MinIO users during tenant provisioning. + 
  Each element in the array is an object consisting of a key-value pair `name: <string>`, where the `<string>` references an opaque Kubernetes secret. + 
  Each referenced Kubernetes secret must include the following fields: + 
- * `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user + 
- * `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user + 
+ * `ACCESS_KEY` - The "Username" for the MinIO user +
+ * `SECRET_KEY` - The "Password" for the MinIO user +
+ * `POLICY` - The "Policy" for the MinIO user +
  The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
 
 |*`buckets`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-bucket[$$Bucket$$] array__ 

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -247,7 +247,7 @@ tenant:
   ###
   # Array of Kubernetes secrets from which the Operator generates MinIO users during tenant provisioning.
   #
-  # Each secret should specify the ``CONSOLE_ACCESS_KEY`` and ``CONSOLE_SECRET_KEY`` as the access key and secret key for that user.
+  # Each secret should specify the ``ACCESS_KEY``, ``SECRET_KEY``, ``POLICY`` as the access key, secret key, and policy for that user.
   users: [ ]
   ###
   # The `PodManagement <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy>`__ policy for MinIO Tenant Pods. 

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -323,10 +323,12 @@ type TenantSpec struct {
 	//
 	// Each referenced Kubernetes secret must include the following fields: +
 	//
-	// * `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user +
+	// * `ACCESS_KEY` - The "Username" for the MinIO user +
 	//
-	// * `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user +
+	// * `SECRET_KEY` - The "Password" for the MinIO user +
 	//
+        // * `POLICY` = The "Policy" for the MinIO user +
+        //
 	// The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
 	// +optional
 	Users []*corev1.LocalObjectReference `json:"users,omitempty"`


### PR DESCRIPTION
Piggybacking off of the work presented in #1359 (thank you, @drivebyer). Fixes #629

Not sure of the preferred testing method, but this should allow you to decoratively create users with specific policies, or no policy at all. We'd still need a separate PR for allowing declaration of policies as well, and if we do, then those policies must be created before we create users.

Happy to workshop this to be better if you have any suggestions! :)