### PR TITLE
Annotate Operator Deployment with Version

### DIFF
--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -290,7 +290,7 @@ spec:
         - args:
             - ui
             - --certs-dir=/tmp/certs
-          image: minio/operator:v5.0.13
+          image: minio/operator:v5.0.12
           imagePullPolicy: IfNotPresent
           name: console
           securityContext:

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -273,7 +273,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: minio-operator
     app.kubernetes.io/name: operator
-    operator.min.io/version: v5.0.12
+    min.io/operator: v5.0.12
 spec:
   replicas: 1
   selector:

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -273,6 +273,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: minio-operator
     app.kubernetes.io/name: operator
+    operator.min.io/version: v5.0.12
 spec:
   replicas: 1
   selector:
@@ -289,7 +290,7 @@ spec:
         - args:
             - ui
             - --certs-dir=/tmp/certs
-          image: minio/operator:v5.0.12
+          image: minio/operator:v5.0.13
           imagePullPolicy: IfNotPresent
           name: console
           securityContext:
@@ -327,5 +328,5 @@ spec:
                   name: console-tls
                   optional: true
         - name: tmp
-          emptyDir: {}
+          emptyDir: { }
       serviceAccountName: console-sa

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: minio-operator
     app.kubernetes.io/name: operator
+    operator.min.io/version: v5.0.12
 spec:
   replicas: 2
   selector:

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: minio-operator
     app.kubernetes.io/name: operator
-    operator.min.io/version: v5.0.12
+    min.io/operator: v5.0.12
 spec:
   replicas: 2
   selector:


### PR DESCRIPTION
we will add `operator.min.io/version: v5.0.12` label to indiciate the release, this string will get updated with each release