### PR TITLE
Issue 1984

### DIFF
--- a/helm/operator/README.md
+++ b/helm/operator/README.md
@@ -32,6 +32,56 @@ helm install \
 
 The command deploys MinIO Operator on the Kubernetes cluster in the default configuration.
 
+Deploy Operator with Ingress controller enabled
+-----------------------------------------------
+
+**Expose HTTP route to operator `console` service**
+
+Install this chart using:
+
+```bash
+helm install \
+  --namespace minio-operator \
+  --create-namespace \
+  --set console.ingress.enabled="true" \
+  --set console.ingress.host="hostname" \
+  --set console.ingress.ingressClassName="class-name" \
+  minio-operator minio/operator
+```
+
+Replace `hostname` by the domain of your external load balancer to interface it with the ingress controller.
+
+Replace `class-name` by the ingress class name of the ingress controller intended to perform the routing (for example `nginx`).
+
+**Expose HTTPS route to operator `console` service**
+
+Install this chart using:
+
+```bash
+helm install \
+  --namespace minio-operator \
+  --create-namespace \
+  --set console.ingress.enabled="true" \
+  --set console.ingress.host="hostname" \
+  --set console.ingress.tls.enabled="true" \
+  --set console.ingress.tls.secretName="certificate-tls-secret-name" \
+  --set console.ingress.ingressClassName="class-name" \
+  minio-operator minio/operator
+```
+
+Replace `hostname` by the domain of your external load balancer to interface it with the ingress controller. The `hostname` must match either the Common Name (CN) in your CA certificate or any of the Subject Alternative Names (SANs) for the certificate to be considered valid.
+
+Replace `class-name` by the ingress class name of the ingress controller intended to perform the routing (for example `nginx`).
+
+To mount the CA certificate as a secret use:
+
+```bash
+kubectl create secret tls certificate-tls-secret-name \
+  --cert=/path/to/certificate.crt \
+  --key=/path/to/certificatePrivate.key \
+  --namespace minio-operator
+```
+
 Creating a Tenant
 -----------------
 

--- a/helm/operator/templates/console-ingress.yaml
+++ b/helm/operator/templates/console-ingress.yaml
@@ -15,15 +15,11 @@ spec:
   {{- with .Values.console.ingress.ingressClassName }}
   ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.console.ingress.tls }}
+  {{- if .Values.console.ingress.tls.enabled }}
   tls:
-    {{- range .Values.console.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+      - {{ .Values.console.ingress.host }}
+      secretName: {{ .Values.console.ingress.tls.secretName }}
   {{- end }}
   rules:
     - host: {{ .Values.console.ingress.host }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -285,7 +285,9 @@ console:
     ingressClassName: ""
     labels: { }
     annotations: { }
-    tls: [ ]
+    tls:
+      enabled: false
+      secretName: ""
     host: console.local
     path: /
     pathType: Prefix


### PR DESCRIPTION
Changes added:

1) Ingress specification added for minio operator console to route http/https traffic to console service 
2) Only support 1 CA certificate for https routing (instead of multiple TLS configurations) since only 1 console service is defined in the ingress configuration

Fixes https://github.com/minio/operator/issues/1984