### PR TITLE
Add a PoolLabel selector to PodAntiAffinity

### DIFF
--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -85,11 +85,18 @@ func Pool(opts *TenantOptions, volumes int32, q resource.Quantity) miniov2.Pool 
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 					{
 						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      miniov2.TenantLabel,
-								Operator: "In",
-								Values:   []string{opts.Name},
-							}},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      miniov2.TenantLabel,
+									Operator: "In",
+									Values:   []string{opts.Name},
+								},
+								{
+									Key:      miniov2.PoolLabel,
+									Operator: "In",
+									Values:   []string{opts.Name},
+								},
+							},
 						},
 						TopologyKey: "kubernetes.io/hostname",
 					},


### PR DESCRIPTION
Add a PoolLabel selector to PodAntiAffinity to ensure that the kubectl-minio plugin expand command allows pod in one pool to be scheduled on available nodes when pods from another pool have already been scheduled on those same nodes

See detailed tests [here](https://github.com/allanrogerr/public/wiki/operator%E2%80%90949)

Fixes https://github.com/minio/operator/issues/949