### PR TITLE
Operator release should update everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,10 @@ helm-reindex:
 	@echo "Re-indexing helm chart release"
 	@./helm-reindex.sh
 
-release: assets generate-code regen-crd regen-crd-docs
+update-versions:
 	@./release.sh
+
+release: update-versions generate-code regen-crd regen-crd-docs assets
 
 apply-gofmt:
 	@echo "Applying gofmt to all generated an existing files"

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ update-versions:
 	@./release.sh
 
 release: update-versions generate-code regen-crd regen-crd-docs assets
+	@git add .
 
 apply-gofmt:
 	@echo "Applying gofmt to all generated an existing files"

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ helm-reindex:
 	@echo "Re-indexing helm chart release"
 	@./helm-reindex.sh
 
-release: assets
+release: assets generate-code regen-crd regen-crd-docs
 	@./release.sh
 
 apply-gofmt:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ for [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kusto
 use that to install MiniO Operator.
 
 ```sh
-kubectl kustomize github.com/minio/operator\?ref=v5.0.15
+kubectl kustomize github.com/minio/operator\?ref=v5.0.16
 ```
 
 Run the following command to verify the status of the Operator:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ for [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kusto
 use that to install MiniO Operator.
 
 ```sh
-kubectl kustomize github.com/minio/operator\?ref=v5.0.16
+kubectl kustomize github.com/minio/operator\?ref=v5.0.15
 ```
 
 Run the following command to verify the status of the Operator:

--- a/release.sh
+++ b/release.sh
@@ -69,5 +69,3 @@ sed -i -e "s~operator.min.io/version: .*~operator.min.io/version: v${RELEASE}~g"
 
 echo "clean -e files"
 rm -vf $(git ls-files --others | grep -e "-e$" | awk '{print $1}')
-git add .
-


### PR DESCRIPTION
# What this do?

Been noticing that after changes to the Types we are often missing to regenerate the controller code to include new fields, same with  CRD's  and CRD's docs, this PR is a reordering of the release process to make sure we are regenerating everything should be regenerated, in the right order.

* Reorder release steps to make sure all references are correctly created:
1) Update Operator, minio and KES versions (run release.sh)
2) Generate controller code
3) Update CRD's
4) Update CRD docs
5) Generate Operator console assets

* Add all resulting files to git at the end of all files modifications

The command to create a release stays the same

```shell
RELEASE=5.0.15 make release
```