### PR TITLE
fix: sts will restart when use kubectl

### DIFF
--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -72,7 +72,10 @@ func poolSSMatchesSpec(expectedStatefulSet, existingStatefulSet *appsv1.Stateful
 	if !equality.Semantic.DeepEqual(expectedMetadata.Labels, existingStatefulSet.ObjectMeta.Labels) {
 		return false, nil
 	}
-	expectedAnnotations := expectedMetadata.Annotations
+	expectedAnnotations := map[string]string{}
+	for k, v := range expectedMetadata.Annotations {
+		expectedAnnotations[k] = v
+	}
 	currentAnnotations := existingStatefulSet.ObjectMeta.Annotations
 	delete(expectedAnnotations, corev1.LastAppliedConfigAnnotation)
 	delete(currentAnnotations, corev1.LastAppliedConfigAnnotation)


### PR DESCRIPTION
fix: sts will restart when use kubectl
https://github.com/minio/operator/blob/22d46128863cd06b3fcad1684b3590a074d149a8/pkg/controller/main-controller.go#L1360
when `	delete(expectedAnnotations, corev1.LastAppliedConfigAnnotation)` will delete `expectedStatefulSet.Spec.Template.Metadata.Annotations`'s key.
So when someone use `kubectl apply -f tenant.yaml` statuefulset will restart as soon as possible.