### PR TITLE
Create statefulset even on cert update failure

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -985,7 +985,8 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 	// check if operator-ca-tls has to be updated or re-created in the tenant namespace
 	operatorCATLSExists, err := c.checkOperatorCAForTenant(ctx, tenant)
 	if err != nil {
-		return WrapResult(Result{}, err)
+		// Don't return here as we get stuck when recreating the stateful set
+		klog.Infof("There was an error while updating the certificate %s", err)
 	}
 
 	// consolidate the status of all pools. this is meant to cover for legacy tenants


### PR DESCRIPTION
### Objective:

To be able to create statefulset even if there is an error when updating the certificate

### User Story:

We got stuck waiting for the `ss` while applying `cert-manager`. Just notify the issue but create the `ss` no matter what.

### Additional info:

This isn't necessarily a problem since we've merged this PR: https://github.com/minio/operator/pull/1847.

### Scenario:

When a user deletes the StatefulSet, we no longer see any pods, making it difficult to identify the issue. We would prefer encountering a TLS issue in the Minio logs that we can resolve with an external certificate rather than being stuck without a StatefulSet.