### PR TITLE
[WIP] - Catch up with re-newed external certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MinIO Operator
+# MinIO Operator:
 
 ![build](https://github.com/minio/operator/workflows/Go/badge.svg) ![license](https://img.shields.io/badge/license-AGPL%20V3-blue)
 


### PR DESCRIPTION
Currently, we are facing an issue where the TLS certificate is being updated by cert-manager, but our pods continue to use the old external certificate. To address this, we need to ensure that our system seamlessly adopts the new certificate when renewed by cert-manager, preventing any failure to trust the updated certificate. Achieving this requires incorporating additional logic into the operator to automate the entire process.

The proposed approach in this pull request is as follows:

When we receive an external certificate, typically from cert-manager.

If cert-manager updates or renews the TLS secret containing the certificate.

Subsequently, our pods may encounter the following error:

vbnet
Copy code
Post "<URL>:7373/v1/key/generate/myminio-key": tls: failed to verify certificate: x509: certificate signed by unknown authority
Instead of immediately throwing this error in the code, we suggest implementing a check at this point. If the certificate is external, it is highly likely that all we need to do is use the latest secret's content, which has been renewed. In such cases, we can initiate a Minio restart to synchronize with the change. A similar approach can be applied for the KES pod in a separate pull request if necessary.

I will thoroughly test this change to ensure a smoother experience with external certificates.