### PR TITLE
Fields immutable

### DIFF
--- a/docs/job_crd.adoc
+++ b/docs/job_crd.adoc
@@ -4,8 +4,8 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-02-09T21-25-16Z]
-:kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-01-11T13-09-29Z]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-03-15T01-07-19Z]
+:kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-03-13T17-52-13Z]
 
 
 [id="{anchor_prefix}-job-min-io-v1alpha1"]
@@ -32,8 +32,10 @@ CommandSpec (`spec`) defines the configuration of a MinioClient Command.
 | Field | Description
 
 |*`op`* __string__ 
-|*Required* + 
- Operation is the MinioClient Action
+|*Required* +
+
+
+Operation is the MinioClient Action
 
 |*`name`* __string__ 
 |Name is the Command Name, optional, required if want to reference it with `DependsOn`
@@ -116,8 +118,10 @@ MinIOJob is a top-level type. A client is created for it
 
 
 |*`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-job-min-io-v1alpha1-miniojobspec[$$MinIOJobSpec$$]__ 
-|*Required* + 
- The root field for the MinIOJob object.
+|*Required* +
+
+
+The root field for the MinIOJob object.
 
 |===
 
@@ -139,22 +143,33 @@ MinIOJobSpec (`spec`) defines the configuration of a MinIOJob object. +
 | Field | Description
 
 |*`serviceAccountName`* __string__ 
-|*Required* + 
- Service Account name for the jobs to run
+|*Required* +
+
+
+Service Account name for the jobs to run
 
 |*`tenant`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-job-min-io-v1alpha1-tenantref[$$TenantRef$$]__ 
-|*Required* + 
- TenantRef Reference for minio Tenant to eun the jobs against
+|*Required* +
+
+
+TenantRef Reference for minio Tenant to eun the jobs against
 
 |*`execution`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-job-min-io-v1alpha1-execution[$$Execution$$]__ 
-|Execution order of the jobs, either `parallel` or `sequential`. Defaults to `parallel` if not provided.
+|Execution order of the jobs, either `parallel` or `sequential`.
+Defaults to `parallel` if not provided.
 
 |*`failureStrategy`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-job-min-io-v1alpha1-failurestrategy[$$FailureStrategy$$]__ 
-|FailureStrategy is the forward plan in case of the failure of one or more MinioJob pods Either `stopOnFailure` or `continueOnFailure`, defaults to `continueOnFailure`.
+|FailureStrategy is the forward plan in case of the failure of one or more MinioJob pods
+Either `stopOnFailure` or `continueOnFailure`, defaults to `continueOnFailure`.
 
 |*`commands`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-job-min-io-v1alpha1-commandspec[$$CommandSpec$$] array__ 
-|*Required* + 
- Commands List of MinioClient commands
+|*Required* +
+
+
+Commands List of MinioClient commands
+
+|*`mcImage`* __string__ 
+|mc job image
 
 |===
 

--- a/docs/policybinding_crd.adoc
+++ b/docs/policybinding_crd.adoc
@@ -61,8 +61,10 @@ PolicyBinding is a https://kubernetes.io/docs/concepts/overview/working-with-obj
 
 
 |*`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-sts-min-io-v1alpha1-policybindingspec[$$PolicyBindingSpec$$]__ 
-|*Required* + 
- The root field for the MinIO PolicyBinding object.
+|*Required* +
+
+
+The root field for the MinIO PolicyBinding object.
 
 |===
 
@@ -84,8 +86,10 @@ PolicyBindingSpec (`spec`) defines the configuration of a MinIO PolicyBinding ob
 | Field | Description
 
 |*`application`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-sts-min-io-v1alpha1-application[$$Application$$]__ 
-|*Required* + 
- The Application Property identifies the namespace and service account that will be authorized
+|*Required* +
+
+
+The Application Property identifies the namespace and service account that will be authorized
 
 |*`policies`* __string array__ 
 |*Required* +

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -64,16 +64,22 @@ CertificateConfig (`certConfig`) defines controlling attributes associated to an
 | Field | Description
 
 |*`commonName`* __string__ 
-|*Optional* + 
- The `CommonName` or `CN` attribute to associate to automatically generated TLS certificates. +
+|*Optional* +
+
+
+The `CommonName` or `CN` attribute to associate to automatically generated TLS certificates. +
 
 |*`organizationName`* __string array__ 
-|*Optional* + 
- Specify one or more `OrganizationName` or `O` attributes to associate to automatically generated TLS certificates. +
+|*Optional* +
+
+
+Specify one or more `OrganizationName` or `O` attributes to associate to automatically generated TLS certificates. +
 
 |*`dnsNames`* __string array__ 
-|*Optional* + 
- Specify one or more x.509 Subject Alternative Names (SAN) to associate to automatically generated TLS certificates. MinIO Server pods use SNI to determine which certificate to respond with based on the requested hostname.
+|*Optional* +
+
+
+Specify one or more x.509 Subject Alternative Names (SAN) to associate to automatically generated TLS certificates. MinIO Server pods use SNI to determine which certificate to respond with based on the requested hostname.
 
 |===
 
@@ -101,6 +107,51 @@ CertificateStatus keeps track of all the certificates managed by the operator
 |===
 
 
