### PR TITLE
fix: correctly validate root credentials from secret

### DIFF
--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -151,23 +151,23 @@ func NewSideCarController(kubeClient *kubernetes.Clientset, controllerClient *cl
 			}
 			data := newSecret.Data["config.env"]
 			// validate root creds in string
-			rootUserMissing := true
-			rootPassMissing := false
+			rootUserFound := false
+			rootPwdFound := false
 
 			dataStr := string(data)
-			if !strings.Contains(dataStr, "MINIO_ROOT_USER") {
-				rootUserMissing = true
+			if strings.Contains(dataStr, "MINIO_ROOT_USER") {
+				rootUserFound = true
 			}
-			if !strings.Contains(dataStr, "MINIO_ACCESS_KEY") {
-				rootUserMissing = true
+			if strings.Contains(dataStr, "MINIO_ACCESS_KEY") {
+				rootUserFound = true
 			}
-			if !strings.Contains(dataStr, "MINIO_ROOT_PASSWORD") {
-				rootPassMissing = true
+			if strings.Contains(dataStr, "MINIO_ROOT_PASSWORD") {
+				rootPwdFound = true
 			}
-			if !strings.Contains(dataStr, "MINIO_SECRET_KEY") {
-				rootPassMissing = true
+			if strings.Contains(dataStr, "MINIO_SECRET_KEY") {
+				rootPwdFound = true
 			}
-			if rootUserMissing || rootPassMissing {
+			if !rootUserFound || !rootPwdFound {
 				log.Println("Missing root credentials in the configuration.")
 				log.Println("MinIO won't start")
 				os.Exit(1)


### PR DESCRIPTION
When using the MinIO operator to deploy a tenant, the operator-deployed sidecar container keeps crashing on startup:

```
2024/03/31 22:02:42 sidecar.go:48: Starting Sidecar
2024/03/31 22:03:28 sidecar.go:171: Missing root credentials in the configuration.
2024/03/31 22:03:28 sidecar.go:172: MinIO won't start
```

This occurs when deploying https://github.com/minio/operator/tree/master/helm/tenant, even with *default* values, with a configuration secret in the same form as the automatically generated one:

```
apiVersion: v1
kind: Secret
metadata:
  name: myminio-env-configuration
stringData:
  config.env: |-
    export MINIO_ROOT_USER="minio"
    export MINIO_ROOT_PASSWORD="minio123"
type: Opaque
```

After a bunch of messing around with the configuration I figured out that this is a bug introduced in https://github.com/minio/operator/pull/1437. Regardless of the configuration provided in the secret, the following check will *always* fail due to `rootUserMissing := true`, and even if that is fixed, it will still fail unless all four of the supported environment variables are defined, even though AFAICT they are supposed to be either-or (user/pass or access/secret):

https://github.com/minio/operator/blob/a6a3e21dc7c0e9cac88b12a6fed63e8cce8308d1/pkg/sidecar/sidecar.go#L153-L174

This PR fixes the issue by copying the intended logic from `validator.go`:

https://github.com/minio/operator/blob/a6a3e21dc7c0e9cac88b12a6fed63e8cce8308d1/pkg/validator/validator.go#L110-L128

Tested working in a bare-metal deployment.

Two questions remain:

- How has this not been caught for over a year at this point? I'm beginning to doubt whether the operator is production-ready. Am I doing something incorrectly?
- There are three identical instances of the `Missing root credentials in the configuration.` termination in the code without a way to easily distinguish between them from stdout. Maybe a proper logging framework could be of use here?