### PR TITLE
To fix upgrade test

### DIFF
--- a/testing/common.sh
+++ b/testing/common.sh
@@ -604,7 +604,7 @@ function install_operator_version() {
   echo "Target operator release: $version"
 
   # Initialize the MinIO Kubernetes Operator
-  kubectl apply -k "${SCRIPT_DIR}/../resources"
+  kubectl apply -k github.com/minio/operator/resources/\?ref=v"$version"
 
 
   if [ "$1" = "helm" ]; then


### PR DESCRIPTION
### Objective:

To address the broken or altered Tenant Upgrade Test, please refer to the changes made in https://github.com/minio/operator/pull/2051, which were necessitated by the deprecation of the plugin.

### Reasoning:

In this particular scenario, we should not overlook the version; it's essential.

### What could happen if left unfixed:

The new release will fail without this fix.