+[id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificateconfig"]
+==== CustomCertificateConfig 
+
+CustomCertificateConfig (`customCertificateConfig`) provides attributes associated of the TLS certificates manually added to the Operator as part of tenant creation. These fields contain no data if there are no custom TLS certificates.
+
+.Appears In:
+****
+- xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificates[$$CustomCertificates$$]
+****
+
+[cols="25a,75a", options="header"]
+|===
+| Field | Description
+
+|*`certName`* __string__ 
+|*Optional* +
+
+
+Output one or more `CertName` attributes associated with the manually provided TLS certificates. +
+
+|*`domains`* __string array__ 
+|*Optional* +
+
+
+Output one or more `Domains` attributes associated with the manually provided TLS certificates. +
+
+|*`expiry`* __string__ 
+|*Optional* +
+
+
+Output one or more `Expiry` attributes associated with the manually provided TLS certificates. +
+
+|*`expiresIn`* __string__ 
+|*Optional* +
+
+
+Output one or more `ExpiresIn` attributes associated with the manually provided TLS certificates. +
+
+|*`serialNo`* __string__ 
+|*Optional* +
+
+
+Output one or more `SerialNo` attributes associated with the manually provided TLS certificates. +
+
+|===
 
 
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificates"]
@@ -118,16 +169,22 @@ CustomCertificates (`customCertificates`) provides groupings of the TLS certific
 | Field | Description
 
 |*`client`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificateconfig[$$CustomCertificateConfig$$] array__ 
-|*Optional* + 
- Client
+|*Optional* +
+
+
+Client
 
 |*`minio`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificateconfig[$$CustomCertificateConfig$$] array__ 
-|*Optional* + 
- Minio
+|*Optional* +
+
+
+Minio
 
 |*`minioCAs`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-customcertificateconfig[$$CustomCertificateConfig$$] array__ 
-|*Optional* + 
- Certificate Authorities
+|*Optional* +
+
+
+Certificate Authorities
 
 |===
 
@@ -147,12 +204,16 @@ ExposeServices (`exposeServices`) defines the exposure of the MinIO object stora
 | Field | Description
 
 |*`minio`* __boolean__ 
-|*Optional* + 
- Directs the Operator to expose the MinIO service. Defaults to `false`. +
+|*Optional* +
+
+
+Directs the Operator to expose the MinIO service. Defaults to `false`. +
 
 |*`console`* __boolean__ 
-|*Optional* + 
- Directs the Operator to expose the MinIO Console service. Defaults to `false`. +
+|*Optional* +
+
+
+Directs the Operator to expose the MinIO Console service. Defaults to `false`. +
 
 |===
 
@@ -172,16 +233,22 @@ Features (`features`) - Object describing which MinIO features to enable/disable
 | Field | Description
 
 |*`bucketDNS`* __boolean__ 
-|*Optional* + 
- Specify `true` to allow clients to access buckets using the DNS path `<bucket>.minio.default.svc.cluster.local`. Defaults to `false`.
+|*Optional* +
+
+
+Specify `true` to allow clients to access buckets using the DNS path `<bucket>.minio.default.svc.cluster.local`. Defaults to `false`.
 
 |*`domains`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantdomains[$$TenantDomains$$]__ 
-|*Optional* + 
- Specify a list of domains used to access MinIO and Console.
+|*Optional* +
+
+
+Specify a list of domains used to access MinIO and Console.
 
 |*`enableSFTP`* __boolean__ 
-|*Optional* + 
- Starts minio server with SFTP support
+|*Optional* +
+
+
+Starts minio server with SFTP support
 
 |===
 
@@ -213,102 +280,178 @@ KESConfig (`kes`) defines the configuration of the https://github.com/minio/kes[
 | Field | Description
 
 |*`replicas`* __integer__ 
-|*Optional* + 
- Specify the number of replica KES pods to deploy in the tenant. Defaults to `2`.
+|*Optional* +
+
+
+Specify the number of replica KES pods to deploy in the tenant. Defaults to `2`.
 
 |*`image`* __string__ 
-|*Optional* + 
- The Docker image to use for deploying MinIO KES. Defaults to {kes-image}. +
+|*Optional* +
+
+
+The Docker image to use for deploying MinIO KES. Defaults to {kes-image}. +
 
 |*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#pullpolicy-v1-core[$$PullPolicy$$]__ 
-|*Optional* + 
- The pull policy for the MinIO Docker image. Specify one of the following: + 
- * `Always` + 
- * `Never` + 
- * `IfNotPresent` (Default) + 
- Refer to the Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+|*Optional* +
+
+
+The pull policy for the MinIO Docker image. Specify one of the following: +
+
+
+* `Always` +
+
+
+* `Never` +
+
+
+* `IfNotPresent` (Default) +
+
+
+Refer to the Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
 
 |*`serviceAccountName`* __string__ 
-|*Optional* + 
- The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
+|*Optional* +
+
+
+The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO KES pods created as part of the Tenant. +
 
 |*`kesSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
-|*Required* + 
- Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] which contains environment variables to use for setting up the MinIO KES service. + 
- See the https://github.com/minio/operator/blob/master/examples/kes-secret.yaml[MinIO Operator `console-secret.yaml`] for an example.
+|*Required* +
+
+
+Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] which contains environment variables to use for setting up the MinIO KES service. +
+
+
+See the https://github.com/minio/operator/blob/master/examples/kes-secret.yaml[MinIO Operator `console-secret.yaml`] for an example.
 
 |*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
-|*Optional* + 
- Enables TLS with SNI support on each MinIO KES pod in the tenant. If `externalCertSecret` is omitted *and* `spec.requestAutoCert` is set to `false`, MinIO KES pods deploy *without* TLS enabled. + 
- Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret]. The MinIO Operator copies the specified certificate to every MinIO pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
- Specify an object containing the following fields: + 
- * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
- * - `type` - Specify `kubernetes.io/tls` + 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+|*Optional* +
+
+
+Enables TLS with SNI support on each MinIO KES pod in the tenant. If `externalCertSecret` is omitted *and* `spec.requestAutoCert` is set to `false`, MinIO KES pods deploy *without* TLS enabled. +
+
+
+Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret]. The MinIO Operator copies the specified certificate to every MinIO pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. +
+
+
+Specify an object containing the following fields: +
+
+
+* - `name` - The name of the Kubernetes secret containing the TLS certificate. +
+
+
+* - `type` - Specify `kubernetes.io/tls` +
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
 |*`clientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
-|*Optional* + 
- Specify a a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret] containing a custom root Certificate Authority and x.509 certificate to use for performing mTLS authentication with an external Key Management Service, such as Hashicorp Vault. + 
- Specify an object containing the following fields: + 
- * - `name` - The name of the Kubernetes secret containing the Certificate Authority and x.509 Certificate. + 
- * - `type` - Specify `kubernetes.io/tls` +
+|*Optional* +
+
+
+Specify a a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secret] containing a custom root Certificate Authority and x.509 certificate to use for performing mTLS authentication with an external Key Management Service, such as Hashicorp Vault. +
+
+
+Specify an object containing the following fields: +
+
+
+* - `name` - The name of the Kubernetes secret containing the Certificate Authority and x.509 Certificate. +
+
+
+* - `type` - Specify `kubernetes.io/tls` +
 
 |*`gcpCredentialSecretName`* __string__ 
-|*Optional* + 
+|*Optional* +
+
+
  Specify the GCP default credentials to be used for KES to authenticate to GCP key store
 
 |*`gcpWorkloadIdentityPool`* __string__ 
-|*Optional* + 
+|*Optional* +
+
+
  Specify the name of the workload identity pool (This is required for generating service account token)
 
 |*`annotations`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, use these annotations for KES Object Meta annotations
+|*Optional* +
+
+
+If provided, use these annotations for KES Object Meta annotations
 
 |*`labels`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, use these labels for KES Object Meta labels
+|*Optional* +
+
+
+If provided, use these labels for KES Object Meta labels
 
 |*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
-|*Optional* + 
- Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+|*Optional* +
+
+
+Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
 
 |*`nodeSelector`* __object (keys:string, values:string)__ 
