### PR TITLE
feature: env variables in configuration secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ TAG ?= "minio/operator:$(VERSION)"
 SHA ?= $(shell git rev-parse --short HEAD)
 LDFLAGS ?= "-s -w -X github.com/minio/operator/pkg.ReleaseTag=$(VERSIONV) -X github.com/minio/operator/pkg.Version=$(VERSION) -X github.com/minio/operator/pkg.ShortCommitID=$(SHA)"
 GOPATH := $(shell go env GOPATH)
+GOBIN := $(shell go env GOBIN)
 GOARCH := $(shell go env GOARCH)
 GOOS := $(shell go env GOOS)
 
@@ -66,7 +67,7 @@ clean:
 
 regen-crd:
 	@go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
-	@${GOPATH}/bin/controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true paths="./..." output:crd:artifacts:config=$(KUSTOMIZE_CRDS)
+	@${GOBIN}/controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true paths="./..." output:crd:artifacts:config=$(KUSTOMIZE_CRDS)
 	@sed 's#namespace: minio-operator#namespace: {{ .Release.Namespace }}#g' resources/base/crds/minio.min.io_tenants.yaml > $(HELM_TEMPLATES)/minio.min.io_tenants.yaml
 	@sed 's#namespace: minio-operator#namespace: {{ .Release.Namespace }}#g' resources/base/crds/sts.min.io_policybindings.yaml > $(HELM_TEMPLATES)/sts.min.io_policybindings.yaml
 

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -822,7 +822,7 @@ TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. +
  Enable JSON, Anonymous logging for MinIO tenants.
 
 |*`configuration`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
