### PR TITLE
Validate service label and annotation absence

### DIFF
--- a/pkg/controller/minio-services.go
+++ b/pkg/controller/minio-services.go
@@ -91,12 +91,18 @@ func (c *Controller) checkMinIOSvc(ctx context.Context, tenant *miniov2.Tenant, 
 
 func minioSvcMatchesSpecification(svc *corev1.Service, expectedSvc *corev1.Service) (bool, error) {
 	// expected labels match
+	if len(svc.ObjectMeta.Labels) != len(expectedSvc.ObjectMeta.Labels) {
+		return false, errors.New("service labels don't match")
+	}
 	for k, expVal := range expectedSvc.ObjectMeta.Labels {
 		if value, ok := svc.ObjectMeta.Labels[k]; !ok || value != expVal {
 			return false, errors.New("service labels don't match")
 		}
 	}
 	// expected annotations match
+	if len(svc.ObjectMeta.Annotations) != len(expectedSvc.ObjectMeta.Annotations) {
+		return false, errors.New("service annotations don't match")
+	}
 	for k, expVal := range expectedSvc.ObjectMeta.Annotations {
 		if value, ok := svc.ObjectMeta.Annotations[k]; !ok || value != expVal {
 			return false, errors.New("service annotations don't match")


### PR DESCRIPTION
When the users delete labels or annotations from `serviceMetadata`, the operator should delete the corresponding label or annotation from the service. This is to maintain the expected and actual service definitions in sync. 

Currently, if an entry is deleted from the serviceMetadata element, the corresponding label or annotation remains on the corresponding service.

This fixes https://github.com/minio/operator/issues/2038

See full tests here https://github.com/allanrogerr/public/wiki/operator%E2%80%902038

Test summary:
1. Deploy an operator and tenant
2. Add labels and annotations to `.spec.serviceMetadata`
3. Observe the console and minio services match these tenant changes
4. Validate that minio is still accessible from the Console UI and s3 API
5. Remove labels and annotations to `.spec.serviceMetadata`
6. Observe the console and minio services match these tenant changes
7. Validate that minio is still accessible from the Console UI and s3 API