-|*Optional* + 
- The filter for the Operator to apply when selecting which nodes on which to deploy MinIO KES pods. The Operator only selects those nodes whose labels match the specified selector. + 
- See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+|*Optional* +
+
+
+The filter for the Operator to apply when selecting which nodes on which to deploy MinIO KES pods. The Operator only selects those nodes whose labels match the specified selector. +
+
+
+See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
 |*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[$$Toleration$$] array__ 
-|*Optional* + 
- Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO KES pods.
+|*Optional* +
+
+
+Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to MinIO KES pods.
 
 |*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#affinity-v1-core[$$Affinity$$]__ 
-|*Optional* + 
- Specify node affinity, pod affinity, and pod anti-affinity for the KES pods. +
+|*Optional* +
+
+
+Specify node affinity, pod affinity, and pod anti-affinity for the KES pods. +
 
 |*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
-|*Optional* + 
- Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+|*Optional* +
+
+
+Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
 |*`keyName`* __string__ 
-|*Optional* + 
- If provided, use this as the name of the key that KES creates on the KMS backend
+|*Optional* +
+
+
+If provided, use this as the name of the key that KES creates on the KMS backend
 
 |*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
-|Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of MinIO KES pods. The Operator supports only the following pod security fields: + 
- * `fsGroup` + 
- * `fsGroupChangePolicy` + 
- * `runAsGroup` + 
- * `runAsNonRoot` + 
- * `runAsUser` + 
- * `seLinuxOptions` +
+|Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of MinIO KES pods. The Operator supports only the following pod security fields: +
+
+
+* `fsGroup` +
+
+
+* `fsGroupChangePolicy` +
+
+
+* `runAsGroup` +
+
+
+* `runAsNonRoot` +
+
+
+* `runAsUser` +
+
+
+* `seLinuxOptions` +
 
 |*`containerSecurityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core[$$SecurityContext$$]__ 
 |Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of MinIO KES pods.
 
 |*`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envvar-v1-core[$$EnvVar$$] array__ 
-|*Optional* + 
- If provided, the MinIO Operator adds the specified environment variables when deploying the KES resource.
+|*Optional* +
+
+
+If provided, the MinIO Operator adds the specified environment variables when deploying the KES resource.
 
 |===
 
@@ -329,12 +472,16 @@ LocalCertificateReference (`externalCertSecret`, `externalCaCertSecret`,`clientC
 | Field | Description
 
 |*`name`* __string__ 
-|*Required* + 
- The name of the Kubernetes secret containing the TLS certificate or Certificate Authority file. +
+|*Required* +
+
+
+The name of the Kubernetes secret containing the TLS certificate or Certificate Authority file. +
 
 |*`type`* __string__ 
-|*Required* + 
- The type of Kubernetes secret. Specify `kubernetes.io/tls` +
+|*Required* +
+
+
+The type of Kubernetes secret. Specify `kubernetes.io/tls` +
 
 |===
 
@@ -368,8 +515,10 @@ Logging describes Logging for MinIO tenants.
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool"]
 ==== Pool 
 
-Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. + 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
+Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
 
 .Appears In:
 ****
@@ -381,75 +530,128 @@ Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a 
 | Field | Description
 
 |*`name`* __string__ 
-|*Optional* + 
- Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
+|*Optional* +
+
+
+Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
 
 |*`servers`* __integer__ 
-|*Required* 
- The number of MinIO server pods to deploy in the pool. The minimum value is `2`. 
- The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+|*Required*
+
+
+The number of MinIO server pods to deploy in the pool. The minimum value is `2`.
+
+
+The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 
 |*`volumesPerServer`* __integer__ 
-|*Required* + 
- The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. + 
- The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+|*Required* +
+
+
+The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. +
+
+
+The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 
 |*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
-|*Required* + 
- Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the MinIO tenant. +
+|*Required* +
+
+
+Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the MinIO tenant. +
 
 |*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
-|*Optional* + 
- Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
+|*Optional* +
+
+
+Object specification for specifying CPU and memory https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[resource allocations] or limits in the MinIO tenant. +
 
 |*`nodeSelector`* __object (keys:string, values:string)__ 
-|*Optional* + 
- The filter for the Operator to apply when selecting which nodes on which to deploy pods in the pool. The Operator only selects those nodes whose labels match the specified selector. + 
- See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
+|*Optional* +
+
+
+The filter for the Operator to apply when selecting which nodes on which to deploy pods in the pool. The Operator only selects those nodes whose labels match the specified selector. +
+
+
+See the Kubernetes documentation on https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[Assigning Pods to Nodes] for more information.
 
 |*`affinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#affinity-v1-core[$$Affinity$$]__ 
-|*Optional* + 
- Specify node affinity, pod affinity, and pod anti-affinity for pods in the MinIO pool. +
+|*Optional* +
+
+
+Specify node affinity, pod affinity, and pod anti-affinity for pods in the MinIO pool. +
 
 |*`tolerations`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#toleration-v1-core[$$Toleration$$] array__ 
-|*Optional* + 
- Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to pods deployed in the MinIO pool.
+|*Optional* +
+
+
+Specify one or more https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Kubernetes tolerations] to apply to pods deployed in the MinIO pool.
 
 |*`topologySpreadConstraints`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#topologyspreadconstraint-v1-core[$$TopologySpreadConstraint$$] array__ 
