### PR TITLE
To use port number instead of port name

### DIFF
--- a/helm/operator/templates/console-ingress.yaml
+++ b/helm/operator/templates/console-ingress.yaml
@@ -35,6 +35,6 @@ spec:
               service:
                 name: "console"
                 port:
-                  name: http
+                  number: {{ .Values.console.ingress.number }}
 {{- end }}
 {{- end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -24,9 +24,12 @@ operator:
   #      value: "OpenShift" 
   #
   # See `Operator environment variables <https://github.com/minio/operator/blob/master/docs/env-variables.md>`__ for a list of all supported values.
+  # If MINIO_CONSOLE_TLS_ENABLE is enabled, utilize port 9443 for console.ingress.number.
   env:
     - name: OPERATOR_STS_ENABLED
       value: "on"
+    - name: MINIO_CONSOLE_TLS_ENABLE
+      value: "off"
   # An array of additional annotations to be applied to the operator service account
   serviceAccountAnnotations: []
   ###
@@ -280,6 +283,8 @@ console:
   # Configures `Ingress <https://kubernetes.io/docs/concepts/services-networking/ingress/>`__ for the Operator Console.
   #
   # Set the keys to conform to the Ingress controller and configuration of your choice.
+  # Set console.ingress.number to any port. For example:
+  # You may choose port number 9443 for HTTPS or 9090 for HTTP, as desired.
   ingress:
     enabled: false
     ingressClassName: ""
@@ -289,6 +294,7 @@ console:
     host: console.local
     path: /
     pathType: Prefix
+    number: 9090
   ###
   # An array of `Volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`__ which the Operator Console can mount to pods.
   #


### PR DESCRIPTION
fixes: https://github.com/minio/operator/issues/1984
### Objectives:

* To fix https://github.com/minio/operator/issues/1984
* To ensure flexibility in selecting the port number for the Operator console, whether utilizing TLS or not.

### Current problem:

* We are hardcoding service.port.name to be http only, necessitating patching.

```yaml
  rules:
    - host: {{ .Values.console.ingress.host }}
      http:
        paths:
          - path: {{ .Values.console.ingress.path }}
            pathType: {{ .Values.console.ingress.pathType }}
            backend:
              service:
                name: "console"
                port:
                  name: http <------- here
```

### Solution:

* By utilizing `service.port.number`, we provide flexibility in port selection, enabling users to choose TLS on or off according to their requirements, without requiring them to patch our ingress.

<img width="625" alt="Screenshot 2024-04-05 at 11 52 47 AM" src="https://github.com/minio/operator/assets/6667358/0f5cafbf-336f-48d5-9299-647ea0659a79">

### Documentation:

* The documentation regarding port types can be found at: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules.

```
A list of paths (for example, /testpath), each of which has an associated backend defined with a service.name and a service.port.name or service.port.number. Both the host and path must match the content of an incoming request before the load balancer directs traffic to the referenced Service.
```

Notice is either one or the other but not both: `service.port.name` or `service.port.number`