### PR TITLE
Fix namespace reference in Helm chart NOTES.txt

### DIFF
--- a/helm/operator/templates/NOTES.txt
+++ b/helm/operator/templates/NOTES.txt
@@ -9,7 +9,7 @@ metadata:
     kubernetes.io/service-account.name: console-sa
 type: kubernetes.io/service-account-token
 EOF
-kubectl -n minio-operator  get secret console-sa-secret -o jsonpath="{.data.token}" | base64 --decode
+kubectl -n {{ .Release.Namespace }} get secret console-sa-secret -o jsonpath="{.data.token}" | base64 --decode
 
 2. Get the Operator Console URL by running these commands:
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/console 9090:9090


### PR DESCRIPTION
# Change: Fix an issue in the NOTES.txt file of the Helm chart

Issue: While deploying the MinIO Operator using Helm, the command suggested in the NOTES.txt file was incorrect. It instructs users to retrieve a Secret in the "minio-operator" namespace, while the Secret is actually located in the namespace specified by the user.

Cause: In the NOTES.txt file, the namespace was hardcoded as "minio-operator".

Solution: I changed the hardcoded "minio-operator" to `{{ .Release.Namespace }}`. This way, when Helm deploys the chart, it will replace the placeholder with the actual namespace specified by the user.

I've attached the following screenshot to highlight the differences before and after the change.

|  | screenshot |
|---|---|
| before | ![before-minio-helm](https://github.com/minio/operator/assets/58482090/34cfdbfc-f939-4f6b-847e-fd5dda73ed86) |
|  after | ![after-modify-note](https://github.com/minio/operator/assets/58482090/ede3e749-129b-475e-8e66-80fdd5458a85) |