-|*Optional* + 
- Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
+|*Optional* +
+
+
+Specify one or more https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/[Kubernetes Topology Spread Constraints] to apply to pods deployed in the MinIO pool.
 
 |*`securityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podsecuritycontext-v1-core[$$PodSecurityContext$$]__ 
-|*Optional* + 
- Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods in the pool. The Operator supports only the following pod security fields: + 
- * `fsGroup` + 
- * `fsGroupChangePolicy` + 
- * `runAsGroup` + 
- * `runAsNonRoot` + 
- * `runAsUser` +
+|*Optional* +
+
+
+Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of pods in the pool. The Operator supports only the following pod security fields: +
+
+
+* `fsGroup` +
+
+
+* `fsGroupChangePolicy` +
+
+
+* `runAsGroup` +
+
+
+* `runAsNonRoot` +
+
+
+* `runAsUser` +
 
 |*`containerSecurityContext`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core[$$SecurityContext$$]__ 
-|Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of containers in the pool. The Operator supports only the following container security fields: + 
- * `runAsGroup` + 
- * `runAsNonRoot` + 
- * `runAsUser` +
+|Specify the https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Security Context] of containers in the pool. The Operator supports only the following container security fields: +
+
+
+* `runAsGroup` +
+
+
+* `runAsNonRoot` +
+
+
+* `runAsUser` +
 
 |*`annotations`* __object (keys:string, values:string)__ 
-|*Optional* + 
- Specify custom labels and annotations to append to the Pool. *Optional* + 
- If provided, use these annotations for the Pool Objects Meta annotations (Statefulset and Pod template)
+|*Optional* +
+
+
+Specify custom labels and annotations to append to the Pool.
+*Optional* +
+
+
+If provided, use these annotations for the Pool Objects Meta annotations (Statefulset and Pod template)
 
 |*`labels`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, use these labels for the Pool Objects Meta annotations (Statefulset and Pod template)
+|*Optional* +
+
+
+If provided, use these labels for the Pool Objects Meta annotations (Statefulset and Pod template)
 
 |*`runtimeClassName`* __string__ 
-|*Optional* + 
- If provided, each pod on the Statefulset will run with the specified RuntimeClassName, for more info https://kubernetes.io/docs/concepts/containers/runtime-class/
+|*Optional* +
+
+
+If provided, each pod on the Statefulset will run with the specified RuntimeClassName, for more info https://kubernetes.io/docs/concepts/containers/runtime-class/
 
 |*`reclaimStorage`* __boolean__ 
-|*Optional* + 
- If true. Will delete the storage when tenant has been deleted.
+|*Optional* +
+
+
+If true. Will delete the storage when tenant has been deleted.
 
 |===
 
@@ -487,7 +689,9 @@ PoolStatus keeps track of all the pools and their current state
 |
 
 |*`legacySecurityContext`* __boolean__ 
-|LegacySecurityContext stands for Legacy SecurityContext. It represents that these pool was created before v4.2.3 when we introduced the default securityContext as non-root, thus we should keep running this Pool without a Security Context
+|LegacySecurityContext stands for Legacy SecurityContext. It represents that these pool was created before v4.2.3 when
+we introduced the default securityContext as non-root, thus we should keep running this Pool without a
+Security Context
 
 |===
 
@@ -507,20 +711,28 @@ ServiceMetadata (`serviceMetadata`) defines custom labels and annotations for th
 | Field | Description
 
 |*`minioServiceLabels`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, append these labels to the MinIO service
+|*Optional* +
+
+
+If provided, append these labels to the MinIO service
 
 |*`minioServiceAnnotations`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, append these annotations to the MinIO service
+|*Optional* +
+
+
+If provided, append these annotations to the MinIO service
 
 |*`consoleServiceLabels`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, append these labels to the Console service
+|*Optional* +
+
+
+If provided, append these labels to the Console service
 
 |*`consoleServiceAnnotations`* __object (keys:string, values:string)__ 
-|*Optional* + 
- If provided, append these annotations to the Console service
+|*Optional* +
+
+
+If provided, append these annotations to the Console service
 
 |===
 
@@ -540,20 +752,34 @@ SideCars (`sidecars`) defines a list of containers that the Operator attaches to
 | Field | Description
 
 |*`containers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core[$$Container$$] array__ 
-|*Optional* + 
- List of containers to run inside the Pod
+|*Optional* +
+
+
+List of containers to run inside the Pod
 
 |*`volumeClaimTemplates`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$] array__ 
-|*Optional* + 
- volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+|*Optional* +
+
+
+volumeClaimTemplates is a list of claims that pods are allowed to reference.
+The StatefulSet controller is responsible for mapping network identities to
+claims in a way that maintains the identity of a pod. Every claim in
+this list must have at least one matching (by name) volumeMount in one
+container in the template. A claim in this list takes precedence over
+any volumes in the template, with the same name.
 
 |*`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#volume-v1-core[$$Volume$$] array__ 
-|*Optional* + 
- List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+|*Optional* +
+
+
+List of volumes that can be mounted by containers belonging to the pod.
+More info: https://kubernetes.io/docs/concepts/storage/volumes
 
 |*`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ 
-|*Optional* + 
- sidecar's Resource, initcontainer will use that if set.
+|*Optional* +
+
+
+sidecar's Resource, initcontainer will use that if set.
 
 |===
 
@@ -586,8 +812,10 @@ Tenant is a https://kubernetes.io/docs/concepts/overview/working-with-objects/ku
 |
 
 |*`spec`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec[$$TenantSpec$$]__ 
-|*Required* + 
- The root field for the MinIO Tenant object.
+|*Required* +
+
+
+The root field for the MinIO Tenant object.
 
 |===
 
@@ -595,7 +823,9 @@ Tenant is a https://kubernetes.io/docs/concepts/overview/working-with-objects/ku
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantdomains"]
 ==== TenantDomains 
 
-TenantDomains (`domains`) - List of domains used to access the tenant from outside the kubernetes clusters. this will only configure MinIO for the domains listed, but external DNS configuration is still needed. The listed domains should include schema and port if any is used, i.e. https://minio.domain.com:8123
+TenantDomains (`domains`) - List of domains used to access the tenant from outside the kubernetes clusters.
+this will only configure MinIO for the domains listed, but external DNS configuration is still needed.
+The listed domains should include schema and port if any is used, i.e. https://minio.domain.com:8123
 
 .Appears In:
 ****
@@ -607,10 +837,12 @@ TenantDomains (`domains`) - List of domains used to access the tenant from outsi
 | Field | Description
 
 |*`minio`* __string array__ 
-|List of Domains used by MinIO. This will enable DNS style access to the object store where the bucket name is inferred from a subdomain in the domain.
+|List of Domains used by MinIO. This will enable DNS style access to the object store where the bucket name is
+inferred from a subdomain in the domain.
 
 |*`console`* __string__ 
-|Domain used to expose the MinIO Console, this will configure the redirect on MinIO when visiting from the browser If Console is exposed via a subpath, the domain should include it, i.e. https://console.domain.com:8123/subpath/
+|Domain used to expose the MinIO Console, this will configure the redirect on MinIO when visiting from the browser
+If Console is exposed via a subpath, the domain should include it, i.e. https://console.domain.com:8123/subpath/
 
 |===
 
@@ -632,8 +864,10 @@ TenantScheduler (`scheduler`) - Object describing Kubernetes Scheduler to use fo
 | Field | Description
 
 |*`name`* __string__ 
-|*Optional* + 
- Specify the name of the https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/[Kubernetes scheduler] to be used to schedule Tenant pods
+|*Optional* +
+
+
+Specify the name of the https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/[Kubernetes scheduler] to be used to schedule Tenant pods
 
 |===
 
@@ -641,9 +875,13 @@ TenantScheduler (`scheduler`) - Object describing Kubernetes Scheduler to use fo
 [id="{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-tenantspec"]
 ==== TenantSpec 
 
-TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. + 
- The following parameters are specific to the `minio.min.io/v2` MinIO CRD API `spec` definition added as part of the MinIO Operator v4.0.0. + 
- For more complete documentation on this object, see the https://min.io/docs/minio/kubernetes/upstream/operations/installation.html[MinIO Kubernetes Documentation]. +
+TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. +
+
+
+The following parameters are specific to the `minio.min.io/v2` MinIO CRD API `spec` definition added as part of the MinIO Operator v4.0.0. +
+
+
+For more complete documentation on this object, see the https://min.io/docs/minio/kubernetes/upstream/operations/installation.html[MinIO Kubernetes Documentation]. +
 
 .Appears In:
 ****
