### PR TITLE
Optionnally install CRDs in the operator helm chart

### DIFF
--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5197,3 +5198,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/helm/operator/templates/sts.min.io_policybindings.yaml
+++ b/helm/operator/templates/sts.min.io_policybindings.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.installCRDs }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -73,3 +74,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -1,3 +1,8 @@
+# If true, CRD resources will be installed as part of the Helm chart.
+# If enabled, when uninstalling CRD resources will be deleted causing
+# all installed custom resources to be DELETED.
+installCRDs: true
+
 ###
 # Root key for Operator Helm Chart
 operator:


### PR DESCRIPTION
Add installCRDs flag in the operator helm chart to be able to not install the CRDs at the same time of the operator itself.

Fix #1915