### PR TITLE
Fix kes test

### DIFF
--- a/examples/vault/kes-policy.hcl
+++ b/examples/vault/kes-policy.hcl
@@ -1,3 +1,3 @@
-path "kv/my-minio/*" {
-     capabilities = [ "create", "read", "delete" ]
+path "kv/minio-tenant-1/*" {
+     capabilities = [ "create", "read", "delete", "list" ]
 }

--- a/examples/vault/kes-policy.hcl
+++ b/examples/vault/kes-policy.hcl
@@ -1,3 +1,3 @@
-path "kv/minio-tenant-1/*" {
+path "kv/my-minio/*" {
      capabilities = [ "create", "read", "delete", "list" ]
 }

--- a/testing/kes-config.yaml
+++ b/testing/kes-config.yaml
@@ -8,41 +8,10 @@ stringData:
     version: v1
     address: 0.0.0.0:7373 # The pseudo address 0.0.0.0 refers to all network interfaces 
     admin:
-      identity: c84cc9b91ae2399b043da7eca616048d4b4200edf2ff418d8af3835911db945d
+      identity: ${MINIO_KES_IDENTITY}
     tls:
       key: /tmp/kes/server.key
       cert: /tmp/kes/server.crt
-    policy:
-      my-app:
-        allow:
-        - /v1/key/create/*
-        - /v1/key/import/*
-        - /v1/key/delete/*
-        - /v1/key/list/*
-        - /v1/key/generate/*
-        - /v1/key/decrypt/*
-        - /v1/policy/describe/*
-        - /v1/policy/assign/*
-        - /v1/policy/write/*
-        - /v1/policy/read/*
-        - /v1/policy/list/*
-        - /v1/policy/delete/*
-        - /v1/identity/describe/*
-        - /v1/identity/self/describe/*
-        - /v1/identity/delete/*
-        - /v1/identity/list/*
-        - /v1/log/audit/*
-        - /v1/log/error/*
-        - /version/*
-        - /v1/api/*
-        - /v1/metrics/*
-        - /v1/status/*
-        - /v1/status
-        - /v1/metrics
-        - /v1/api
-        - /version
-        identities:
-        - ${MINIO_KES_IDENTITY}
     cache:
       expiry:
         any: 5m0s


### PR DESCRIPTION
KES test fails with minio version `RELEASE.2024-02-17T01-15-57Z`  when the Vault policy is missing the `list` grant.