### PR TITLE
feat: support more type to admin/config/set

### DIFF
--- a/pkg/utils/miniojob/minioJob_test.go
+++ b/pkg/utils/miniojob/minioJob_test.go
@@ -51,49 +51,49 @@ func TestParser(t *testing.T) {
 	}{
 		{
 			command:     FLAGS("--user"),
-			args:        args,
-			expect:      Arg{Command: "--with-locks --region=us-west-2"},
+			args:        copyArgs(args),
+			expect:      Arg{Command: "--region=us-west-2 --with-locks"},
 			expectError: false,
 		},
 		{
 			command:     FLAGS("user"),
-			args:        args,
-			expect:      Arg{Command: "--with-locks --region=us-west-2"},
+			args:        copyArgs(args),
+			expect:      Arg{Command: "--region=us-west-2 --with-locks"},
 			expectError: false,
 		},
 		{
 			command:     Key("password"),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "somepassword"},
 			expectError: false,
 		},
 		{
 			command:     KeyForamt("user", "--user $0"),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "--user a b c d"},
 			expectError: false,
 		},
 		{
 			command:     KeyForamt("user", "--user"),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "--user a b c d"},
 			expectError: false,
 		},
 		{
 			command:     ALIAS(),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "myminio"},
 			expectError: false,
 		},
 		{
 			command:     Static("test-static"),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "test-static"},
 			expectError: false,
 		},
 		{
 			command: File("policy", "json"),
-			args:    args,
+			args:    copyArgs(args),
 			expect: Arg{
 				FileName: "policy",
 				FileExt:  "json",
@@ -117,31 +117,31 @@ func TestParser(t *testing.T) {
 		},
 		{
 			command:     OneOf(KeyForamt("user", "--user"), KeyForamt("group", "--group")),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "--user a b c d"},
 			expectError: false,
 		},
 		{
 			command:     OneOf(KeyForamt("miss_user", "--user"), KeyForamt("group", "--group")),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "--group group1 group2 group3"},
 			expectError: false,
 		},
 		{
 			command:     OneOf(KeyForamt("miss_user", "--user"), KeyForamt("miss_group", "--group")),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "--group group1 group2 group3"},
 			expectError: true,
 		},
 		{
 			command:     Sanitize(ALIAS(), Static("/"), Key("name")),
-			args:        args,
+			args:        copyArgs(args),
 			expect:      Arg{Command: "myminio/mybucketName"},
 			expectError: false,
 		},
 	}
 	for _, tc := range testCase {
-		cmd, err := tc.command(args)
+		cmd, err := tc.command(tc.args)
 		if tc.expectError && err == nil {
 			t.Fatalf("expectCommand error")
 		}
@@ -239,7 +239,7 @@ func TestMCConfigSet(t *testing.T) {
 				"client_cert": "cert1",
 				"client_key":  "key1",
 			},
-			expectCommand:    "myminio webhook1 endpoint=\"endpoint1\" auth_token=\"token1\" client_key=\"/temp/client_key.key\" client_cert=\"/temp/client_cert.pem\"",
+			expectCommand:    "myminio webhook1 endpoint=\"endpoint1\" client_key=\"/temp/client_key.key\" client_cert=\"/temp/client_cert.pem\" auth_token=\"token1\"",
 			expectFileNumber: 2,
 		},
 		{
@@ -250,7 +250,7 @@ func TestMCConfigSet(t *testing.T) {
 				"auth_token":  "token1",
 				"client_key":  "key1",
 			},
-			expectCommand:    "myminio webhook1 endpoint=\"endpoint1\" auth_token=\"token1\" client_key=\"/temp/client_key.key\"",
+			expectCommand:    "myminio webhook1 endpoint=\"endpoint1\" client_key=\"/temp/client_key.key\" auth_token=\"token1\"",
 			expectFileNumber: 1,
 		},
 		{
@@ -263,6 +263,50 @@ func TestMCConfigSet(t *testing.T) {
 			expectCommand:    "myminio webhook1 endpoint=\"endpoint1\" client_key=\"/temp/client_key.key\"",
 			expectFileNumber: 1,
 		},
+		{
+			name: "notify_mysql",
+			args: map[string]string{
+				"webhookName": "notify_mysql",
+				"dsn_string":  "username:password@tcp(mysql.example.com:3306)/miniodb",
+				"table":       "minioevents",
+				"format":      "namespace",
+			},
+			expectCommand:    "myminio notify_mysql dsn_string=\"username:password@tcp(mysql.example.com:3306)/miniodb\" format=\"namespace\" table=\"minioevents\"",
+			expectFileNumber: 0,
+		},
+		{
+			name: "notify_amqp",
+			args: map[string]string{
+				"webhookName": "notify_amqp:primary",
+				"url":         "user:password@amqp://amqp-endpoint.example.net:5672",
+			},
+			expectCommand:    "myminio notify_amqp:primary url=\"user:password@amqp://amqp-endpoint.example.net:5672\"",
+			expectFileNumber: 0,
+		},
+		{
+			name: "notify_elasticsearch",
+			args: map[string]string{
+				"webhookName": "notify_elasticsearch:primary",
+				"url":         "user:password@https://elasticsearch-endpoint.example.net:9200",
+				"index":       "bucketevents",
+				"format":      "namespace",
+			},
+			expectCommand:    "myminio notify_elasticsearch:primary format=\"namespace\" index=\"bucketevents\" url=\"user:password@https://elasticsearch-endpoint.example.net:9200\"",
+			expectFileNumber: 0,
+		},
+		{
+			name: "identity_ldap",
+			args: map[string]string{
+				"webhookName":             "identity_ldap",
+				"enabled":                 "true",
+				"server_addr":             "ad-ldap.example.net/",
+				"lookup_bind_dn":          "cn=miniolookupuser,dc=example,dc=net",
+				"lookup_bind_dn_password": "userpassword",
+				"user_dn_search_base_dn":  "dc=example,dc=net",
+				"user_dn_search_filter":   "(&(objectCategory=user)(sAMAccountName=%s))",
+			},
+			expectCommand: "myminio identity_ldap enabled=\"true\" lookup_bind_dn=\"cn=miniolookupuser,dc=example,dc=net\" lookup_bind_dn_password=\"userpassword\" server_addr=\"ad-ldap.example.net/\" user_dn_search_base_dn=\"dc=example,dc=net\" user_dn_search_filter=\"(&(objectCategory=user)(sAMAccountName=%s))\"",
+		},
 	}
 	for _, tc := range testCase {
 		command, err := GenerateMinIOIntervalJobCommand(mcCommand, 0, nil, "test", tc.args, funcs)
@@ -273,10 +317,21 @@ func TestMCConfigSet(t *testing.T) {
 			if command.Command != tc.expectCommand {
 				t.Fatalf("[%s] expectCommand %s, but got %s", tc.name, tc.expectCommand, command.Command)
 			}
+			if tc.expectFileNumber != len(command.Files) {
+				t.Fatalf("[%s] expectFileNumber %d, but got %d", tc.name, tc.expectFileNumber, len(command.Files))
+			}
 		} else {
 			if err == nil {
 				t.Fatalf("[%s] expectCommand error", tc.name)
 			}
 		}
 	}
