### PR TITLE
feat: wait tenant be green to do command

### DIFF
--- a/helm/operator/templates/job.min.io_jobs.yaml
+++ b/helm/operator/templates/job.min.io_jobs.yaml
@@ -98,11 +98,10 @@ spec:
                   - result
                   type: object
                 type: array
+              message:
+                type: string
               phase:
                 type: string
-            required:
-            - commands
-            - phase
             type: object
         type: object
     served: true

--- a/helm/operator/templates/operator-clusterrole.yaml
+++ b/helm/operator/templates/operator-clusterrole.yaml
@@ -4,16 +4,6 @@ metadata:
   name: minio-operator-role
 rules:
   - apiGroups:
-      - "job.min.io"
-    resources:
-      - miniojobs
-    verbs:
-      - list
-      - get
-      - update
-      - delete
-      - watch
-  - apiGroups:
       - "apiextensions.k8s.io"
     resources:
       - customresourcedefinitions
@@ -151,6 +141,7 @@ rules:
   - apiGroups:
       - minio.min.io
       - sts.min.io
+      - job.min.io
     resources:
       - "*"
     verbs:

--- a/pkg/apis/job.min.io/v1alpha1/types.go
+++ b/pkg/apis/job.min.io/v1alpha1/types.go
@@ -123,10 +123,12 @@ type TenantRef struct {
 
 // MinIOJobStatus Status of MinioJob resource
 type MinIOJobStatus struct {
-	// *Required* +
+	// +optional
 	Phase string `json:"phase"`
-	// *Required* +
+	// +optional
 	CommandsStatus []CommandStatus `json:"commands"`
+	// +optional
+	Message string `json:"message"`
 }
 
 // CommandStatus Status of MinioJob command execution

--- a/pkg/controller/job-controller.go
+++ b/pkg/controller/job-controller.go
@@ -5,16 +5,17 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"fmt"
 	"github.com/minio/minio-go/v7/pkg/set"
-	"k8s.io/apimachinery/pkg/api/meta"
-
 	"github.com/minio/operator/pkg/apis/job.min.io/v1alpha1"
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	clientset "github.com/minio/operator/pkg/client/clientset/versioned"
 	jobinformers "github.com/minio/operator/pkg/client/informers/externalversions/job.min.io/v1alpha1"
 	joblisters "github.com/minio/operator/pkg/client/listers/job.min.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -207,15 +208,37 @@ func (c *JobController) SyncHandler(key string) (Result, error) {
 		runtime.HandleError(fmt.Errorf("Invalid resource key: %s", key))
 		return WrapResult(Result{}, nil)
 	}
-	namespace, tenantName := key2NamespaceName(key)
+	namespace, jobName := key2NamespaceName(key)
+	ctx := context.Background()
 	jobCR := v1alpha1.MinIOJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tenantName,
+			Name:      jobName,
 			Namespace: namespace,
 		},
 	}
-	err := c.k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&jobCR), &jobCR)
+	err := c.k8sClient.Get(ctx, client.ObjectKeyFromObject(&jobCR), &jobCR)
 	if err != nil {
+		// job cr have gone
+		if errors.IsNotFound(err) {
+			return WrapResult(Result{}, nil)
+		}
+		return WrapResult(Result{}, err)
+	}
+	// get tenant
+	tenant := &miniov2.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: jobCR.Spec.TenantRef.Namespace,
+			Name:      jobCR.Spec.TenantRef.Name,
+		},
+	}
+	err = c.k8sClient.Get(ctx, client.ObjectKeyFromObject(tenant), tenant)
+	if err != nil {
+		jobCR.Status.Phase = "Error"
+		jobCR.Status.Message = fmt.Sprintf("Get tenant %s/%s error:%v", jobCR.Spec.TenantRef.Namespace, jobCR.Spec.TenantRef.Name, err)
+		err = c.updateJobStatus(ctx, &jobCR)
+		return WrapResult(Result{}, err)
+	}
+	if tenant.Status.HealthStatus != miniov2.HealthStatusGreen {
 		return WrapResult(Result{RequeueAfter: time.Second * 5}, nil)
 	}
 	// Loop through the different supported operations.
@@ -226,4 +249,8 @@ func (c *JobController) SyncHandler(key string) (Result, error) {
 		}
 	}
 	return WrapResult(Result{}, err)
+}
+
+func (c *JobController) updateJobStatus(ctx context.Context, job *v1alpha1.MinIOJob) error {
+	return c.k8sClient.Status().Update(ctx, job)
 }

--- a/pkg/controller/job-controller.go
+++ b/pkg/controller/job-controller.go
@@ -5,9 +5,9 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"fmt"
 	"github.com/minio/minio-go/v7/pkg/set"
 	"github.com/minio/operator/pkg/apis/job.min.io/v1alpha1"
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"

--- a/pkg/controller/job-controller.go
+++ b/pkg/controller/job-controller.go
@@ -241,6 +241,7 @@ func (c *JobController) SyncHandler(key string) (Result, error) {
 	if tenant.Status.HealthStatus != miniov2.HealthStatusGreen {
 		return WrapResult(Result{RequeueAfter: time.Second * 5}, nil)
 	}
+	fmt.Println("will do somthing next")
 	// Loop through the different supported operations.
 	for _, val := range jobCR.Spec.Commands {
 		operation := val.Operation

--- a/resources/base/cluster-role.yaml
+++ b/resources/base/cluster-role.yaml
@@ -4,16 +4,6 @@ metadata:
   name: minio-operator-role
 rules:
   - apiGroups:
-      - "job.min.io"
-    resources:
-      - miniojobs
-    verbs:
-      - list
-      - get
-      - update
-      - delete
-      - watch
-  - apiGroups:
       - "apiextensions.k8s.io"
     resources:
       - customresourcedefinitions
@@ -150,6 +140,7 @@ rules:
   - apiGroups:
       - minio.min.io
       - sts.min.io
+      - job.min.io
     resources:
       - "*"
     verbs:

--- a/resources/base/crds/job.min.io_miniojobs.yaml
+++ b/resources/base/crds/job.min.io_miniojobs.yaml
@@ -98,11 +98,10 @@ spec:
                   - result
                   type: object
                 type: array
+              message:
+                type: string
               phase:
                 type: string
-            required:
-            - commands
-            - phase
             type: object
         type: object
     served: true


### PR DESCRIPTION
feat: wait tenant be green to do command

**How to test:**
Deploy tenant and 
```
apiVersion: job.min.io/v1alpha1
kind: MinIOJob
metadata:
  name: minio-test-job
  namespace: default
spec:
  serviceAccountName: minio
  tenant:
    name: mytest-minio
    namespace: default
  commands:
    - name: create-minio
      op: make-bucket
      args:
        name: memes
      dependsOn: []
```
1. When tenant have gone (or ref a unknown tenant). MinIOJob should have a Error status.
2. When tenant have been green. Operator should print `will do somthing next` .