@@ -655,93 +893,194 @@ TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. +
 | Field | Description
 
 |*`pools`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-pool[$$Pool$$] array__ 
-|*Required* + 
- An array of objects describing each MinIO server pool deployed in the MinIO Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. + 
- The MinIO Tenant `spec` *must have* at least *one* element in the `pools` array. + 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
+|*Required* +
+
+
+An array of objects describing each MinIO server pool deployed in the MinIO Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
+
+
+The MinIO Tenant `spec` *must have* at least *one* element in the `pools` array. +
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation.
 
 |*`image`* __string__ 
-|*Optional* + 
- The Docker image to use when deploying `minio` server pods. Defaults to {minio-image}. +
+|*Optional* +
+
+
+The Docker image to use when deploying `minio` server pods. Defaults to {minio-image}. +
 
 |*`imagePullSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
-|*Optional* + 
- Specify the secret key to use for pulling images from a private Docker repository. +
+|*Optional* +
+
+
+Specify the secret key to use for pulling images from a private Docker repository. +
 
 |*`podManagementPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#podmanagementpolicytype-v1-apps[$$PodManagementPolicyType$$]__ 
-|*Optional* + 
- Pod Management Policy for pod created by StatefulSet
+|*Optional* +
+
+
+Pod Management Policy for pod created by StatefulSet
 
 |*`credsSecret`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
-|*optional* + 
- Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] to use for setting the MinIO root access key and secret key. Specify the secret as `name: <secret>`. The Kubernetes secret must contain the following fields: + 
- * `data.accesskey` - The access key for the root credentials + 
- * `data.secretkey` - The secret key for the root credentials +
+|*optional* +
+
+
+Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secret] to use for setting the MinIO root access key and secret key. Specify the secret as `name: <secret>`. The Kubernetes secret must contain the following fields: +
+
+
+* `data.accesskey` - The access key for the root credentials +
+
+
+* `data.secretkey` - The secret key for the root credentials +
 
 |*`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#envvar-v1-core[$$EnvVar$$] array__ 
-|*Optional* + 
- If provided, the MinIO Operator adds the specified environment variables when deploying the Tenant resource.
+|*Optional* +
+
+
+If provided, the MinIO Operator adds the specified environment variables when deploying the Tenant resource.
 
 |*`externalCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ 
