### PR TITLE
buildx to create container image and load in local registry.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ verify: getdeps govet lint
 binary:
 	@CGO_ENABLED=0 GOOS=linux go build -trimpath --ldflags $(LDFLAGS) -o minio-operator ./cmd/operator
 
-operator: assets binary
+operator: binary
 
 docker: operator
-	@docker buildx build --no-cache --platform linux/amd64,linux/arm64 -t $(TAG) .
+	@docker buildx build --no-cache --load --platform linux/$(GOARCH) -t $(TAG) .
 
 build: regen-crd verify plugin operator docker
 


### PR DESCRIPTION
`--platform linux/amd64,linux/arm64 --load` does not work because local docker registry can't host different architectures

`$(GOOS)/$(GOARCH)` would also not work because causes an error pulling ubi image from redhat

```
ERROR: failed to solve: registry.access.redhat.com/ubi9/ubi-micro:latest: no match for platform in manifest: not found
```