### PR TITLE
label is vague and create conflicts, renaming to `minio-operator`

### DIFF
--- a/resources/kustomization.yaml
+++ b/resources/kustomization.yaml
@@ -7,7 +7,7 @@ commonAnnotations:
   operator.min.io/support: "https://subnet.min.io"
   operator.min.io/version: v5.0.14
 commonLabels:
-  app.kubernetes.io/name: operator
+  app.kubernetes.io/name: minio-operator
 resources:
   - base/namespace.yaml
   - base/service-account.yaml


### PR DESCRIPTION
Fix bug:
```
for: "/home/runner/work/operator/operator/testing/../testing/dev": Deployment.apps "minio-operator" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/name":"operator", "name":"minio-operator"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```