### PR TITLE
Add support for dnsConfig in the podSpec of the statefulset

### DIFF
--- a/docs/job_crd.adoc
+++ b/docs/job_crd.adoc
@@ -4,7 +4,7 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-03-05T04-48-44Z]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-03-10T02-53-48Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-03-01T18-06-46Z]
 
 

--- a/docs/job_crd.adoc
+++ b/docs/job_crd.adoc
@@ -4,8 +4,8 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-02-09T21-25-16Z]
-:kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-01-11T13-09-29Z]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-03-05T04-48-44Z]
+:kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-03-01T18-06-46Z]
 
 
 [id="{anchor_prefix}-job-min-io-v1alpha1"]

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -830,6 +830,11 @@ TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. +
 |*Optional* + 
  If provided, statefulset will add these volumes. You should set the rules for the corresponding volumes and volume mounts. We will not test this rule, k8s will show the result.
 
+|*`dnsConfig`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#poddnsconfig-v1-core[$$PodDNSConfig$$]__ 
+|*Optional* + 
+ If provided, will set the DNS config in the statefulset. This is applied to MinIO pods only. + 
+ Refer Kubernetes https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config[Pod DNS config documentation] for more complete documentation.
+
 |===
 
 

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -853,6 +853,26 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              dnsConfig:
+                properties:
+                  nameservers:
+                    items:
+                      type: string
+                    type: array
+                  options:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  searches:
+                    items:
+                      type: string
+                    type: array
+                type: object
               env:
                 items:
                   properties:

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -361,6 +361,14 @@ type TenantSpec struct {
 	// If provided, statefulset will add these volumes. You should set the rules for the corresponding volumes and volume mounts. We will not test this rule, k8s will show the result.
 	// +optional
 	AdditionalVolumeMounts []corev1.VolumeMount `json:"additionalVolumeMounts,omitempty"`
+	// *Optional* +
+	//
+	// If provided, will set the DNS config in the statefulset.
+	// This is applied to MinIO pods only. +
+	//
+	// Refer Kubernetes https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config[Pod DNS config documentation] for more complete documentation.
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
 }
 
 // Logging describes Logging for MinIO tenants.

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -830,6 +830,7 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 					SecurityContext:           poolSecurityContext(pool, poolStatus),
 					ServiceAccountName:        t.Spec.ServiceAccountName,
 					PriorityClassName:         t.Spec.PriorityClassName,
+					DNSConfig:                 t.Spec.DNSConfig,
 				},
 			},
 		},

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -853,6 +853,26 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              dnsConfig:
+                properties:
+                  nameservers:
+                    items:
+                      type: string
+                    type: array
+                  options:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  searches:
+                    items:
+                      type: string
+                    type: array
+                type: object
               env:
                 items:
                   properties:


### PR DESCRIPTION
This will provide a way to set custom DNS servers for the pods.

Reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config

Steps to test 

- Create a tenant
- Set the `dnsConfig` in the tenant spec and apply it. For example, 

```yaml
dnsConfig:
    nameservers:
      - 192.0.2.1 # this is an example
```
- Check if the specified nameserver got appended in `/etc/resolv.conf` inside the pods - `kubectl exec -it -n <tenant-ns> <tenant-pod> -- cat /etc/resolv.conf`