### PR TITLE
bugfix: upgrades not running

### DIFF
--- a/pkg/controller/upgrades.go
+++ b/pkg/controller/upgrades.go
@@ -41,6 +41,8 @@ const (
 	version430 = "v4.3.0"
 	version45  = "v4.5"
 	version500 = "v5.0.0"
+	// currentVersion will point to the latest released update version
+	currentVersion = version500
 )
 
 // Legacy const
@@ -62,7 +64,13 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 		version500: c.upgrade500,
 	}
 
-	// if the version is not empty, this is not a new tenant, upgrade accordingly
+	// if tenant has no version we mark it with latest version upgrade released
+	if tenant.Status.SyncVersion == "" {
+		tenant.Status.SyncVersion = currentVersion
+		return c.updateTenantSyncVersion(ctx, tenant, version500)
+	}
+
+	// if the version is empty, upgrades might not been applied, we apply them all
 	if tenant.Status.SyncVersion != "" {
 		currentSyncVersion, err := version.NewVersion(tenant.Status.SyncVersion)
 		if err != nil {


### PR DESCRIPTION
In the past we used to run all upgrades when the `.status.syncVersion` field was empty, after change introduced on https://github.com/minio/operator/pull/1512 we are conscidering this field being empty as an indicator that the tenant is "brand new".

https://github.com/minio/operator/commit/6701b4fca4b77d7942273f36692098436d108f72#diff-1657476cde2d3b4184231b8d4ce3cb4db7615db642cf329dcb314db0ce190fe6R66

That comes with a problem: no upgrade ever will run on tenants created after v5.0.0 was released, so if we publish a new Upgrade, it will not run, ever.


This fix approach is to set `.status.syncVersion` (when empty) with the latest published upgrade, right now "v5.0.0" so that future upgrades can actually run