### PR TITLE
fix: Infinite reconciliation for existing buckets

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1420,6 +1420,8 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 			return WrapResult(Result{RequeueAfter: time.Second * 5}, err)
 		} else if create {
 			c.recorder.Event(tenant, corev1.EventTypeNormal, "BucketsCreated", "Buckets created")
+		} else {
+			c.recorder.Event(tenant, corev1.EventTypeNormal, "BucketsCreated", "Buckets already exist")
 		}
 	}
 


### PR DESCRIPTION
controller.createBuckets passes return (created, error) of tenant.createBuckets which can be also `false, nil` when buckets already exist

in logs this message is dumped every 20 seconds

```
helper.go:776] Your previous request to create the named bucket succeeded and you already own it.
```
