### PR TITLE
Revert "feat: add annotations to operator"

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -266,15 +266,6 @@ func NewController(
 			}
 		}
 	}
-	if len(oprImg) > 0 {
-		imageInfo := strings.Split(oprImg, ":")
-		if len(imageInfo) == 2 {
-			_, err = kubeClientSet.AppsV1().Deployments(ns).Patch(ctx, getOperatorDeploymentName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"min.io/operator":"`+imageInfo[1]+`"}}}`), metav1.PatchOptions{})
-			if err != nil {
-				klog.Errorf("Patch operator deployments annotations['min.io/operator':'%s'] err: %s", imageInfo[1], err)
-			}
-		}
-	}
 
 	oprImg = env.Get(DefaultOperatorImageEnv, oprImg)
 


### PR DESCRIPTION
Reverts minio/operator#1914

`oprImg` has the value detected from the container image, we want to have this annotation on the deployment