### PR TITLE
Document boolean behaviour of helm .secrets.existingSecret

### DIFF
--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -1,4 +1,10 @@
-{{- if not .Values.secrets.existingSecret }}
+{{- if (.Values.secrets) }}
+{{- print "# WARNING: '.secrets' is deprecated since v5.0.15 and will be removed in next minor release (i.e. v5.1.0). Please use '.tenant.configSecret' instead." }}
+{{- end }}
+{{- if and (.Values.secrets) (.Values.tenant.configSecret) }}
+{{- fail "ERROR: '.secrets' and '.tenant.configSecret' are mutually exclusive. Please use 'tenant.configSecret' instead." }}
+{{- end }}
+{{- if and (.Values.secrets) (not (.Values.secrets).existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +14,15 @@ stringData:
   config.env: |-
     export MINIO_ROOT_USER={{ .Values.secrets.accessKey | quote }}
     export MINIO_ROOT_PASSWORD={{ .Values.secrets.secretKey | quote }}
+{{- end }}
+{{- if and (.Values.tenant.configSecret) (not (.Values.tenant.configSecret).existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ dig "tenant" "configSecret" "name" "" (.Values | merge (dict)) }}
+type: Opaque
+stringData:
+  config.env: |-
+    export MINIO_ROOT_USER={{ .Values.tenant.configSecret.accessKey | quote }}
+    export MINIO_ROOT_PASSWORD={{ .Values.tenant.configSecret.secretKey | quote }}
 {{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -20,7 +20,8 @@ secrets:
   accessKey: minio 
   secretKey: minio123
   ###
-  # The name of an existing Kubernetes secret to import to the MinIO Tenant
+  # If this variable is set, then enable the usage of an existing Kubernetes secret to set environment variables for the Tenant.
+  # The existing Kubernetes secret name must be placed under .tenant.configuration.name e.g. existing-minio-env-configuration
   # The secret must contain a key ``config.env``.
   # The values should be a series of export statements to set environment variables for the Tenant.
   # For example:
@@ -33,7 +34,7 @@ secrets:
   #         export MINIO_ROOT_PASSWORD=ROOTUSERPASSWORD
   #
   #existingSecret:
-  #  name: myminio-env-configuration
+  #  name: enabled
 ###
 # Root key for MinIO Tenant Chart
 tenant:

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,4 +1,6 @@
 ###
+# WARNING: '.secrets' is deprecated since v5.0.15 and will be removed in next minor release (i.e. v5.1.0).
+# WARNING: Please use '.tenant.configSecret' instead.
 # Root key for dynamically creating a secret for use with configuring root MinIO User
 # Specify the ``name`` and then a list of environment variables. 
 #
@@ -29,7 +31,7 @@ secrets:
   # .. code-block:: shell
   #
   #    stringData:
-  #       config.env: | -
+  #       config.env: |-
   #         export MINIO_ROOT_USER=ROOTUSERNAME
   #         export MINIO_ROOT_PASSWORD=ROOTUSERPASSWORD
   #
@@ -85,6 +87,42 @@ tenant:
   # The secret is expected to have a key named config.env containing environment variables exports.
   configuration:
     name: myminio-env-configuration
+  ###
+  # Root key for dynamically creating a secret for use with configuring root MinIO User
+  # Specify the ``name`` and then a list of environment variables.
+  #
+  # .. important::
+  #
+  #    Do not use this in production environments.
+  #    This field is intended for use with rapid development or testing only.
+  #
+  # For example:
+  #
+  # .. code-block:: yaml
+  #
+  #    name: myminio-env-configuration
+  #    accessKey: minio
+  #    secretKey: minio123
+  #
+  # configSecret:
+  #   name: myminio-env-configuration
+  #   accessKey: minio
+  #   secretKey: minio123
+  ###
+  # If this variable is set to true, then enable the usage of an existing Kubernetes secret to set environment variables for the Tenant.
+  # The existing Kubernetes secret name must be placed under .tenant.configuration.name e.g. existing-minio-env-configuration
+  # The secret must contain a key ``config.env``.
+  # The values should be a series of export statements to set environment variables for the Tenant.
+  # For example:
+  #
+  # .. code-block:: shell
+  #
+  #    stringData:
+  #       config.env: |-
+  #         export MINIO_ROOT_USER=ROOTUSERNAME
+  #         export MINIO_ROOT_PASSWORD=ROOTUSERPASSWORD
+  #
+  #   existingSecret: false
   ###
   # Top level key for configuring MinIO Pool(s) in this Tenant.
   #
@@ -452,7 +490,7 @@ ingress:
 #    kind: Secret
 #    type: Opaque
 #    metadata:
-#      name: {{ dig "secrets" "existingSecret" "" (.Values | merge (dict)) }}
+#      name: {{ dig "tenant" "configSecret" "name" "" (.Values | merge (dict)) }}
 #    stringData:
 #      config.env: |-
 #        export MINIO_ROOT_USER='minio'


### PR DESCRIPTION
### Summary
#### Current functionality
If `.secrets.existingSecret` is set, then enable the usage of an existing Kubernetes secret to set environment variables for the Tenant.
The existing Kubernetes secret name must be placed under .tenant.configuration.name e.g. `existing-minio-env-configuration`.

#### Proposed functionality
Refactor tenant-configuration.yaml to consider boolean .tenant.configSecret.existingSecret, instead of string .secrets.existingSecret. 
Current functionality uses counterintuitively the existence of string .secrets.existingSecret when creating a secret with MINIO_ROOT_USER and MINIO_ROOT_PASSWORD, versus using an existing secret with these and similar environment variables.
Proposed functionality:
- uses a clear boolean .tenant.configSecret.existingSecret instead.
- provides warnings when using current functionality
- indicates when the deprecated field will be removed i.e. next minor version
- prevents usage of both functionalities; string .tenant.configSecret.existingSecret, instead of string .secrets.existingSecret

### Tests. See https://github.com/allanrogerr/public/wiki/operator-2032
#### Summary
Tests 1-4: Regression tests of current functionality
Tests 5-9: Integration tests of proposed functionality