-|*Optional* + 
+|*Required* + 
  Specify a secret that contains additional environment variable configurations to be used for the MinIO pools. The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
 
 |*`initContainers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core[$$Container$$] array__ 

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -5038,6 +5038,7 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
             required:
+            - configuration
             - pools
             type: object
           status:

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -209,6 +209,54 @@ const PrometheusNamespace = "PROMETHEUS_NAMESPACE"
 // PrometheusName is the name of the prometheus
 const PrometheusName = "PROMETHEUS_NAME"
 
+// RootUserEnv Env variable containing the root username
+const RootUserEnv = "MINIO_ROOT_USER"
+
+// RootUserPassword Env variable containing the root user password
+const RootUserPassword = "MINIO_ROOT_PASSWORD"
+
+// StorageClassEnv Env variable for erasure code parity
+const StorageClassEnv = "MINIO_STORAGE_CLASS_STANDARD"
+
+// AccessKeyEnv Env variable (deprecated) containing the root user access Key
+// See note https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management/minio-user-management.html#minio-root-user
+const AccessKeyEnv = "MINIO_ACCESS_KEY"
+
+// SecretKeyEnv  Env variable (deprecated) containing the root user secret Key
+// See note https://min.io/docs/minio/kubernetes/upstream/administration/identity-access-management/minio-user-management.html#minio-root-user
+const SecretKeyEnv = "MINIO_SECRET_KEY"
+
+// MinioArgsEnv Env variable for the start arguments of the command `minio server`
+const MinioArgsEnv = "MINIO_ARGS"
+
+// MinioUpdateEnv env variable enables `mc admin update` style updates to MinIO binaries
+// within the container, only operator is supposed to perform these operations.
+const MinioUpdateEnv = "MINIO_UPDATE"
+
+// MinioSignPubKey Public key to sign minio binaries env variable
+const MinioSignPubKey = "MINIO_UPDATE_MINISIGN_PUBKEY"
+
+// MinioOperatorVersionEnv Env variable that stores Operator version for the tenant
+const MinioOperatorVersionEnv = "MINIO_OPERATOR_VERSION"
+
+// MinioPrometheusJobIdEnv Env variable to set Prometheus job ID
+const MinioPrometheusJobIdEnv = "MINIO_PROMETHEUS_JOB_ID"
+
+// MinioKMSKESEndpointEnv Env variable to set KMS KES endpoint URL
+const MinioKMSKESEndpointEnv = "MINIO_KMS_KES_ENDPOINT"
+
+// MinioKMSKESCertFileEnv Env variable to contains KES client cert file path
+const MinioKMSKESCertFileEnv = "MINIO_KMS_KES_CERT_FILE"
+
+// MinioKMSKESKeyFileEnv Env variable contains KES client private key file path
+const MinioKMSKESKeyFileEnv = "MINIO_KMS_KES_KEY_FILE"
+
+// MinioKMSKESCAPathEnv Env variable contains KEY client CA public that issued the client certificate
+const MinioKMSKESCAPathEnv = "MINIO_KMS_KES_CA_PATH"
+
+// MinioKMSKESKeyNameEnv If provided, use this as the name of the key that KES creates on the KMS backend
+const MinioKMSKESKeyNameEnv = "MINIO_KMS_KES_KEY_NAME"
+
 // DefaultPrometheusNamespace is the default namespace for prometheus
 const DefaultPrometheusNamespace = "default"
 

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -340,12 +340,12 @@ type TenantSpec struct {
 	// Enable JSON, Anonymous logging for MinIO tenants.
 	// +optional
 	Logging *Logging `json:"logging,omitempty"`
-	// *Optional* +
+	// *Required* +
 	//
 	// Specify a secret that contains additional environment variable configurations to be used for the MinIO pools.
 	// The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
-	// +optional
-	Configuration *corev1.LocalObjectReference `json:"configuration,omitempty"`
+	// +Required
+	Configuration *corev1.LocalObjectReference `json:"configuration"`
 	// *Optional* +
 	//
 	// Add custom initContainers to StatefulSet

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -43,6 +43,7 @@ type sharedInformerFactory struct {
 	lock             sync.Mutex
 	defaultResync    time.Duration
 	customResync     map[reflect.Type]time.Duration
+	transform        cache.TransformFunc
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -77,6 +78,14 @@ func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFu
 func WithNamespace(namespace string) SharedInformerOption {
 	return func(factory *sharedInformerFactory) *sharedInformerFactory {
 		factory.namespace = namespace
+		return factory
+	}
+}
+
+// WithTransform sets a transform on all informers.
+func WithTransform(transform cache.TransformFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.transform = transform
 		return factory
 	}
 }
@@ -185,6 +194,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	}
 
 	informer = newFunc(f.client, resyncPeriod)
+	informer.SetTransform(f.transform)
 	f.informers[informerType] = informer
 
 	return informer

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -28,6 +28,8 @@ const (
 const (
 	// OperatorRuntimeEnv tells us which runtime we have. (EKS, Rancher, OpenShift, etc...)
 	OperatorRuntimeEnv = "MINIO_OPERATOR_RUNTIME"
+	// BucketDNSEnv DNS webhook endpoint env variable name
+	BucketDNSEnv = "MINIO_DNS_WEBHOOK_ENDPOINT"
 	// OperatorRuntimeK8s is the default runtime when no specific runtime is set
 	OperatorRuntimeK8s Runtime = "K8S"
 	// OperatorRuntimeEKS is the EKS runtime flag

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -827,8 +827,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 		}
 		return WrapResult(Result{}, err)
 	}
-	// get existing configuration from config.env
-	err = c.saveTenantConfiguration(ctx, tenant)
+
 	if err != nil {
 		return WrapResult(Result{}, err)
 	}

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -828,7 +828,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 		return WrapResult(Result{}, err)
 	}
 	// get existing configuration from config.env
-	skipEnvVars, err := c.getTenantConfiguration(ctx, tenant)
+	err = c.saveTenantConfiguration(ctx, tenant)
 	if err != nil {
 		return WrapResult(Result{}, err)
 	}
@@ -1034,15 +1034,13 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 				return WrapResult(Result{}, err)
 			}
 			ss = statefulsets.NewPool(&statefulsets.NewPoolArgs{
-				Tenant:          tenant,
-				SkipEnvVars:     skipEnvVars,
-				Pool:            &pool,
-				PoolStatus:      &tenant.Status.Pools[i],
-				ServiceName:     tenant.MinIOHLServiceName(),
-				HostsTemplate:   c.hostsTemplate,
-				OperatorVersion: c.operatorVersion,
-				OperatorCATLS:   operatorCATLSExists,
-				OperatorImage:   c.operatorImage,
+				Tenant:        tenant,
+				Pool:          &pool,
+				PoolStatus:    &tenant.Status.Pools[i],
+				ServiceName:   tenant.MinIOHLServiceName(),
+				HostsTemplate: c.hostsTemplate,
+				OperatorCATLS: operatorCATLSExists,
+				OperatorImage: c.operatorImage,
 			})
 			ss, err = c.kubeClientSet.AppsV1().StatefulSets(tenant.Namespace).Create(ctx, ss, cOpts)
 			if err != nil {
@@ -1244,15 +1242,13 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 		for i, pool := range tenant.Spec.Pools {
 			// Now proceed to make the yaml changes for the tenant statefulset.
 			ss := statefulsets.NewPool(&statefulsets.NewPoolArgs{
-				Tenant:          tenant,
-				SkipEnvVars:     skipEnvVars,
-				Pool:            &pool,
-				PoolStatus:      &tenant.Status.Pools[i],
-				ServiceName:     tenant.MinIOHLServiceName(),
-				HostsTemplate:   c.hostsTemplate,
-				OperatorVersion: c.operatorVersion,
-				OperatorCATLS:   operatorCATLSExists,
-				OperatorImage:   c.operatorImage,
+				Tenant:        tenant,
+				Pool:          &pool,
+				PoolStatus:    &tenant.Status.Pools[i],
+				ServiceName:   tenant.MinIOHLServiceName(),
+				HostsTemplate: c.hostsTemplate,
+				OperatorCATLS: operatorCATLSExists,
+				OperatorImage: c.operatorImage,
 			})
 			if _, err = c.kubeClientSet.AppsV1().StatefulSets(tenant.Namespace).Update(ctx, ss, uOpts); err != nil {
 				return WrapResult(Result{}, err)
@@ -1294,15 +1290,13 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 		}
 		// generated the expected StatefulSet based on the new tenant configuration
 		expectedStatefulSet := statefulsets.NewPool(&statefulsets.NewPoolArgs{
-			Tenant:          tenant,
-			SkipEnvVars:     skipEnvVars,
-			Pool:            &pool,
-			PoolStatus:      &tenant.Status.Pools[i],
-			ServiceName:     tenant.MinIOHLServiceName(),
-			HostsTemplate:   c.hostsTemplate,
-			OperatorVersion: c.operatorVersion,
-			OperatorCATLS:   operatorCATLSExists,
-			OperatorImage:   c.operatorImage,
+			Tenant:        tenant,
+			Pool:          &pool,
+			PoolStatus:    &tenant.Status.Pools[i],
+			ServiceName:   tenant.MinIOHLServiceName(),
+			HostsTemplate: c.hostsTemplate,
+			OperatorCATLS: operatorCATLSExists,
+			OperatorImage: c.operatorImage,
 		})
 		// Verify if this pool matches the spec on the tenant (resources, affinity, sidecars, etc)
 		poolMatchesSS, err := poolSSMatchesSpec(expectedStatefulSet, existingStatefulSet)

--- a/pkg/controller/tenants.go
+++ b/pkg/controller/tenants.go
@@ -90,7 +90,7 @@ func (c *Controller) saveTenantConfiguration(ctx context.Context, tenant *miniov
 		tenantConfiguration[minioBrowserEnv] = string(prevConfiguration[minioBrowserEnv])
 	}
 
-	// Update credentials  based on the existing credsSecret, we will overwrite root credentials only when the fields
+	// Update credentials based on the existing credsSecret, we will overwrite root credentials only when the fields
 	// accesskey and secretkey are not empty
 	if tenant.HasCredsSecret() {
 		credsSecret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.Spec.CredsSecret.Name, metav1.GetOptions{})
@@ -120,7 +120,7 @@ func (c *Controller) saveTenantConfiguration(ctx context.Context, tenant *miniov
 	tenantConfiguration["MINIO_PROMETHEUS_JOB_ID"] = tenant.PrometheusConfigJobName()
 
 	var domains []string
-	// Enable Bucket DNS only if asked for by default turned off
+	// Set Bucket DNS domain only if enabled
 	if tenant.BucketDNS() {
 		domains = append(domains, tenant.MinIOBucketBaseDomain())
 		sidecarBucketURL := fmt.Sprintf("http://127.0.0.1:%s%s/%s/%s",

--- a/pkg/controller/tenants.go
+++ b/pkg/controller/tenants.go
@@ -19,13 +19,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
-
-	"github.com/minio/operator/pkg/common"
-	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
@@ -33,15 +26,6 @@ import (
 
 // ErrEmptyRootCredentials is the error returned when we detect missing root credentials
 var ErrEmptyRootCredentials = errors.New("empty tenant credentials")
-
-const (
-	rootUserEnv      = "MINIO_ROOT_USER"
-	rootUserPassword = "MINIO_ROOT_PASSWORD"
-	storageClassEnv  = "MINIO_STORAGE_CLASS_STANDARD"
-	accessKeyEnv     = "MINIO_ACCESS_KEY"
-	secretKeyEnv     = "MINIO_SECRET_KEY"
-	minioBrowserEnv  = "MINIO_BROWSER"
-)
 
 func (c *Controller) getTenantConfiguration(ctx context.Context, tenant *miniov2.Tenant) (map[string][]byte, error) {
 	tenantConfiguration := map[string][]byte{}
@@ -58,162 +42,6 @@ func (c *Controller) getTenantConfiguration(ctx context.Context, tenant *miniov2
 		}
 	}
 	return tenantConfiguration, nil
-}
-
-func (c *Controller) saveTenantConfiguration(ctx context.Context, tenant *miniov2.Tenant) error {
-	prevConfiguration, err := c.getTenantConfiguration(ctx, tenant)
-	if err != nil {
-		return fmt.Errorf("secret '%s' reference on tenant.spec.configuration not found: %v", tenant.Spec.Configuration, err)
-	}
-	tenantConfiguration := map[string]string{}
-	if _, ok := prevConfiguration[storageClassEnv]; ok {
-		tenantConfiguration[storageClassEnv] = string(prevConfiguration[storageClassEnv])
-	}
-
-	if _, ok := prevConfiguration[rootUserEnv]; ok {
-		tenantConfiguration[rootUserEnv] = string(prevConfiguration[rootUserEnv])
-	}
-
-	if _, ok := prevConfiguration[rootUserPassword]; ok {
-		tenantConfiguration[rootUserPassword] = string(prevConfiguration[rootUserPassword])
-	}
-
-	if _, ok := prevConfiguration[accessKeyEnv]; ok {
-		tenantConfiguration[accessKeyEnv] = string(prevConfiguration[accessKeyEnv])
-	}
-
-	if _, ok := prevConfiguration[secretKeyEnv]; ok {
-		tenantConfiguration[secretKeyEnv] = string(prevConfiguration[secretKeyEnv])
-	}
-
-	if _, ok := prevConfiguration[minioBrowserEnv]; ok {
-		tenantConfiguration[minioBrowserEnv] = string(prevConfiguration[minioBrowserEnv])
-	}
-
-	// Update credentials based on the existing credsSecret, we will overwrite root credentials only when the fields
-	// accesskey and secretkey are not empty
-	if tenant.HasCredsSecret() {
-		credsSecret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.Spec.CredsSecret.Name, metav1.GetOptions{})
-		if err != nil && !k8serrors.IsNotFound(err) {
-			return err
-		}
-		var accessKey string
-		var secretKey string
-		if _, ok := credsSecret.Data["accesskey"]; ok {
-			accessKey = string(credsSecret.Data["accesskey"])
-		}
-		if _, ok := credsSecret.Data["secretkey"]; ok {
-			secretKey = string(credsSecret.Data["secretkey"])
-		}
-		if accessKey != "" || secretKey != "" {
-			tenantConfiguration["MINIO_ROOT_USER"] = accessKey
-			tenantConfiguration["MINIO_ROOT_PASSWORD"] = secretKey
-		}
-	}
-
-	// Enable `mc admin update` style updates to MinIO binaries
-	// within the container, only operator is supposed to perform
-	// these operations.
-	tenantConfiguration["MINIO_UPDATE"] = "on"
-	tenantConfiguration["MINIO_UPDATE_MINISIGN_PUBKEY"] = "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"
-	tenantConfiguration["MINIO_OPERATOR_VERSION"] = c.operatorVersion
-	tenantConfiguration["MINIO_PROMETHEUS_JOB_ID"] = tenant.PrometheusConfigJobName()
-
-	var domains []string
-	// Set Bucket DNS domain only if enabled
-	if tenant.BucketDNS() {
-		domains = append(domains, tenant.MinIOBucketBaseDomain())
-		sidecarBucketURL := fmt.Sprintf("http://127.0.0.1:%s%s/%s/%s",
-			common.WebhookDefaultPort,
-			common.WebhookAPIBucketService,
-			tenant.Namespace,
-			tenant.Name)
-		tenantConfiguration[common.BucketDNSEnv] = sidecarBucketURL
-	}
-	// Check if any domains are configured
-	if tenant.HasMinIODomains() {
-		domains = append(domains, tenant.GetDomainHosts()...)
-	}
-	// tell MinIO about all the domains meant to hit it if they are not passed manually via .spec.env
-	if len(domains) > 0 {
-		tenantConfiguration[miniov2.MinIODomain] = strings.Join(domains, ",")
-	}
-	// If no specific server URL is specified we will specify the internal k8s url, but if a list of domains was
-	// provided we will use the first domain.
-	serverURL := tenant.MinIOServerEndpoint()
-	if tenant.HasMinIODomains() {
-		// Infer schema from tenant TLS, if not explicit
-		if !strings.HasPrefix(tenant.Spec.Features.Domains.Minio[0], "http") {
-			useSchema := "http"
-			if tenant.TLS() {
-				useSchema = "https"
-			}
-			serverURL = fmt.Sprintf("%s://%s", useSchema, tenant.Spec.Features.Domains.Minio[0])
-		} else {
-			serverURL = tenant.Spec.Features.Domains.Minio[0]
-		}
-	}
-	tenantConfiguration[miniov2.MinIOServerURL] = serverURL
-
-	// Set the redirect url for console
-	if tenant.HasConsoleDomains() {
-		consoleDomain := tenant.Spec.Features.Domains.Console
-		// Infer schema from tenant TLS, if not explicit
-		if !strings.HasPrefix(consoleDomain, "http") {
-			useSchema := "http"
-			if tenant.TLS() {
-				useSchema = "https"
-			}
-			consoleDomain = fmt.Sprintf("%s://%s", useSchema, consoleDomain)
-		}
-		tenantConfiguration[miniov2.MinIOBrowserRedirectURL] = consoleDomain
-	}
-
-	if tenant.HasKESEnabled() {
-		tenantConfiguration["MINIO_KMS_KES_ENDPOINT"] = tenant.KESServiceEndpoint()
-		tenantConfiguration["MINIO_KMS_KES_CERT_FILE"] = miniov2.MinIOCertPath + "/client.crt"
-		tenantConfiguration["MINIO_KMS_KES_KEY_FILE"] = miniov2.MinIOCertPath + "/client.key"
-		tenantConfiguration["MINIO_KMS_KES_CA_PATH"] = miniov2.MinIOCertPath + "/CAs/kes.crt"
-		tenantConfiguration["MINIO_KMS_KES_KEY_NAME"] = tenant.Spec.KES.KeyName
-	}
-
-	// Set the env variables in the tenant.spec.env field
-	// User defined environment variables will take precedence over default environment variables
-	envVars := tenant.GetEnvVars()
-	for _, ev := range envVars {
-		tenantConfiguration[ev.Name] = ev.Value
-	}
-
-	configurationSecret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.Spec.Configuration.Name, metav1.GetOptions{})
-	if err != nil && k8serrors.IsNotFound(err) {
-		configurationSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      tenant.ConfigurationSecretName(),
-				Namespace: tenant.Namespace,
-			},
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: corev1.SchemeGroupVersion.Version,
-			},
-			Data: map[string][]byte{
-				"config.env": []byte(miniov2.GenerateTenantConfigurationFile(tenantConfiguration)),
-			},
-		}
-		_, err = c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Create(ctx, configurationSecret, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("error updating tenant '%s/%s', could not create tenant.spec.configuration secret: %v", tenant.Namespace, tenant.Name, err)
-		}
-	} else {
-		configurationSecret.Data = map[string][]byte{
-			"config.env": []byte(miniov2.GenerateTenantConfigurationFile(tenantConfiguration)),
-		}
-		_, err = c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Update(ctx, configurationSecret, metav1.UpdateOptions{})
-		if err != nil {
-			return fmt.Errorf("error updating tenant '%s/%s', could not update tenant.spec.configuration secret: %v", tenant.Namespace, tenant.Name, err)
-		}
-	}
-
-	return nil
 }
 
 // getTenantCredentials returns a combination of env, credsSecret and Configuration tenant credentials

--- a/pkg/controller/tenants.go
+++ b/pkg/controller/tenants.go
@@ -19,6 +19,12 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/minio/operator/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,6 +33,15 @@ import (
 
 // ErrEmptyRootCredentials is the error returned when we detect missing root credentials
 var ErrEmptyRootCredentials = errors.New("empty tenant credentials")
+
+const (
+	rootUserEnv      = "MINIO_ROOT_USER"
+	rootUserPassword = "MINIO_ROOT_PASSWORD"
+	storageClassEnv  = "MINIO_STORAGE_CLASS_STANDARD"
+	accessKeyEnv     = "MINIO_ACCESS_KEY"
+	secretKeyEnv     = "MINIO_SECRET_KEY"
+	minioBrowserEnv  = "MINIO_BROWSER"
+)
 
 func (c *Controller) getTenantConfiguration(ctx context.Context, tenant *miniov2.Tenant) (map[string][]byte, error) {
 	tenantConfiguration := map[string][]byte{}
@@ -43,6 +58,162 @@ func (c *Controller) getTenantConfiguration(ctx context.Context, tenant *miniov2
 		}
 	}
 	return tenantConfiguration, nil
+}
+
+func (c *Controller) saveTenantConfiguration(ctx context.Context, tenant *miniov2.Tenant) error {
+	prevConfiguration, err := c.getTenantConfiguration(ctx, tenant)
+	if err != nil {
+		return fmt.Errorf("secret '%s' reference on tenant.spec.configuration not found: %v", tenant.Spec.Configuration, err)
+	}
+	tenantConfiguration := map[string]string{}
+	if _, ok := prevConfiguration[storageClassEnv]; ok {
+		tenantConfiguration[storageClassEnv] = string(prevConfiguration[storageClassEnv])
+	}
+
+	if _, ok := prevConfiguration[rootUserEnv]; ok {
+		tenantConfiguration[rootUserEnv] = string(prevConfiguration[rootUserEnv])
+	}
+
+	if _, ok := prevConfiguration[rootUserPassword]; ok {
+		tenantConfiguration[rootUserPassword] = string(prevConfiguration[rootUserPassword])
+	}
+
+	if _, ok := prevConfiguration[accessKeyEnv]; ok {
+		tenantConfiguration[accessKeyEnv] = string(prevConfiguration[accessKeyEnv])
+	}
+
+	if _, ok := prevConfiguration[secretKeyEnv]; ok {
+		tenantConfiguration[secretKeyEnv] = string(prevConfiguration[secretKeyEnv])
+	}
+
+	if _, ok := prevConfiguration[minioBrowserEnv]; ok {
+		tenantConfiguration[minioBrowserEnv] = string(prevConfiguration[minioBrowserEnv])
+	}
+
+	// Update credentials  based on the existing credsSecret, we will overwrite root credentials only when the fields
+	// accesskey and secretkey are not empty
+	if tenant.HasCredsSecret() {
+		credsSecret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.Spec.CredsSecret.Name, metav1.GetOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		var accessKey string
+		var secretKey string
+		if _, ok := credsSecret.Data["accesskey"]; ok {
+			accessKey = string(credsSecret.Data["accesskey"])
+		}
+		if _, ok := credsSecret.Data["secretkey"]; ok {
+			secretKey = string(credsSecret.Data["secretkey"])
+		}
+		if accessKey != "" || secretKey != "" {
+			tenantConfiguration["MINIO_ROOT_USER"] = accessKey
+			tenantConfiguration["MINIO_ROOT_PASSWORD"] = secretKey
+		}
+	}
+
+	// Enable `mc admin update` style updates to MinIO binaries
+	// within the container, only operator is supposed to perform
+	// these operations.
+	tenantConfiguration["MINIO_UPDATE"] = "on"
+	tenantConfiguration["MINIO_UPDATE_MINISIGN_PUBKEY"] = "RWTx5Zr1tiHQLwG9keckT0c45M3AGeHD6IvimQHpyRywVWGbP1aVSGav"
+	tenantConfiguration["MINIO_OPERATOR_VERSION"] = c.operatorVersion
+	tenantConfiguration["MINIO_PROMETHEUS_JOB_ID"] = tenant.PrometheusConfigJobName()
+
+	var domains []string
+	// Enable Bucket DNS only if asked for by default turned off
+	if tenant.BucketDNS() {
+		domains = append(domains, tenant.MinIOBucketBaseDomain())
+		sidecarBucketURL := fmt.Sprintf("http://127.0.0.1:%s%s/%s/%s",
+			common.WebhookDefaultPort,
+			common.WebhookAPIBucketService,
+			tenant.Namespace,
+			tenant.Name)
+		tenantConfiguration[common.BucketDNSEnv] = sidecarBucketURL
+	}
+	// Check if any domains are configured
+	if tenant.HasMinIODomains() {
+		domains = append(domains, tenant.GetDomainHosts()...)
+	}
+	// tell MinIO about all the domains meant to hit it if they are not passed manually via .spec.env
+	if len(domains) > 0 {
+		tenantConfiguration[miniov2.MinIODomain] = strings.Join(domains, ",")
+	}
+	// If no specific server URL is specified we will specify the internal k8s url, but if a list of domains was
+	// provided we will use the first domain.
+	serverURL := tenant.MinIOServerEndpoint()
+	if tenant.HasMinIODomains() {
+		// Infer schema from tenant TLS, if not explicit
+		if !strings.HasPrefix(tenant.Spec.Features.Domains.Minio[0], "http") {
+			useSchema := "http"
+			if tenant.TLS() {
+				useSchema = "https"
+			}
+			serverURL = fmt.Sprintf("%s://%s", useSchema, tenant.Spec.Features.Domains.Minio[0])
+		} else {
+			serverURL = tenant.Spec.Features.Domains.Minio[0]
+		}
+	}
+	tenantConfiguration[miniov2.MinIOServerURL] = serverURL
+
+	// Set the redirect url for console
+	if tenant.HasConsoleDomains() {
+		consoleDomain := tenant.Spec.Features.Domains.Console
+		// Infer schema from tenant TLS, if not explicit
+		if !strings.HasPrefix(consoleDomain, "http") {
+			useSchema := "http"
+			if tenant.TLS() {
+				useSchema = "https"
+			}
+			consoleDomain = fmt.Sprintf("%s://%s", useSchema, consoleDomain)
+		}
+		tenantConfiguration[miniov2.MinIOBrowserRedirectURL] = consoleDomain
+	}
+
+	if tenant.HasKESEnabled() {
+		tenantConfiguration["MINIO_KMS_KES_ENDPOINT"] = tenant.KESServiceEndpoint()
+		tenantConfiguration["MINIO_KMS_KES_CERT_FILE"] = miniov2.MinIOCertPath + "/client.crt"
+		tenantConfiguration["MINIO_KMS_KES_KEY_FILE"] = miniov2.MinIOCertPath + "/client.key"
+		tenantConfiguration["MINIO_KMS_KES_CA_PATH"] = miniov2.MinIOCertPath + "/CAs/kes.crt"
+		tenantConfiguration["MINIO_KMS_KES_KEY_NAME"] = tenant.Spec.KES.KeyName
+	}
+
+	// Set the env variables in the tenant.spec.env field
+	// User defined environment variables will take precedence over default environment variables
+	envVars := tenant.GetEnvVars()
+	for _, ev := range envVars {
+		tenantConfiguration[ev.Name] = ev.Value
+	}
+
+	configurationSecret, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Get(ctx, tenant.Spec.Configuration.Name, metav1.GetOptions{})
+	if err != nil && k8serrors.IsNotFound(err) {
+		configurationSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tenant.ConfigurationSecretName(),
+				Namespace: tenant.Namespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: corev1.SchemeGroupVersion.Version,
+			},
+			Data: map[string][]byte{
+				"config.env": []byte(miniov2.GenerateTenantConfigurationFile(tenantConfiguration)),
+			},
+		}
+		_, err = c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Create(ctx, configurationSecret, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("error updating tenant '%s/%s', could not create tenant.spec.configuration secret: %v", tenant.Namespace, tenant.Name, err)
+		}
+	} else {
+		configurationSecret.Data = map[string][]byte{
+			"config.env": []byte(miniov2.GenerateTenantConfigurationFile(tenantConfiguration)),
+		}
+		_, err = c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Update(ctx, configurationSecret, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("error updating tenant '%s/%s', could not update tenant.spec.configuration secret: %v", tenant.Namespace, tenant.Name, err)
+		}
+	}
+
+	return nil
 }
 
 // getTenantCredentials returns a combination of env, credsSecret and Configuration tenant credentials

--- a/pkg/controller/upgrades.go
+++ b/pkg/controller/upgrades.go
@@ -35,14 +35,14 @@ import (
 )
 
 const (
-	version420 = "v4.2.0"
-	version424 = "v4.2.4"
-	version429 = "v4.2.9"
-	version430 = "v4.3.0"
-	version45  = "v4.5"
-	version500 = "v5.0.0"
-	// currentVersion will point to the latest released update version
+	version420     = "v4.2.0"
+	version424     = "v4.2.4"
+	version429     = "v4.2.9"
+	version430     = "v4.3.0"
+	version45      = "v4.5"
+	version500     = "v5.0.0"
 	currentVersion = version500
+	version510     = "v5.1.0"
 )
 
 // Legacy const
@@ -62,6 +62,7 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 		version430: c.upgrade430,
 		version45:  c.upgrade45,
 		version500: c.upgrade500,
+		version510: c.upgrade510,
 	}
 
 	// if tenant has no version we mark it with latest version upgrade released
@@ -84,6 +85,7 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 			version430,
 			version45,
 			version500,
+			version510,
 		}
 		for _, v := range versionsThatNeedUpgrades {
 			vp, _ := version.NewVersion(v)
@@ -413,4 +415,15 @@ func (c *Controller) upgrade500(ctx context.Context, tenant *miniov2.Tenant) (*m
 		}
 	}
 	return c.updateTenantSyncVersion(ctx, tenant, version500)
+}
+
+// Upgrades the sync version to v5.1.0
+// in this version we save most of the minio env variables in the config secret, except for the env variables needed
+// for k8s runtime
+func (c *Controller) upgrade510(ctx context.Context, tenant *miniov2.Tenant) (*miniov2.Tenant, error) {
+	err := c.saveTenantConfiguration(ctx, tenant)
+	if err != nil {
+		return tenant, err
+	}
+	return c.updateTenantSyncVersion(ctx, tenant, version510)
 }

--- a/pkg/controller/upgrades.go
+++ b/pkg/controller/upgrades.go
@@ -42,7 +42,6 @@ const (
 	version45      = "v4.5"
 	version500     = "v5.0.0"
 	currentVersion = version500
-	version510     = "v5.1.0"
 )
 
 // Legacy const
@@ -62,7 +61,6 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 		version430: c.upgrade430,
 		version45:  c.upgrade45,
 		version500: c.upgrade500,
-		version510: c.upgrade510,
 	}
 
 	// if tenant has no version we mark it with latest version upgrade released
@@ -85,7 +83,6 @@ func (c *Controller) checkForUpgrades(ctx context.Context, tenant *miniov2.Tenan
 			version430,
 			version45,
 			version500,
-			version510,
 		}
 		for _, v := range versionsThatNeedUpgrades {
 			vp, _ := version.NewVersion(v)
@@ -415,15 +412,4 @@ func (c *Controller) upgrade500(ctx context.Context, tenant *miniov2.Tenant) (*m
 		}
 	}
 	return c.updateTenantSyncVersion(ctx, tenant, version500)
-}
-
-// Upgrades the sync version to v5.1.0
-// in this version we save most of the minio env variables in the config secret, except for the env variables needed
-// for k8s runtime
-func (c *Controller) upgrade510(ctx context.Context, tenant *miniov2.Tenant) (*miniov2.Tenant, error) {
-	err := c.saveTenantConfiguration(ctx, tenant)
-	if err != nil {
-		return tenant, err
-	}
-	return c.updateTenantSyncVersion(ctx, tenant, version510)
 }

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -5038,6 +5038,7 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
             required:
+            - configuration
             - pools
             type: object
           status:


### PR DESCRIPTION
## What this PR does?

No longer update the statefulset pods with added env variables, instead of that the env variables are stored in the `configuration` secret and this secret is mounted inside the pods in the `/tmp/minio/config.env ` path


* Made field `spec.configuration` required
* Added a upgrade for (future) version v5.0.12 to migrate configured env variables into the `configuration` secret
* bugfix: sidecar was giving a false negative of missing credentials 
* New Feature: loading and saving env variables to the Config secret 💪
* bugfix: make regen-crd
controller-gen binary installed with `go install ` was not being used, instead if a manually installed binary existed it was picked automatically, fixed by using `GOBIN` instead of `GOPATH`
