### PR TITLE
Add RBAC Permissions to Operator for Jobs

### DIFF
--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -4,6 +4,16 @@ metadata:
   name: minio-operator-role
 rules:
   - apiGroups:
+      - "job.min.io"
+    resources:
+      - miniojobs
+    verbs:
+      - list
+      - get
+      - update
+      - delete
+      - watch
+  - apiGroups:
       - "apiextensions.k8s.io"
     resources:
       - customresourcedefinitions


### PR DESCRIPTION
### Objective:

For Operator to have access to Jobs API Group and its resources.

