### PR TITLE
fix: don't need match number for labels/annotations for service diff

### DIFF
--- a/pkg/controller/minio-services.go
+++ b/pkg/controller/minio-services.go
@@ -90,18 +90,10 @@ func (c *Controller) checkMinIOSvc(ctx context.Context, tenant *miniov2.Tenant, 
 }
 
 func minioSvcMatchesSpecification(svc *corev1.Service, expectedSvc *corev1.Service) (bool, error) {
-	// expected labels match
-	if len(svc.ObjectMeta.Labels) != len(expectedSvc.ObjectMeta.Labels) {
-		return false, errors.New("service labels don't match")
-	}
 	for k, expVal := range expectedSvc.ObjectMeta.Labels {
 		if value, ok := svc.ObjectMeta.Labels[k]; !ok || value != expVal {
 			return false, errors.New("service labels don't match")
 		}
-	}
-	// expected annotations match
-	if len(svc.ObjectMeta.Annotations) != len(expectedSvc.ObjectMeta.Annotations) {
-		return false, errors.New("service annotations don't match")
 	}
 	for k, expVal := range expectedSvc.ObjectMeta.Annotations {
 		if value, ok := svc.ObjectMeta.Annotations[k]; !ok || value != expVal {


### PR DESCRIPTION
don't need match number for labels/annotations for service diff
other operator will update labels or annotations to our service.
![image](https://github.com/minio/operator/assets/13503801/440ad563-6271-474d-8b48-93d0f8b9b69a)
