### PR TITLE
remove pointer from `Users` field

### DIFF
--- a/api/tenant-add-handlers.go
+++ b/api/tenant-add-handlers.go
@@ -54,7 +54,7 @@ func createTenant(ctx context.Context, params operator_api.CreateTenantParams, c
 
 	accessKey, secretKey := getTenantCredentials(tenantReq.AccessKey, tenantReq.SecretKey)
 	tenantName := *tenantReq.Name
-	var users []*corev1.LocalObjectReference
+	var users []corev1.LocalObjectReference
 
 	// delete secrets created if an errors occurred during tenant creation,
 	defer func() {
@@ -387,7 +387,7 @@ func deleteSecretsIfTenantCreationFails(ctx context.Context, mError *models.Erro
 	}
 }
 
-func setTenantActiveDirectoryConfig(ctx context.Context, clientSet K8sClientI, tenantReq *models.CreateTenantRequest, tenantConfigurationENV map[string]string, users []*corev1.LocalObjectReference) (map[string]string, []*corev1.LocalObjectReference, error) {
+func setTenantActiveDirectoryConfig(ctx context.Context, clientSet K8sClientI, tenantReq *models.CreateTenantRequest, tenantConfigurationENV map[string]string, users []corev1.LocalObjectReference) (map[string]string, []corev1.LocalObjectReference, error) {
 	imm := true
 	serverAddress := *tenantReq.Idp.ActiveDirectory.URL
 	tlsSkipVerify := tenantReq.Idp.ActiveDirectory.SkipTLSVerification
@@ -427,7 +427,7 @@ func setTenantActiveDirectoryConfig(ctx context.Context, clientSet K8sClientI, t
 	// Attach the list of LDAP user DNs that will be administrator for the Tenant
 	for i, userDN := range tenantReq.Idp.ActiveDirectory.UserDNS {
 		userSecretName := fmt.Sprintf("%s-user-%d", *tenantReq.Name, i)
-		users = append(users, &corev1.LocalObjectReference{Name: userSecretName})
+		users = append(users, corev1.LocalObjectReference{Name: userSecretName})
 
 		userSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -466,11 +466,11 @@ func setTenantOIDCConfig(tenantReq *models.CreateTenantRequest, tenantConfigurat
 	return tenantConfigurationENV
 }
 
-func setTenantBuiltInUsers(ctx context.Context, clientSet K8sClientI, tenantReq *models.CreateTenantRequest, users []*corev1.LocalObjectReference) ([]*corev1.LocalObjectReference, error) {
+func setTenantBuiltInUsers(ctx context.Context, clientSet K8sClientI, tenantReq *models.CreateTenantRequest, users []corev1.LocalObjectReference) ([]corev1.LocalObjectReference, error) {
 	imm := true
 	for i := 0; i < len(tenantReq.Idp.Keys); i++ {
 		userSecretName := fmt.Sprintf("%s-user-%d", *tenantReq.Name, i)
-		users = append(users, &corev1.LocalObjectReference{Name: userSecretName})
+		users = append(users, corev1.LocalObjectReference{Name: userSecretName})
 		userSecret := corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: userSecretName,

--- a/kubectl-minio/cmd/resources/tenant.go
+++ b/kubectl-minio/cmd/resources/tenant.go
@@ -133,7 +133,7 @@ func NewTenant(opts *TenantOptions, userSecret *v1.Secret) (*miniov2.Tenant, err
 			Mountpath:       helpers.MinIOMountPath,
 			KES:             tenantKESConfig(opts.Name, opts.KmsSecret, opts.KesImage),
 			ImagePullSecret: v1.LocalObjectReference{Name: opts.ImagePullSecret},
-			Users: []*v1.LocalObjectReference{
+			Users: []v1.LocalObjectReference{
 				{
 					Name: userSecret.Name,
 				},

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -329,7 +329,7 @@ type TenantSpec struct {
 	//
 	// The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
 	// +optional
-	Users []*corev1.LocalObjectReference `json:"users,omitempty"`
+	Users []corev1.LocalObjectReference `json:"users,omitempty"`
 	// *Optional* +
 	//
 	// Create buckets when creating a new tenant. Skip if bucket with given name already exists

--- a/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
@@ -739,14 +739,8 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 	}
 	if in.Users != nil {
 		in, out := &in.Users, &out.Users
-		*out = make([]*v1.LocalObjectReference, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(v1.LocalObjectReference)
-				**out = **in
-			}
-		}
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	if in.Buckets != nil {
 		in, out := &in.Buckets, &out.Buckets

--- a/pkg/client/applyconfiguration/minio.min.io/v2/tenantspec.go
+++ b/pkg/client/applyconfiguration/minio.min.io/v2/tenantspec.go
@@ -53,7 +53,7 @@ type TenantSpecApplyConfiguration struct {
 	SideCars                  *SideCarsApplyConfiguration                  `json:"sideCars,omitempty"`
 	ExposeServices            *ExposeServicesApplyConfiguration            `json:"exposeServices,omitempty"`
 	ServiceMetadata           *ServiceMetadataApplyConfiguration           `json:"serviceMetadata,omitempty"`
-	Users                     []*v1.LocalObjectReference                   `json:"users,omitempty"`
+	Users                     []v1.LocalObjectReference                    `json:"users,omitempty"`
 	Buckets                   []BucketApplyConfiguration                   `json:"buckets,omitempty"`
 	Logging                   *LoggingApplyConfiguration                   `json:"logging,omitempty"`
 	Configuration             *v1.LocalObjectReference                     `json:"configuration,omitempty"`
@@ -301,11 +301,8 @@ func (b *TenantSpecApplyConfiguration) WithServiceMetadata(value *ServiceMetadat
 // WithUsers adds the given value to the Users field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Users field.
-func (b *TenantSpecApplyConfiguration) WithUsers(values ...*v1.LocalObjectReference) *TenantSpecApplyConfiguration {
+func (b *TenantSpecApplyConfiguration) WithUsers(values ...v1.LocalObjectReference) *TenantSpecApplyConfiguration {
 	for i := range values {
-		if values[i] == nil {
-			panic("nil value passed to WithUsers")
-		}
 		b.Users = append(b.Users, values[i])
 	}
 	return b


### PR DESCRIPTION
This fixes the problem when invoking `/k8s/update-codegen.sh` code generator.

```
 make binary
# github.com/minio/operator/pkg/client/applyconfiguration/minio.min.io/v2
pkg/client/applyconfiguration/minio.min.io/v2/tenantspec.go:309:29: cannot use *values[i] (variable of type "k8s.io/api/core/v1".LocalObjectReference) as *"k8s.io/api/core/v1".LocalObjectReference value in argument to append
make: *** [binary] Error 1
```