+}
+
+func copyArgs(args map[string]string) map[string]string {
+	newArgs := make(map[string]string)
+	for key, val := range args {
+		newArgs[key] = val
+	}
+	return newArgs
 }

--- a/pkg/utils/miniojob/types.go
+++ b/pkg/utils/miniojob/types.go
@@ -61,7 +61,7 @@ var JobOperation = map[string][]FieldsFunc{
 	"admin/user/add":      {ALIAS(), Key("user"), Key("password")},
 	"admin/policy/create": {ALIAS(), Key("name"), File("policy", "json")},
 	"admin/policy/attach": {ALIAS(), Key("policy"), OneOf(KeyForamt("user", "--user"), KeyForamt("group", "--group"))},
-	"admin/config/set":    {ALIAS(), Key("webhookName"), Option(KeyValue("endpoint")), Option(KeyValue("auth_token")), Option(KeyFile("client_key", "key")), Option(KeyFile("client_cert", "pem"))},
+	"admin/config/set":    {ALIAS(), Key("webhookName"), Option(KeyValue("endpoint")), Option(KeyFile("client_key", "key")), Option(KeyFile("client_cert", "pem")), OthersKeyValues()},
 }
 
 // OperationAliasToMC - convert operation to mc operation


### PR DESCRIPTION
feat: support more type to admin/config/set

add `identity_ldap`, `notify_elasticsearch` support.

How to test it:
pkg/utils/miniojob/minioJob_test.go should cover it.

```golang
{
			name: "notify_mysql",
			args: map[string]string{
				"webhookName": "notify_mysql",
				"dsn_string":  "username:password@tcp(mysql.example.com:3306)/miniodb",
				"table":       "minioevents",
				"format":      "namespace",
			},
			expectCommand:    "myminio notify_mysql dsn_string=\"username:password@tcp(mysql.example.com:3306)/miniodb\" format=\"namespace\" table=\"minioevents\"",
			expectFileNumber: 0,
		},
		{
			name: "notify_amqp",
			args: map[string]string{
				"webhookName": "notify_amqp:primary",
				"url":         "user:password@amqp://amqp-endpoint.example.net:5672",
			},
			expectCommand:    "myminio notify_amqp:primary url=\"user:password@amqp://amqp-endpoint.example.net:5672\"",
			expectFileNumber: 0,
		},
		{
			name: "notify_elasticsearch",
			args: map[string]string{
				"webhookName": "notify_elasticsearch:primary",
				"url":         "user:password@https://elasticsearch-endpoint.example.net:9200",
				"index":       "bucketevents",
				"format":      "namespace",
			},
			expectCommand:    "myminio notify_elasticsearch:primary format=\"namespace\" index=\"bucketevents\" url=\"user:password@https://elasticsearch-endpoint.example.net:9200\"",
			expectFileNumber: 0,
		},
		{
			name: "identity_ldap",
			args: map[string]string{
				"webhookName":             "identity_ldap",
				"enabled":                 "true",
				"server_addr":             "ad-ldap.example.net/",
				"lookup_bind_dn":          "cn=miniolookupuser,dc=example,dc=net",
				"lookup_bind_dn_password": "userpassword",
				"user_dn_search_base_dn":  "dc=example,dc=net",
				"user_dn_search_filter":   "(&(objectCategory=user)(sAMAccountName=%s))",
			},
			expectCommand: "myminio identity_ldap enabled=\"true\" lookup_bind_dn=\"cn=miniolookupuser,dc=example,dc=net\" lookup_bind_dn_password=\"userpassword\" server_addr=\"ad-ldap.example.net/\" user_dn_search_base_dn=\"dc=example,dc=net\" user_dn_search_filter=\"(&(objectCategory=user)(sAMAccountName=%s))\"",
		},
```