-|*Optional* + 
- Enables TLS with SNI support on each MinIO pod in the tenant. If `externalCertSecret` is omitted *and* `requestAutoCert` is set to `false`, the MinIO Tenant deploys *without* TLS enabled. + 
- Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. + 
- Each element in the `externalCertSecret` array is an object containing the following fields: + 
- * - `name` - The name of the Kubernetes secret containing the TLS certificate. + 
- * - `type` - Specify `kubernetes.io/tls` + 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+|*Optional* +
+
+
+Enables TLS with SNI support on each MinIO pod in the tenant. If `externalCertSecret` is omitted *and* `requestAutoCert` is set to `false`, the MinIO Tenant deploys *without* TLS enabled. +
+
+
+Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. When the MinIO pod/service responds to a TLS connection request, it uses SNI to select the certificate with matching `subjectAlternativeName`. +
+
+
+Each element in the `externalCertSecret` array is an object containing the following fields: +
+
+
+* - `name` - The name of the Kubernetes secret containing the TLS certificate. +
+
+
+* - `type` - Specify `kubernetes.io/tls` +
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
 |*`externalCaCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ 
-|*Optional* + 
- Allows MinIO server pods to verify client TLS certificates signed by a Certificate Authority not in the pod's trust store. + 
- Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. + 
- Each element in the `externalCertSecret` array is an object containing the following fields: + 
- * - `name` - The name of the Kubernetes secret containing the Certificate Authority. + 
- * - `type` - Specify `kubernetes.io/tls`. + 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+|*Optional* +
+
+
+Allows MinIO server pods to verify client TLS certificates signed by a Certificate Authority not in the pod's trust store. +
+
+
+Specify an array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificates to every MinIO server pod in the tenant. +
+
+
+Each element in the `externalCertSecret` array is an object containing the following fields: +
+
+
+* - `name` - The name of the Kubernetes secret containing the Certificate Authority. +
+
+
+* - `type` - Specify `kubernetes.io/tls`. +
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
 |*`externalClientCertSecret`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$]__ 
-|*Optional* + 
- Enables mTLS authentication between the MinIO Tenant pods and https://github.com/minio/kes[MinIO KES]. *Required* for enabling connectivity between the MinIO Tenant and MinIO KES. + 
- Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant. The secret *must* contain the following fields: + 
- * `name` - The name of the Kubernetes secret containing the TLS certificate. + 
- * `type` - Specify `kubernetes.io/tls` + 
- The specified certificate *must* correspond to an identity on the KES server. See the https://github.com/minio/kes/wiki/Configuration#policy-configuration[KES Wiki] for more information on KES identities. + 
- If deploying KES with the MinIO Operator, include the hash of the certificate as part of the <<k8s-api-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig,`kes`>> object specification. + 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+|*Optional* +
+
+
+Enables mTLS authentication between the MinIO Tenant pods and https://github.com/minio/kes[MinIO KES]. *Required* for enabling connectivity between the MinIO Tenant and MinIO KES. +
+
+
+Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant. The secret *must* contain the following fields: +
+
+
+* `name` - The name of the Kubernetes secret containing the TLS certificate. +
+
+
+* `type` - Specify `kubernetes.io/tls` +
+
+
+The specified certificate *must* correspond to an identity on the KES server. See the https://github.com/minio/kes/wiki/Configuration#policy-configuration[KES Wiki] for more information on KES identities. +
+
+
+If deploying KES with the MinIO Operator, include the hash of the certificate as part of the <<k8s-api-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig,`kes`>> object specification. +
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
 |*`externalClientCertSecrets`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-localcertificatereference[$$LocalCertificateReference$$] array__ 
-|*Optional* + 
- Provide support for mounting additional client certificate into MinIO Tenant pods Multiple client certificates will be mounted using the following folder structure: + 
- * certs + 
- * * client-0 + 
- * * * client.crt + 
- * * * client.key + 
- * * client-1 + 
- * * * client.crt + 
- * * * client.key + 
- * * * client-2 + 
- * * client.crt + 
- * * *  client.key + 
- Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant that later can be referenced using environment variables. The secret *must* contain the following fields: + 
- * `name` - The name of the Kubernetes secret containing the TLS certificate. + 
- * `type` - Specify `kubernetes.io/tls` +
+|*Optional* +
+
+
+Provide support for mounting additional client certificate into MinIO Tenant pods
+Multiple client certificates will be mounted using the following folder structure: +
+
+
+* certs +
+
+
+* * client-0 +
+
+
+* * * client.crt +
+
+
+* * * client.key +
+
+
+* * client-1 +
+
+
+* * * client.crt +
+
+
+* * * client.key +
+
+
+* * * client-2 +
+
+
+* * client.crt +
+
+
+* * *  client.key +
+
+
+Specify a https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes TLS secrets]. The MinIO Operator copies the specified certificate to every MinIO server pod in the tenant that later can be referenced using environment variables. The secret *must* contain the following fields: +
+
+
+* `name` - The name of the Kubernetes secret containing the TLS certificate. +
+
+
+* `type` - Specify `kubernetes.io/tls` +
 
 |*`mountPath`* __string__ 
-|*Optional* + 
- Mount path for MinIO volume (PV). Defaults to `/export`
+|*Optional* +
+
+
+Mount path for MinIO volume (PV). Defaults to `/export`
 
 |*`subPath`* __string__ 
-|*Optional* + 
- Subpath inside mount path. This is the directory where MinIO stores data. Default to `""`` (empty)
+|*Optional* +
+
+
+Subpath inside mount path. This is the directory where MinIO stores data. Default to `""`` (empty)
 
 |*`requestAutoCert`* __boolean__ 
-|*Optional* + 
- Enables using https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/[Kubernetes-based TLS certificate generation] and signing for pods and services in the MinIO Tenant. + 
- * Specify `true` to explicitly enable automatic certificate generate (Default). + 
- * Specify `false` to disable automatic certificate generation. + 
- If `requestAutoCert` is set to `false` *and* `externalCertSecret` is omitted, the MinIO Tenant deploys *without* TLS enabled. 
- See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
+|*Optional* +
+
+
+Enables using https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/[Kubernetes-based TLS certificate generation] and signing for pods and services in the MinIO Tenant. +
+
+
+* Specify `true` to explicitly enable automatic certificate generate (Default). +
+
+
+* Specify `false` to disable automatic certificate generation. +
+
+
+If `requestAutoCert` is set to `false` *and* `externalCertSecret` is omitted, the MinIO Tenant deploys *without* TLS enabled.
+
+
+See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#create-tenant-security-section[MinIO Operator CRD] reference for examples and more complete documentation on configuring TLS for MinIO Tenants.
 
 |*`liveness`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#probe-v1-core[$$Probe$$]__ 
 |Liveness Probe for container liveness. Container will be restarted if the probe fails.
@@ -756,79 +1095,135 @@ TenantSpec (`spec`) defines the configuration of a MinIO Tenant object. +
 |S3 related features can be disabled or enabled such as `bucketDNS` etc.
 
 |*`certConfig`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-certificateconfig[$$CertificateConfig$$]__ 
-|*Optional* + 
- Enables setting the `CommonName`, `Organization`, and `dnsName` attributes for all TLS certificates automatically generated by the Operator. Configuring this object has no effect if `requestAutoCert` is `false`. +
+|*Optional* +
+
+
+Enables setting the `CommonName`, `Organization`, and `dnsName` attributes for all TLS certificates automatically generated by the Operator. Configuring this object has no effect if `requestAutoCert` is `false`. +
 
 |*`kes`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-kesconfig[$$KESConfig$$]__ 
-|*Optional* + 
- Directs the MinIO Operator to deploy the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) using the specified configuration. The MinIO KES supports performing server-side encryption of objects on the MiNIO Tenant. +
+|*Optional* +
+
+
+Directs the MinIO Operator to deploy the https://github.com/minio/kes[MinIO Key Encryption Service] (KES) using the specified configuration. The MinIO KES supports performing server-side encryption of objects on the MiNIO Tenant. +
 
 |*`prometheusOperator`* __boolean__ 
-|*Optional* + 
- Directs the MinIO Operator to use prometheus operator. + 
- Tenant scrape configuration will be added to prometheus managed by the prometheus-operator.
+|*Optional* +
+
+
+Directs the MinIO Operator to use prometheus operator. +
+
+
+Tenant scrape configuration will be added to prometheus managed by the prometheus-operator.
 
 |*`serviceAccountName`* __string__ 
-|*Optional* + 
- The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO pods created as part of the Tenant. +
+|*Optional* +
+
+
+The https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/[Kubernetes Service Account] to use for running MinIO pods created as part of the Tenant. +
 
 |*`priorityClassName`* __string__ 
-|*Optional* + 
- Indicates the Pod priority and therefore importance of a Pod relative to other Pods in the cluster. This is applied to MinIO pods only. + 
- Refer Kubernetes https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[Priority Class documentation] for more complete documentation.
+|*Optional* +
+
+
+Indicates the Pod priority and therefore importance of a Pod relative to other Pods in the cluster.
+This is applied to MinIO pods only. +
+
+
+Refer Kubernetes https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass[Priority Class documentation] for more complete documentation.
 
 |*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#pullpolicy-v1-core[$$PullPolicy$$]__ 
-|*Optional* + 
- The pull policy for the MinIO Docker image. Specify one of the following: + 
- * `Always` + 
- * `Never` + 
- * `IfNotPresent` (Default) + 
- Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
+|*Optional* +
+
+
+The pull policy for the MinIO Docker image. Specify one of the following: +
+
+
+* `Always` +
+
+
+* `Never` +
+
+
+* `IfNotPresent` (Default) +
+
+
+Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/containers/images#updating-images
 
 |*`sideCars`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-sidecars[$$SideCars$$]__ 
-|*Optional* + 
- A list of containers to run as sidecars along every MinIO Pod deployed in the tenant.
+|*Optional* +
+
+
+A list of containers to run as sidecars along every MinIO Pod deployed in the tenant.
 
 |*`exposeServices`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-exposeservices[$$ExposeServices$$]__ 
-|*Optional* + 
- Directs the Operator to expose the MinIO and/or Console services. +
+|*Optional* +
+
+
+Directs the Operator to expose the MinIO and/or Console services. +
 
 |*`serviceMetadata`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-servicemetadata[$$ServiceMetadata$$]__ 
-|*Optional* + 
- Specify custom labels and annotations to append to the MinIO service and/or Console service.
+|*Optional* +
+
+
+Specify custom labels and annotations to append to the MinIO service and/or Console service.
 
 |*`users`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[$$LocalObjectReference$$] array__ 
-|*Optional* + 
- An array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secrets] to use for generating MinIO users during tenant provisioning. + 
- Each element in the array is an object consisting of a key-value pair `name: <string>`, where the `<string>` references an opaque Kubernetes secret. + 
- Each referenced Kubernetes secret must include the following fields: + 
- * `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user + 
- * `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user + 
- The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
+|*Optional* +
+
+
+An array of https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes opaque secrets] to use for generating MinIO users during tenant provisioning. +
+
+
+Each element in the array is an object consisting of a key-value pair `name: <string>`, where the `<string>` references an opaque Kubernetes secret. +
+
+
+Each referenced Kubernetes secret must include the following fields: +
+
+
+* `CONSOLE_ACCESS_KEY` - The "Username" for the MinIO user +
+
+
+* `CONSOLE_SECRET_KEY` - The "Password" for the MinIO user +
+
+
+The Operator creates each user with the `consoleAdmin` policy by default. You can change the assigned policy after the Tenant starts. +
 
 |*`buckets`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-bucket[$$Bucket$$] array__ 
-|*Optional* + 
- Create buckets when creating a new tenant. Skip if bucket with given name already exists
+|*Optional* +
+
+
+Create buckets when creating a new tenant. Skip if bucket with given name already exists
 
 |*`logging`* __xref:{anchor_prefix}-github-com-minio-operator-pkg-apis-minio-min-io-v2-logging[$$Logging$$]__ 
-|*Optional* + 
- Enable JSON, Anonymous logging for MinIO tenants.
+|*Optional* +
+
+
+Enable JSON, Anonymous logging for MinIO tenants.
 
 |*`configuration`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#localobjectreference-v1-core[$$LocalObjectReference$$]__ 
-|*Optional* + 
- Specify a secret that contains additional environment variable configurations to be used for the MinIO pools. The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
+|*Optional* +
+
+
+Specify a secret that contains additional environment variable configurations to be used for the MinIO pools.
+The secret is expected to have a key named config.env containing all exported environment variables for MinIO+
 
 |*`initContainers`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#container-v1-core[$$Container$$] array__ 
-|*Optional* + 
- Add custom initContainers to StatefulSet
+|*Optional* +
+
+
+Add custom initContainers to StatefulSet
 
 |*`additionalVolumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#volume-v1-core[$$Volume$$] array__ 
