### PR TITLE
Upgrade base image to to Ubi minimal 9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2 as build
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3 as build
 
 RUN microdnf update -y --nodocs && microdnf install ca-certificates -y --nodocs
 


### PR DESCRIPTION
Upgrade base image to to Ubi minimal 9.3

https://catalog.redhat.com/software/containers/ubi9/ubi-minimal/615bd9b4075b022acc111bf5?architecture=amd64&image=654d0f69e3a98d1bb1e031d2&container-tabs=overview