### PR TITLE
set securityContext for test

### DIFF
--- a/testing/dev/deployment.yaml
+++ b/testing/dev/deployment.yaml
@@ -22,6 +22,12 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Missing to provide this security  context for the MinIO Operator values makes upgrade test fail