### PR TITLE
Allow using a custom secret name

### DIFF
--- a/helm/tenant/templates/obsolete.yaml
+++ b/helm/tenant/templates/obsolete.yaml
@@ -1,0 +1,6 @@
+{{/* See https://github.com/minio/operator/pull/2034 */}}
+{{- if and .Values.tenant .Values.tenant.configuration }}
+{{- if .Values.tenant.configuration.name }}
+{{- fail "tenant.configuration.name is obsolete now." }}
+{{- end }}
+{{- end }}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -27,7 +27,7 @@ spec:
   {{- end }}
   ## Secret with default environment variable configurations
   configuration:
-    name: {{ .configuration.name }}
+    name: {{ (coalesce $.Values.secrets.existingSecret $.Values.secrets).name }}
   pools:
     {{- range (dig "pools" (list) .) }}
     - servers: {{ dig "servers" 4 . }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -80,11 +80,6 @@ tenant:
   # Specify an empty dictionary ``{}`` to dispatch pods with the default scheduler.
   scheduler: { }
   ###
-  # The Kubernetes secret name that contains MinIO environment variable configurations.
-  # The secret is expected to have a key named config.env containing environment variables exports.
-  configuration:
-    name: myminio-env-configuration
-  ###
   # Top level key for configuring MinIO Pool(s) in this Tenant.
   #
   # See `Operator CRD: Pools <https://min.io/docs/minio/kubernetes/upstream/reference/operator-crd.html#pool>`__ for more information on all subfields.


### PR DESCRIPTION
The Helm chart to create a new tenant allows to specify `.secrets.existingSecret.name` (if you already have a secret) or `.secrets.name` (if you want to create a new secret by the Helm chart). When setting the secret's name, the tenant won't initialize properly and the operator shows the following error message:

```text
main-controller.go:697] error syncing 'minio/tenant': secrets "myminio-env-configuration" not found
```

After some digging it seems that you also need to set the `.tenant.configuration.name` value to the secret name to make it work. This isn't obvious from the documentation.

Because these values should always be identical, it doesn't make much sense to use the `.tenant.configuration.name` value in the Helm chart. This PR sets the tenant configuration to the (existing) secret name, so you only need to set one value. Because the Helm chart won't create a new secret when `.secrets.existingSecret.name` is set, this value has precedence above `.secrets.name`.