### PR TITLE
Only specify storageClassName when set

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -43,7 +43,9 @@ spec:
           annotations: {{- toYaml . | nindent 12 }}
       {{- end }}
         spec:
+          {{- if dig "storageClassName" "" . }}
           storageClassName: {{ dig "storageClassName" "" . }}
+          {{- end }}
           accessModes:
             - ReadWriteOnce
           resources:


### PR DESCRIPTION
Although not setting a value for the `storageClassName` works on my machine, it's better not to emit the field if it's not set. Not setting the value will use the default storage class.

A user reported #2111 with not setting the value and this should resolve it.