### PR TITLE
Prevent add `spec.replaces` on new Openshift catalog

### DIFF
--- a/bundles/certified-operators/5.0.11/manifests/minio-operator.clusterserviceversion.yaml
+++ b/bundles/certified-operators/5.0.11/manifests/minio-operator.clusterserviceversion.yaml
@@ -764,4 +764,3 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator.v5.0.10

--- a/bundles/community-operators/5.0.11/manifests/minio-operator.clusterserviceversion.yaml
+++ b/bundles/community-operators/5.0.11/manifests/minio-operator.clusterserviceversion.yaml
@@ -764,4 +764,3 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: "null"

--- a/bundles/redhat-marketplace/5.0.11/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/bundles/redhat-marketplace/5.0.11/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -760,10 +760,9 @@ spec:
     url: https://min.io
   relatedImages:
     - image: quay.io/minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
-      name: console
-    - image: quay.io/minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
       name: minio-operator
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
+    - image: quay.io/minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
+      name: console
   version: 5.0.11
-  replaces: minio-operator-rhmp.v5.0.10

--- a/certified-operators/manifests/minio-operator.clusterserviceversion.yaml
+++ b/certified-operators/manifests/minio-operator.clusterserviceversion.yaml
@@ -766,4 +766,3 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: minio-operator.v5.0.10

--- a/community-operators/manifests/minio-operator.clusterserviceversion.yaml
+++ b/community-operators/manifests/minio-operator.clusterserviceversion.yaml
@@ -766,4 +766,3 @@ spec:
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
   version: 5.0.11
-  replaces: "null"

--- a/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -762,10 +762,9 @@ spec:
     url: https://min.io
   relatedImages:
     - image: minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
-      name: console
-    - image: minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
       name: minio-operator
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
+    - image: minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
+      name: console
   version: 5.0.11
-  replaces: minio-operator-rhmp.v5.0.10

--- a/redhat-marketplace/manifests/minio-operator-rhmp.clusterserviceversion.yaml
+++ b/redhat-marketplace/manifests/minio-operator-rhmp.clusterserviceversion.yaml
@@ -762,10 +762,9 @@ spec:
     url: https://min.io
   relatedImages:
     - image: quay.io/minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
-      name: console
-    - image: quay.io/minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
       name: minio-operator
     - image: quay.io/minio/minio@sha256:91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3
       name: minio-91866cdaad4cc11d2f86056b234f33f3768a44adc600ea37c225708c83076bc3-annotation
+    - image: quay.io/minio/operator@sha256:3ab501c476f269c4e4fc84017543ff7f6c8209ed474d77de472311472ba2e2ff
+      name: console
   version: 5.0.11
-  replaces: minio-operator-rhmp.v5.0.10


### PR DESCRIPTION
Evaluates if a CSV have already published to the catalog, if no then we should not add the `spec.replaces` annotation.
More details on [Support case](https://connect.redhat.com/support/technology-partner/#/case/03671253)