### PR TITLE
Fix ingress creation for DNS enabled tenant

### DIFF
--- a/helm/tenant/templates/api-ingress.yaml
+++ b/helm/tenant/templates/api-ingress.yaml
@@ -38,4 +38,20 @@ spec:
                   {{- else }}
                   name: http-minio
                   {{- end }}
+    {{- if .Values.tenant.features.bucketDNS }}
+    - host: "*.{{ .Values.ingress.api.host }}"
+      http:
+        paths:
+          - path: {{ .Values.ingress.api.path }}
+            pathType: {{ .Values.ingress.api.pathType }}
+            backend:
+              service:
+                name: minio
+                port:
+                  {{- if or .Values.tenant.certificate.requestAutoCert (not (empty .Values.tenant.certificate.externalCertSecret)) }}
+                  name: https-minio
+                  {{- else }}
+                  name: http-minio
+                  {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Create an extra ingress rule for wildcard api host if dns feature is enabled. Need to configure the TLS block accordingly in values.yaml

Fixes #1796