### PR TITLE
fix: no default label when nothing set for console service

### DIFF
--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -89,6 +89,8 @@ func NewClusterIPForConsole(t *miniov2.Tenant) *corev1.Service {
 	}
 	if t.Spec.ServiceMetadata != nil && t.Spec.ServiceMetadata.ConsoleServiceLabels != nil {
 		labels = miniov2.MergeMaps(internalLabels, t.Spec.ServiceMetadata.ConsoleServiceLabels)
+	} else {
+		labels = internalLabels
 	}
 
 	if t.Spec.ServiceMetadata != nil && t.Spec.ServiceMetadata.ConsoleServiceAnnotations != nil {


### PR DESCRIPTION
no default label when nothing set for console service