### PR TITLE
Display UI binary error messages instead of silently exiting

### DIFF
--- a/cmd/operator/ui.go
+++ b/cmd/operator/ui.go
@@ -186,7 +186,12 @@ func startOperatorServer(ctx *cli.Context) error {
 
 	defer server.Shutdown()
 
-	return server.Serve()
+	if err = server.Serve(); err != nil {
+		server.Logf("error serving API: %v", err)
+		return err
+	}
+
+	return nil
 }
 
 func loadAllCerts(ctx *cli.Context) error {


### PR DESCRIPTION
In the same vein as minio/console#3276, we would like to record the error when an error prevents `./minio-operator ui` from running.

Fixes #1755