### PR TITLE
Remove noisy log message

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -780,7 +780,6 @@ func key2NamespaceName(key string) (namespace, name string) {
 // converge the two. It then updates the Status block of the Tenant resource
 // with the current status of the resource.
 func (c *Controller) syncHandler(key string) (Result, error) {
-	klog.Info("MinIO Tenant Main loop!!!!")
 	ctx := context.Background()
 	cOpts := metav1.CreateOptions{}
 	uOpts := metav1.UpdateOptions{}


### PR DESCRIPTION
Log message is showing every time tenant lister loops.

```
I0226 17:57:43.415969       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:43.713013       1 main-controller.go:783] MinIO Tenant Main loop!!!!
I0226 17:57:43.770997       1 event.go:364] Event(v1.ObjectReference{Kind:"Tenant", Namespace:"tenant-kms-encrypted", Name:"myminio", UID:"ab470988-c1d7-43bc-8e23-65ec5a01364b", APIVersion:"minio.min.io/v2", ResourceVersion:"1575", FieldPath:""}): type: 'Warning' reason: 'UsersCreatedFailed' Users creation failed: Put "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/admin/v3/add-user?accessKey=console": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:44.123932       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:48.727244       1 main-controller.go:783] MinIO Tenant Main loop!!!!
I0226 17:57:48.806417       1 event.go:364] Event(v1.ObjectReference{Kind:"Tenant", Namespace:"tenant-kms-encrypted", Name:"myminio", UID:"ab470988-c1d7-43bc-8e23-65ec5a01364b", APIVersion:"minio.min.io/v2", ResourceVersion:"1640", FieldPath:""}): type: 'Warning' reason: 'UsersCreatedFailed' Users creation failed: Put "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/admin/v3/add-user?accessKey=console": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:49.142102       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:49.339848       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:49.921992       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:50.430847       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:52.165030       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:52.427437       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:53.185831       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:53.435563       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:53.742585       1 main-controller.go:783] MinIO Tenant Main loop!!!!
I0226 17:57:53.808196       1 event.go:364] Event(v1.ObjectReference{Kind:"Tenant", Namespace:"tenant-kms-encrypted", Name:"myminio", UID:"ab470988-c1d7-43bc-8e23-65ec5a01364b", APIVersion:"minio.min.io/v2", ResourceVersion:"1724", FieldPath:""}): type: 'Warning' reason: 'UsersCreatedFailed' Users creation failed: Put "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/admin/v3/add-user?accessKey=console": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:54.152512       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:54.424644       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
I0226 17:57:55.168760       1 monitoring.go:122] 'tenant-kms-encrypted/myminio' Failed to get cluster health: Get "https://minio.tenant-kms-encrypted.svc.cluster.local/minio/health/cluster": dial tcp 10.96.104.175:443: connect: connection refused
Stream closed EOF for minio-operator/minio-operator-99876665f-bnmcr (minio-operator)
```