### PR TITLE
Run all integration tests in restricted namespaces

### DIFF
--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -95,6 +95,12 @@ operator:
     runAsUser: 1000
     runAsGroup: 1000
     runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
   ###
   # An array of `Volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`__ which the Operator can mount to pods.
   #
@@ -279,6 +285,12 @@ console:
   containerSecurityContext:
     runAsUser: 1000
     runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
   ###
   # Configures `Ingress <https://kubernetes.io/docs/concepts/services-networking/ingress/>`__ for the Operator Console.
   #

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -278,12 +278,14 @@ console:
   # You may need to modify these values to meet your cluster's security and access settings.
   securityContext:
     runAsUser: 1000
+    runAsGroup: 1000
     runAsNonRoot: true
   ###
   # The Kubernetes `SecurityContext <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/>`__ to use for deploying Operator Console containers.
   # You may need to modify these values to meet your cluster's security and access settings.
   containerSecurityContext:
     runAsUser: 1000
+    runAsGroup: 1000
     runAsNonRoot: true
     allowPrivilegeEscalation: false
     capabilities:

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -203,6 +203,12 @@ tenant:
         runAsUser: 1000
         runAsGroup: 1000
         runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
       ###
       #
       # An array of `Topology Spread Constraints <https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/>`__ to associate to Operator Console pods.

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -465,6 +465,12 @@ tenant:
   #    runAsGroup: 1000
   #    runAsNonRoot: true
   #    allowPrivilegeEscalation: false
+  #    capabilities:
+  #      drop:
+  #        - ALL
+  #    seccompProfile:
+  #      type: RuntimeDefault
+
 ###
 # Configures `Ingress <https://kubernetes.io/docs/concepts/services-networking/ingress/>`__ for the Tenant S3 API and Console.
 #

--- a/resources/base/console-ui.yaml
+++ b/resources/base/console-ui.yaml
@@ -296,6 +296,12 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - containerPort: 9090
               name: http

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -36,6 +36,13 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             runAsNonRoot: true
+            securityContext:
+              allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: MINIO_CONSOLE_TLS_ENABLE
               value: "off"

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -36,8 +36,7 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             runAsNonRoot: true
-            securityContext:
-              allowPrivilegeEscalation: false
+            allowPrivilegeEscalation: false
             capabilities:
               drop:
                 - ALL

--- a/resources/base/namespace.yaml
+++ b/resources/base/namespace.yaml
@@ -2,3 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: minio-operator
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/testing/common.sh
+++ b/testing/common.sh
@@ -529,6 +529,22 @@ function load_kind_images() {
     load_kind_image "$CONSOLE_RELEASE"
 }
 
+function create_restricted_namespace() {
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "$1"
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
+EOF
+}
+
 function install_operator() {
   # It requires compiled binary in minio-operator folder in order for docker build to work when copying this folder.
   # For that in the github actions you need to wait for operator test/step to get the binary.
@@ -550,9 +566,9 @@ function install_operator() {
     yq -i '.console.image.repository = "minio/operator"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
     yq -i '.console.image.tag = "noop"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
     echo "Installing Current Operator via HELM"
+    create_restricted_namespace minio-operator
     helm install \
       --namespace minio-operator \
-      --create-namespace \
       minio-operator ./helm/operator
 
     echo "key, value for pod selector in helm test"
@@ -758,8 +774,9 @@ function install_tenant() {
     namespace=default
     key=v1.min.io/tenant
     value=myminio
+    create_restricted_namespace $namespace
     try helm install --namespace $namespace \
-      --create-namespace tenant ./helm/tenant
+      tenant ./helm/tenant
   elif [ "$1" = "logs" ]; then
     namespace="tenant-lite"
     key=v1.min.io/tenant


### PR DESCRIPTION
PR #2072 adds the required default container security context values, so the Helm scripts for operator and tenant should be able to run in a restricted pod security mode. This PR adds the tests that will run all tests in restricted namespaces.

When PR @2072 is merged, then this PR should be rebased again to only include the test changes.