### PR TITLE
Fix Openshift test

### DIFF
--- a/bundles/certified-operators/5.0.11/manifests/minio-operator.clusterserviceversion.yaml
+++ b/bundles/certified-operators/5.0.11/manifests/minio-operator.clusterserviceversion.yaml
@@ -764,4 +764,4 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator.v5.0.9
+  replaces: minio-operator.v5.0.10

--- a/bundles/redhat-marketplace/5.0.11/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/bundles/redhat-marketplace/5.0.11/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -766,4 +766,4 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator-rhmp.v5.0.9
+  replaces: minio-operator-rhmp.v5.0.10

--- a/certified-operators/manifests/minio-operator.clusterserviceversion.yaml
+++ b/certified-operators/manifests/minio-operator.clusterserviceversion.yaml
@@ -766,4 +766,4 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator.v5.0.9
+  replaces: minio-operator.v5.0.10

--- a/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -768,4 +768,4 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator-rhmp.v5.0.9
+  replaces: minio-operator-rhmp.v5.0.10

--- a/olm.sh
+++ b/olm.sh
@@ -74,7 +74,7 @@ for catalog in "${redhatCatalogs[@]}"; do
   # You can read the documentation at link below:
   # https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/understanding-the-operator-lifecycle-manager-olm#olm-upgrades_olm-understanding-olm
   echo "To provide replacement for upgrading Operator..."
-  PREV_VERSION=$(curl -s "https://catalog.redhat.com/api/containers/v1/operators/bundles?channel_name=stable&package=${package}&organization=${catalog}&include=data.version,data.csv_name,data.ocp_version" | jq '.data | max_by(.version).csv_name' -r)
+  PREV_VERSION=$(curl -s "https://catalog.redhat.com/api/containers/v1/operators/bundles?channel_name=stable&package=${package}&organization=${catalog}&include=data.version,data.csv_name,data.ocp_version" | jq '.data |  max_by(.version | split(".") | map(tonumber)).csv_name' -r)
   echo "replaces: $PREV_VERSION"
   yq -i e ".spec.replaces |= \"${PREV_VERSION}\"" bundles/$catalog/$RELEASE/manifests/$package.clusterserviceversion.yaml
 

--- a/redhat-marketplace/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/redhat-marketplace/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -768,4 +768,4 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator-rhmp.v5.0.9
+  replaces: minio-operator-rhmp.v5.0.10


### PR DESCRIPTION
* Command opm changed default --pull-tool to `none` breaking tests.
* Now CSV include a `.spec.replaces` argument, that was breaking tests. Ignoring for tests
* Make sure the bundle used is downloaded and exists
* fix: olm.sh was not sorting latest published version for  `.spec.replaces`. Sorting semver string properly now

> [!NOTE]  
> Tests are passing, will publish v5.0.11 to Openshit Operator Hub now