### PR TITLE
To fix tenant upgrade test

### DIFF
--- a/testing/dev/console-deployment.yaml
+++ b/testing/dev/console-deployment.yaml
@@ -10,3 +10,13 @@ spec:
       containers:
         - name: console
           image: minio/operator:noop
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/testing/dev/deployment.yaml
+++ b/testing/dev/deployment.yaml
@@ -22,6 +22,12 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
### Objective:

To fix tenant upgrade test:

```
Installing Current Operator
namespace/minio-operator configured
Warning: existing pods in namespace "minio-operator" violate the new PodSecurity enforce level "restricted:latest"
Warning: console-7cbdf5f578-qsppl (and 2 other pods): allowPrivilegeEscalation != false, unrestricted capabilities, seccompProfile
```