### PR TITLE
Use nearest zero-based pool name for expansion

### DIFF
--- a/kubectl-minio/cmd/resources/common.go
+++ b/kubectl-minio/cmd/resources/common.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"log"
 	"path"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/kustomize/kyaml/filesys"
@@ -94,7 +95,7 @@ func Pool(opts *TenantOptions, volumes int32, q resource.Quantity) miniov2.Pool 
 								{
 									Key:      miniov2.PoolLabel,
 									Operator: "In",
-									Values:   []string{opts.Name},
+									Values:   []string{opts.PoolName},
 								},
 							},
 						},
@@ -108,8 +109,19 @@ func Pool(opts *TenantOptions, volumes int32, q resource.Quantity) miniov2.Pool 
 }
 
 // GeneratePoolName Pool Name Generator
-func GeneratePoolName(poolNumber int) string {
-	return fmt.Sprintf("pool-%d", poolNumber)
+func GeneratePoolName(pools []miniov2.Pool) string {
+	poolCounter := 0
+	var poolNames []string
+	for _, pool := range pools {
+		poolNames = append(poolNames, pool.Name)
+	}
+	for poolCounter < len(poolNames) {
+		if !(slices.Contains(poolNames, fmt.Sprintf("pool-%d", poolCounter))) {
+			return fmt.Sprintf("pool-%d", poolCounter)
+		}
+		poolCounter++
+	}
+	return fmt.Sprintf("pool-%d", poolCounter)
 }
 
 // GetSchemeDecoder returns a decoder for the scheme's that we use

--- a/kubectl-minio/cmd/tenant-expand.go
+++ b/kubectl-minio/cmd/tenant-expand.go
@@ -137,9 +137,9 @@ func (v *expandCmd) run() error {
 		return err
 	}
 
-	// Tenant pool id is zero based, generating pool using the count of existing pools in the tenant
+	// Generate pool name using the state of existing pools in the tenant
 	if v.tenantOpts.PoolName == "" {
-		v.tenantOpts.PoolName = resources.GeneratePoolName(len(t.Spec.Pools))
+		v.tenantOpts.PoolName = resources.GeneratePoolName(t.Spec.Pools)
 	}
 
 	t.Spec.Pools = append(t.Spec.Pools, resources.Pool(&v.tenantOpts, v.tenantOpts.VolumesPerServer, *capacityPerVolume))

--- a/web-app/src/common/utils.ts
+++ b/web-app/src/common/utils.ts
@@ -453,7 +453,13 @@ export const erasureCodeCalc = (
 
 // Pool Name Generator
 export const generatePoolName = (pools: Pool[]) => {
-  const poolCounter = pools.length;
+  let poolCounter = 0;
+  const poolNames = pools.map((pool) => pool.name || "");
+  for (; poolCounter < pools.length; poolCounter++) {
+    if (!poolNames.includes(`pool-${poolCounter}`)) {
+      return `pool-${poolCounter}`;
+    }
+  }
   return `pool-${poolCounter}`;
 };
 


### PR DESCRIPTION
### Issue summary
After tenant expansion and decommission, further expansion is not always possible using the MinIO tenant console. 

As an example, in a deployment with `pool-0` and `pool-1`, after `pool-0` decommission, a subsequent expansion by the console tries and fails to create `pool-1` which already exists.

This is because the MinIO tenant console automatically names pools based on the number of pools in existence. If there is `1` pool, then the logic will try to create `pool-1` - which may be incorrect as shown above. This logic needs to consider examining the pools already in existence before determining which pool name to use.

### Test summary
Reproduce issue on master
Test 0 - As reported by user, Create using Console, Expand using Console, Decommission pool-0, Expand tenant using Console

Fix on improve-poolname-search branch
Test 1 - Create tenant using console, Expand using kubectl-minio, Decommission `pool-0`, Expand tenant using Console
Test 2 - Create tenant using kubectl-minio, Expand using console, Decommission `0pool`, Expand tenant using Console
Test 3 - As reported by user, Create tenant using Console, Expand tenant using Console, Decommission `pool-0`, Expand tenant using Console
Test 4 - Create tenant using kubectl, Expand tenant using kubectl, Decommission `pool-1`, Expand tenant using Console


Verbose tests here:
https://github.com/allanrogerr/public/wiki/operator%E2%80%901785

Fixes: https://github.com/minio/operator/issues/1785