### PR TITLE
Recommend trivial parity

### DIFF
--- a/web-app/src/common/utils.ts
+++ b/web-app/src/common/utils.ts
@@ -524,6 +524,8 @@ export const niceDaysInt = (seconds: number, timeVariant: string = "s") => {
   }`;
 };
 
+export const EC0 = "EC:0";
+
 export const MinIOEnvVarsSettings: any = {
   MINIO_ACCESS_KEY: { secret: true },
   MINIO_ACCESS_KEY_OLD: { secret: true },

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/SizePreview.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/SizePreview.tsx
@@ -18,7 +18,7 @@ import React, { Fragment } from "react";
 import { Box, SimpleHeader, Table, TableBody, TableCell, TableRow } from "mds";
 import { useSelector } from "react-redux";
 import { AppState } from "../../../../../store";
-import { niceBytes } from "../../../../../common/utils";
+import { niceBytes, EC0 } from "../../../../../common/utils";
 
 const SizePreview = () => {
   const nodes = useSelector(
@@ -139,7 +139,9 @@ const SizePreview = () => {
               <TableRow>
                 <TableCell scope="row">Usable Capacity</TableCell>
                 <TableCell sx={{ textAlign: "right" }}>
-                  {niceBytes(usableInformation.maxCapacity)}
+                  {ecParity === EC0
+                    ? niceBytes(ecParityCalc.rawCapacity)
+                    : niceBytes(usableInformation.maxCapacity)}
                 </TableCell>
               </TableRow>
               <TableRow>
@@ -150,12 +152,16 @@ const SizePreview = () => {
                   style={{ borderBottom: 0 }}
                   sx={{ textAlign: "right" }}
                 >
-                  {distribution
-                    ? Math.floor(
-                        usableInformation.maxFailureTolerations /
-                          distribution.disks,
-                      )
-                    : "-"}
+                  {ecParity === EC0
+                    ? 0
+                    : distribution &&
+                        distribution.disks > 0 &&
+                        usableInformation.maxFailureTolerations
+                      ? Math.floor(
+                          usableInformation.maxFailureTolerations /
+                            distribution.disks,
+                        )
+                      : "-"}
                 </TableCell>
               </TableRow>
             </TableBody>

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSize.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSize.tsx
@@ -24,6 +24,7 @@ import {
   getBytes,
   k8sScalarUnitsExcluding,
   niceBytes,
+  EC0,
 } from "../../../../../../common/utils";
 import { clearValidationError } from "../../../utils";
 import { ecListTransform } from "../../../ListTenants/utils";
@@ -89,6 +90,38 @@ const TenantSize = ({ formToRender }: ITenantSizeProps) => {
   const selectedStorageType = useSelector(
     (state: AppState) =>
       state.createTenant.fields.nameTenant.selectedStorageType,
+  );
+
+  const maxCPUsUse = useSelector(
+    (state: AppState) => state.createTenant.fields.tenantSize.maxCPUsUse,
+  );
+  const maxMemorySize = useSelector(
+    (state: AppState) => state.createTenant.fields.tenantSize.maxMemorySize,
+  );
+  const resourcesCPURequest = useSelector(
+    (state: AppState) =>
+      state.createTenant.fields.tenantSize.resourcesCPURequest,
+  );
+  const resourcesMemoryRequest = useSelector(
+    (state: AppState) =>
+      state.createTenant.fields.tenantSize.resourcesMemoryRequest,
+  );
+
+  const resourcesCPURequestError = useSelector(
+    (state: AppState) =>
+      state.createTenant.fields.tenantSize.resourcesCPURequestError,
+  );
+  const resourcesCPULimitError = useSelector(
+    (state: AppState) =>
+      state.createTenant.fields.tenantSize.resourcesCPULimitError,
+  );
+  const resourcesMemoryRequestError = useSelector(
+    (state: AppState) =>
+      state.createTenant.fields.tenantSize.resourcesMemoryRequestError,
+  );
+  const resourcesMemoryLimitError = useSelector(
+    (state: AppState) =>
+      state.createTenant.fields.tenantSize.resourcesMemoryLimitError,
   );
 
   const [validationErrors, setValidationErrors] = useState<any>({});
@@ -238,7 +271,11 @@ const TenantSize = ({ formToRender }: ITenantSizeProps) => {
           !("drivesps" in commonValidation) &&
           distribution.error === "" &&
           ecParityCalc.error === 0 &&
-          ecParity !== "",
+          ecParity !== "" &&
+          resourcesMemoryRequestError === "" &&
+          resourcesCPURequestError === "" &&
+          resourcesMemoryLimitError === "" &&
+          resourcesCPULimitError === "",
       }),
     );
 
@@ -258,9 +295,24 @@ const TenantSize = ({ formToRender }: ITenantSizeProps) => {
     nodeError,
     drivesPerServer,
     ecParity,
+    resourcesMemoryRequest,
+    resourcesCPURequest,
+    maxCPUsUse,
+    maxMemorySize,
+    resourcesMemoryRequestError,
+    resourcesCPURequestError,
+    resourcesMemoryLimitError,
+    resourcesCPULimitError,
   ]);
 
   useEffect(() => {
+    // Trivial case
+    if (nodes.trim() === "1") {
+      updateField("ecParity", EC0);
+      updateField("ecparityChoices", ecListTransform([EC0]));
+      updateField("cleanECChoices", [EC0]);
+      return;
+    }
     if (distribution.error === "") {
       // Get EC Value
       if (nodes.trim() !== "" && distribution.disks !== 0) {
@@ -365,13 +417,13 @@ const TenantSize = ({ formToRender }: ITenantSizeProps) => {
           updateField("ecParity", value);
         }}
         label="Erasure Code Parity"
-        disabled={selectedStorageClass === ""}
+        disabled={selectedStorageClass === "" || ecParity === ""}
         value={ecParity}
         options={ecParityChoices}
       />
       <Box className={"muted inputItem"}>
-        Please select the desired parity. This setting will change the max
-        usable capacity in the cluster
+        Please select the desired parity. This setting will change the maximum
+        usable capacity in the cluster.
       </Box>
 
       <TenantSizeResources />

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSizeResources.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/TenantResources/TenantSizeResources.tsx
@@ -183,8 +183,6 @@ const TenantSizeResources = () => {
         updateField("maxMemorySize", 0);
         updateField("resourcesCPURequest", "");
         updateField("resourcesMemoryRequest", "");
-
-        console.error(err);
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodes, updateField]);


### PR DESCRIPTION
### Issue summary
In the minio operator console, when creating a tenant, the user is not able to select any different EC Parity than an invalid `EC:4` or `EC:2`. 
See https://github.com/minio/operator/issues/1901 for more details

### Test summary
Test 0 - Reproduce issue on master.
1. As reported by user, attempt to create a tenant with 1 node and 1 drive with 1GiB storage Observe no valid parity EC:0 available
2. Also observe that if an invalid Resource is specified, then the user navigates away then back to the main create page, the Create button is enabled incorrectly.
3. Also observe that if multiple parities were selectable using a particular drive/server configuration e.g. 4 nodes, 8 drives (giving `EC:8,7,6,5,4,3,2`, THEN a 1 node 1 drive configuration were selected that those same parities `EC:8,7,6,5,4,3,2` are selectable still, even though they cannot be applied to a 1 node 1 drive configuration.

Fix on recommend-trivial-parity branch
Test 1 - As reported by user, attempt to create a tenant with 1 node and 1 drive with 1GiB storage Observe valid parity EC:0 is now available
Test 2 - Actually create the tenant and validate its storage

Verbose tests here:
https://github.com/allanrogerr/public/wiki/operator%E2%80%901901

Fixes: #1901