### PR TITLE
Correct typo

### DIFF
--- a/pkg/utils/miniojob/minioJob.go
+++ b/pkg/utils/miniojob/minioJob.go
@@ -48,12 +48,12 @@ type FieldsFunc func(args map[string]string) (Arg, error)
 
 // Key - key=value|value1,value2,value3
 func Key(key string) FieldsFunc {
-	return KeyForamt(key, "$0")
+	return KeyFormat(key, "$0")
 }
 
 // FLAGS - --key=""|value|value1,value2,value3
 func FLAGS(ignoreKeys ...string) FieldsFunc {
-	return prefixKeyForamt("-", ignoreKeys...)
+	return prefixKeyFormat("-", ignoreKeys...)
 }
 
 // ALIAS - myminio
@@ -135,9 +135,9 @@ func Option(opt FieldsFunc) FieldsFunc {
 	}
 }
 
-// KeyForamt - match key and get outPut to replace $0 to output the value
+// KeyFormat - match key and get outPut to replace $0 to output the value
 // if format not contain $0, will add $0 to the end
-func KeyForamt(key string, format string) FieldsFunc {
+func KeyFormat(key string, format string) FieldsFunc {
 	return func(args map[string]string) (out Arg, err error) {
 		if args == nil {
 			return out, fmt.Errorf("args is nil")
@@ -214,7 +214,7 @@ func Sanitize(funcs ...FieldsFunc) FieldsFunc {
 	}
 }
 
-var prefixKeyForamt = func(pkey string, ignoreKeys ...string) FieldsFunc {
+var prefixKeyFormat = func(pkey string, ignoreKeys ...string) FieldsFunc {
 	return func(args map[string]string) (out Arg, err error) {
 		if args == nil {
 			return out, fmt.Errorf("args is nil")

--- a/pkg/utils/miniojob/minioJob_test.go
+++ b/pkg/utils/miniojob/minioJob_test.go
@@ -68,13 +68,13 @@ func TestParser(t *testing.T) {
 			expectError: false,
 		},
 		{
-			command:     KeyForamt("user", "--user $0"),
+			command:     KeyFormat("user", "--user $0"),
 			args:        copyArgs(args),
 			expect:      Arg{Command: "--user a b c d"},
 			expectError: false,
 		},
 		{
-			command:     KeyForamt("user", "--user"),
+			command:     KeyFormat("user", "--user"),
 			args:        copyArgs(args),
 			expect:      Arg{Command: "--user a b c d"},
 			expectError: false,
@@ -116,19 +116,19 @@ func TestParser(t *testing.T) {
 			expectError: false,
 		},
 		{
-			command:     OneOf(KeyForamt("user", "--user"), KeyForamt("group", "--group")),
+			command:     OneOf(KeyFormat("user", "--user"), KeyFormat("group", "--group")),
 			args:        copyArgs(args),
 			expect:      Arg{Command: "--user a b c d"},
 			expectError: false,
 		},
 		{
-			command:     OneOf(KeyForamt("miss_user", "--user"), KeyForamt("group", "--group")),
+			command:     OneOf(KeyFormat("miss_user", "--user"), KeyFormat("group", "--group")),
 			args:        copyArgs(args),
 			expect:      Arg{Command: "--group group1 group2 group3"},
 			expectError: false,
 		},
 		{
-			command:     OneOf(KeyForamt("miss_user", "--user"), KeyForamt("miss_group", "--group")),
+			command:     OneOf(KeyFormat("miss_user", "--user"), KeyFormat("miss_group", "--group")),
 			args:        copyArgs(args),
 			expect:      Arg{Command: "--group group1 group2 group3"},
 			expectError: true,

--- a/pkg/utils/miniojob/types.go
+++ b/pkg/utils/miniojob/types.go
@@ -60,7 +60,7 @@ var JobOperation = map[string][]FieldsFunc{
 	"mb":                  {FLAGS(), Sanitize(ALIAS(), Static("/"), Key("name")), Static("--ignore-existing")},
 	"admin/user/add":      {ALIAS(), Key("user"), Key("password")},
 	"admin/policy/create": {ALIAS(), Key("name"), File("policy", "json")},
-	"admin/policy/attach": {ALIAS(), Key("policy"), OneOf(KeyForamt("user", "--user"), KeyForamt("group", "--group"))},
+	"admin/policy/attach": {ALIAS(), Key("policy"), OneOf(KeyFormat("user", "--user"), KeyFormat("group", "--group"))},
 	"admin/config/set":    {ALIAS(), Key("webhookName"), Option(KeyValue("endpoint")), Option(KeyFile("client_key", "key")), Option(KeyFile("client_cert", "pem")), OthersKeyValues()},
 }
 


### PR DESCRIPTION
### Objective:

To correct typo, from `KeyForamt` to `KeyFormat`