### PR TITLE
Image Digest should be created differently to work

### DIFF
--- a/olm.sh
+++ b/olm.sh
@@ -63,7 +63,6 @@ for catalog in "${redhatCatalogs[@]}"; do
     --output-dir bundles/$catalog/$RELEASE \
     --channels stable \
     --overwrite \
-    --use-image-digests \
     --kustomize-dir config/manifests
 
   # Set the version, later in olm-post-script.sh we change for Digest form.


### PR DESCRIPTION
### Error While Creating New Release:

```
FATAL[0002] Error generating bundle manifests: 
error resolving image: 
GET https://index.docker.io/v2/minio/operator/manifests/v5.0.15: 
MANIFEST_UNKNOWN: manifest unknown; unknown tag=v5.0.15 
```

### Suggestion:

I'm unsure about resolving the error mentioned above, so I recommend exploring alternative methods for utilizing image digests.

### Story:

While attempting to create the new release, I encountered an issue stemming from the `--use-image-digests` flag. Unfortunately, I'm unsure how to resolve it, especially if we still need to utilize this flag. Assistance in resolving this matter would be greatly appreciated.