-|*Optional* + 
- If provided, statefulset will add these volumes. You should set the rules for the corresponding volumes and volume mounts. We will not test this rule, k8s will show the result.
+|*Optional* +
+
+
+If provided, statefulset will add these volumes. You should set the rules for the corresponding volumes and volume mounts. We will not test this rule, k8s will show the result.
 
 |*`additionalVolumeMounts`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#volumemount-v1-core[$$VolumeMount$$] array__ 
-|*Optional* + 
- If provided, statefulset will add these volumes. You should set the rules for the corresponding volumes and volume mounts. We will not test this rule, k8s will show the result.
+|*Optional* +
+
+
+If provided, statefulset will add these volumes. You should set the rules for the corresponding volumes and volume mounts. We will not test this rule, k8s will show the result.
 
 |===
 

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -530,7 +530,7 @@ See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-
 | Field | Description
 
 |*`name`* __string__ 
-|*Optional* +
+|*Required*
 
 
 Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.

--- a/helm/operator/templates/job.min.io_jobs.yaml
+++ b/helm/operator/templates/job.min.io_jobs.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+    operator.min.io/version: v5.0.14
   name: miniojobs.job.min.io
 spec:
   group: job.min.io

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3300,15 +3300,13 @@ spec:
                       format: int32
                       type: integer
                       x-kubernetes-validations:
-                      - message: VolumesPerServer is immutable
+                      - message: volumesPerServer is immutable
                         rule: self == oldSelf
                   required:
                   - servers
                   - volumeClaimTemplate
+                  - volumesPerServer
                   type: object
-                  x-kubernetes-validations:
-                  - message: volumesPerServer is required once set
-                    rule: '!has(oldSelf.volumesPerServer) || has(self.volumesPerServer)'
                 type: array
               priorityClassName:
                 type: string

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3054,6 +3054,9 @@ spec:
                     servers:
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: servers is immutable
+                        rule: self == oldSelf
                     tolerations:
                       items:
                         properties:

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3303,11 +3303,15 @@ spec:
                       - message: volumesPerServer is immutable
                         rule: self == oldSelf
                   required:
+                  - name
                   - servers
                   - volumeClaimTemplate
                   - volumesPerServer
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               priorityClassName:
                 type: string
               prometheusOperator:

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+    operator.min.io/version: v5.0.14
   name: tenants.minio.min.io
 spec:
   group: minio.min.io
@@ -3298,11 +3299,16 @@ spec:
                     volumesPerServer:
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: VolumesPerServer is immutable
+                        rule: self == oldSelf
                   required:
                   - servers
                   - volumeClaimTemplate
-                  - volumesPerServer
                   type: object
+                  x-kubernetes-validations:
+                  - message: volumesPerServer is required once set
+                    rule: '!has(oldSelf.volumesPerServer) || has(self.volumesPerServer)'
                 type: array
               priorityClassName:
                 type: string

