### PR TITLE
Adding Job CRD

### DIFF
--- a/resources/base/crds/kustomization.yaml
+++ b/resources/base/crds/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - minio.min.io_tenants.yaml
   - sts.min.io_policybindings.yaml
+  - job.min.io_miniojobs.yaml


### PR DESCRIPTION
### Objective:

To avoid the error below, it is necessary to include the MinIO Job CRD when deploying the Operator, as it is required anyway:

```
E0126 16:20:55.697066       1 reflector.go:147] k8s.io/client-go@v0.29.0/tools/cache/reflector.go:229: 
Failed to watch *v1alpha1.MinIOJob: 
failed to list *v1alpha1.MinIOJob: the server could not find the requested resource (get miniojobs.job.min.io)
```