### PR TITLE
Allow root credentials via Tenant.Spec.Env

### DIFF
--- a/pkg/controller/tenants.go
+++ b/pkg/controller/tenants.go
@@ -153,6 +153,12 @@ func (c *Controller) getTenantCredentials(ctx context.Context, tenant *miniov2.T
 
 	for _, config := range tenant.GetEnvVars() {
 		tenantConfiguration[config.Name] = []byte(config.Value)
+		// Allow root credentials via Tenant.Spec.Env
+		if config.Name == "MINIO_ROOT_USER" || config.Name == "MINIO_ACCESS_KEY" {
+			tenantConfiguration["accesskey"] = tenantConfiguration["MINIO_ROOT_USER"]
+		} else if config.Name == "MINIO_ROOT_PASSWORD" || config.Name == "MINIO_SECRET_KEY" {
+			tenantConfiguration["secretkey"] = tenantConfiguration["MINIO_ROOT_PASSWORD"]
+		}
 	}
 
 	// Load tenant configuration from file


### PR DESCRIPTION
### Objective:

To enable root credentials via `Tenant.Spec.Env`.

```yaml
kind: Tenant
spec:
  env:
    - name: MINIO_ROOT_USER
      valueFrom:
        secretKeyRef:
          name: username
          key: usernamekey
    - name: MINIO_ROOT_PASSWORD
      valueFrom:
        secretKeyRef:
          name: password
          key: passwordkey
```

### Story:

In issue https://github.com/minio/operator/issues/1795, the community is requesting a refactor to avoid using our config file inside the secret. Instead, they propose using valueFrom as a more Kubernetes-oriented approach. Implementing this change may potentially be disruptive, requiring a significant amount of code changes, and might not be backward compatible.

However, I have conceived an idea to simplify this process for users who do not prefer our configuration secret. Instead, they can utilize environmental variables in the tenant spec, which can be read from a secret using valueFrom, thereby streamlining the change. Currently, this isn't feasible because we have not defined the access key and secret key values as we do for the config file in the helper:

```go
config[ekv.Key] = []byte(ekv.Value)
if ekv.Key == "MINIO_ROOT_USER" || ekv.Key == "MINIO_ACCESS_KEY" {
	config["accesskey"] = config[ekv.Key]
} else if ekv.Key == "MINIO_ROOT_PASSWORD" || ekv.Key == "MINIO_SECRET_KEY" {
	config["secretkey"] = config[ekv.Key]
}
```