--- a/helm/operator/templates/sts.min.io_policybindings.yaml
+++ b/helm/operator/templates/sts.min.io_policybindings.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+    operator.min.io/version: v5.0.14
   name: policybindings.sts.min.io
 spec:
   group: sts.min.io

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -608,6 +608,7 @@ type CustomCertificateConfig struct {
 // Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
 //
 // See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumesPerServer) || has(self.volumesPerServer)", message="volumesPerServer is required once set"
 type Pool struct {
 	// *Optional* +
 	//
@@ -625,6 +626,8 @@ type Pool struct {
 	// The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. +
 	//
 	// The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
+	// +kubebuilder:validation:Optional
+    // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="VolumesPerServer is immutable"
 	VolumesPerServer int32 `json:"volumesPerServer"`
 	// *Required* +
 	//

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -608,7 +608,6 @@ type CustomCertificateConfig struct {
 // Pool (`pools`) defines a MinIO server pool on a Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
 //
 // See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumesPerServer) || has(self.volumesPerServer)", message="volumesPerServer is required once set"
 type Pool struct {
 	// *Optional* +
 	//
@@ -622,12 +621,11 @@ type Pool struct {
 	// The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 	Servers int32 `json:"servers"`
 	// *Required* +
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumesPerServer is immutable"
 	//
 	// The number of Persistent Volume Claims to generate for each MinIO server pod in the pool. +
 	//
 	// The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
-	// +kubebuilder:validation:Optional
-    // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="VolumesPerServer is immutable"
 	VolumesPerServer int32 `json:"volumesPerServer"`
 	// *Required* +
 	//

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -98,6 +98,8 @@ type Features struct {
 // For more complete documentation on this object, see the https://min.io/docs/minio/kubernetes/upstream/operations/installation.html[MinIO Kubernetes Documentation]. +
 type TenantSpec struct {
 	// *Required* +
+	// +listType=map
+	// +listMapKey=name
 	//
 	// An array of objects describing each MinIO server pool deployed in the MinIO Tenant. Each pool consists of a set of MinIO server pods which "pool" their storage resources for supporting object storage and retrieval requests. Each server pool is independent of all others and supports horizontal scaling of available storage resources in the MinIO Tenant. +
 	//
@@ -609,11 +611,10 @@ type CustomCertificateConfig struct {
 //
 // See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
 type Pool struct {
-	// *Optional* +
+	// *Required*
 	//
 	// Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
-	// +optional
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 	// *Required*
 	//
 	// The number of MinIO server pods to deploy in the pool. The minimum value is `2`.

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -616,6 +616,7 @@ type Pool struct {
 	// Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
 	Name string `json:"name"`
 	// *Required*
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="servers is immutable"
 	//
 	// The number of MinIO server pods to deploy in the pool. The minimum value is `2`.
 	//

--- a/pkg/client/applyconfiguration/job.min.io/v1alpha1/miniojobspec.go
+++ b/pkg/client/applyconfiguration/job.min.io/v1alpha1/miniojobspec.go
@@ -30,6 +30,7 @@ type MinIOJobSpecApplyConfiguration struct {
 	Execution          *jobminiov1alpha1.Execution       `json:"execution,omitempty"`
 	FailureStrategy    *jobminiov1alpha1.FailureStrategy `json:"failureStrategy,omitempty"`
 	Commands           []CommandSpecApplyConfiguration   `json:"commands,omitempty"`
+	MCImage            *string                           `json:"mcImage,omitempty"`
 }
 
 // MinIOJobSpecApplyConfiguration constructs an declarative configuration of the MinIOJobSpec type for use with
@@ -80,5 +81,13 @@ func (b *MinIOJobSpecApplyConfiguration) WithCommands(values ...*CommandSpecAppl
 		}
 		b.Commands = append(b.Commands, *values[i])
 	}
+	return b
+}
+
+// WithMCImage sets the MCImage field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the MCImage field is set to the value of the last call.
+func (b *MinIOJobSpecApplyConfiguration) WithMCImage(value string) *MinIOJobSpecApplyConfiguration {
+	b.MCImage = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/job.min.io/v1alpha1/miniojobstatus.go
+++ b/pkg/client/applyconfiguration/job.min.io/v1alpha1/miniojobstatus.go
@@ -23,6 +23,7 @@ package v1alpha1
 type MinIOJobStatusApplyConfiguration struct {
 	Phase          *string                           `json:"phase,omitempty"`
 	CommandsStatus []CommandStatusApplyConfiguration `json:"commands,omitempty"`
+	Message        *string                           `json:"message,omitempty"`
 }
 
 // MinIOJobStatusApplyConfiguration constructs an declarative configuration of the MinIOJobStatus type for use with
@@ -49,5 +50,13 @@ func (b *MinIOJobStatusApplyConfiguration) WithCommandsStatus(values ...*Command
 		}
 		b.CommandsStatus = append(b.CommandsStatus, *values[i])
 	}
+	return b
+}
+
+// WithMessage sets the Message field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Message field is set to the value of the last call.
+func (b *MinIOJobStatusApplyConfiguration) WithMessage(value string) *MinIOJobStatusApplyConfiguration {
+	b.Message = &value
 	return b
 }

--- a/resources/base/crds/job.min.io_miniojobs.yaml
+++ b/resources/base/crds/job.min.io_miniojobs.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+    operator.min.io/version: v5.0.14
   name: miniojobs.job.min.io
 spec:
   group: job.min.io

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3300,15 +3300,13 @@ spec:
                       format: int32
                       type: integer
                       x-kubernetes-validations:
-                      - message: VolumesPerServer is immutable
+                      - message: volumesPerServer is immutable
                         rule: self == oldSelf
                   required:
                   - servers
                   - volumeClaimTemplate
+                  - volumesPerServer
                   type: object
-                  x-kubernetes-validations:
-                  - message: volumesPerServer is required once set
-                    rule: '!has(oldSelf.volumesPerServer) || has(self.volumesPerServer)'
                 type: array
               priorityClassName:
                 type: string

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3054,6 +3054,9 @@ spec:
                     servers:
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: servers is immutable
+                        rule: self == oldSelf
                     tolerations:
                       items:
                         properties:

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3303,11 +3303,15 @@ spec:
                       - message: volumesPerServer is immutable
                         rule: self == oldSelf
                   required:
+                  - name
                   - servers
                   - volumeClaimTemplate
                   - volumesPerServer
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               priorityClassName:
                 type: string
               prometheusOperator:

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+    operator.min.io/version: v5.0.14
   name: tenants.minio.min.io
 spec:
   group: minio.min.io
@@ -3298,11 +3299,16 @@ spec:
                     volumesPerServer:
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: VolumesPerServer is immutable
+                        rule: self == oldSelf
                   required:
                   - servers
                   - volumeClaimTemplate
-                  - volumesPerServer
                   type: object
+                  x-kubernetes-validations:
+                  - message: volumesPerServer is required once set
+                    rule: '!has(oldSelf.volumesPerServer) || has(self.volumesPerServer)'
                 type: array
               priorityClassName:
                 type: string

--- a/resources/base/crds/sts.min.io_policybindings.yaml
+++ b/resources/base/crds/sts.min.io_policybindings.yaml
@@ -3,7 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+    operator.min.io/version: v5.0.14
   name: policybindings.sts.min.io
 spec:
   group: sts.min.io


### PR DESCRIPTION
# What does it do?

Adds validations in the fields `spec.pools.*.volumesPerServer` and `spec.pools.*.servers` to make the fields read-only after being created.

This could be helpful to prevent undesired changes on `volumesPerServer` and `servers` that could cause a Pool to not start.

As a side-effect the field `spec.pools.*.name` needed to be changed from `Optional` to `Required`, to overcome a limitation on OpenAPI.

```
The CustomResourceDefinition "tenants.minio.min.io" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[pools].items.properties[volumesPerServer].x-kubernetes-validations[0].rule: Invalid value: "self == oldSelf": oldSelf cannot be used on the uncorrelatable portion of the schema within spec.validation.openAPIV3Schema.properties[spec].properties[pools]
```
# How does it look?

On creation the fields are writtable
On edition are not editable anymore, a validation error as following will be shown:

```
# tenants.minio.min.io "minio-tenant-1" was not valid:
# * spec.pools[0].volumesPerServer: Invalid value: "integer": volumesPerServer is immutable
#
```
![field immutable](https://github.com/minio/operator/assets/1334362/8097f67a-9eb6-4309-aa00-732b96ad98ac)
