### PR TITLE
Using clientset to read the Custom Resource

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -309,6 +309,7 @@ func NewController(
 				statefulSetInformer.Lister(),
 				recorder,
 				queue.NewNamedRateLimitingQueue(MinIOControllerRateLimiter(), "Tenants"),
+				minioClientSet,
 			),
 		},
 	}


### PR DESCRIPTION
### Objective:

To be able to read the Job Resource

### Next Steps:

* Launch a Job
* Get STS Access
* Make bucket(s) as requested
* Add other operations and tests truly

### How to test:

```yaml
apiVersion: job.min.io/v1alpha1
kind: MinIOJob
metadata:
  name: myminio
  namespace: tenant-lite
spec:
  serviceAccountName: tenant-lite
  tenant:
    name: my-tenant
    namespace: default
  execution: parallel # Sequential
  # disableWaitForReady: true
  commands:
    - op: ready
    - op: make-bucket
      args:
        name: memes
    - name: add-my-user-1
      op: admin/user/add
      args:
        user: daniel
        password: daniel123
    - name: add-my-policy
      op: admin/policy/add
      args:
        name: memes-access
        policy: |
          {
              "Version": "2012-10-17",
              "Statement": [
                  {
                      "Effect": "Allow",
                      "Action": [
                          "s3:*"
                      ],
                      "Resource": [
                          "arn:aws:s3:::memes",
                          "arn:aws:s3:::memes/*"
                      ]
                  }
              ]
          }
    - op: admin/policy/attach
      dependsOn:
        - add-my-user-1
        - add-my-policy
      args:
        policy: memes-access
status:
  phase: Failed # Completed, Pending, Waiting, Running
  commands:
    - name: wait-ready
      result: success
    - result: succes
    - result: failure
      message: this and that
```

### Additional information:

This is not a new client, as initially thought, but rather the same client we have had since before. The difference is that the Job controller was implemented on top of it in PR: [link to PR](https://github.com/minio/operator/pull/1883). You can examine the interface in `operator/pkg/client/clientset/versioned/clientset.go`:

```go
type Interface interface {
	Discovery() discovery.DiscoveryInterface
	JobV1alpha1() jobv1alpha1.JobV1alpha1Interface
	MinioV2() miniov2.MinioV2Interface
	StsV1alpha1() stsv1alpha1.StsV1alpha1Interface
} 
```

This interface allows us to share different resources over the same clientset: MinIO tenants, STS, and now Job.

Hope this helps clarify a bit.