### PR TITLE
Reload certificates in `operator-ca-tls` secrets

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -37,6 +37,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/minio/operator/pkg/certs"
+
 	"github.com/miekg/dns"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,7 +104,7 @@ var (
 // GetPodCAFromFile assumes the operator is running inside a k8s pod and extract the
 // current ca certificate from /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 func GetPodCAFromFile() []byte {
-	cert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	cert, err := os.ReadFile(fmt.Sprintf("/var/run/secrets/kubernetes.io/serviceaccount/%s", certs.CAPublicCertFile))
 	if err != nil {
 		return nil
 	}
@@ -120,7 +122,7 @@ func GetOpenshiftServiceCAFromFile() []byte {
 
 // GetOpenshiftCSRSignerCAFromFile extracts the tls.crt certificate in Openshift deployments coming from the mounted secret openshift-csr-signer-ca
 func GetOpenshiftCSRSignerCAFromFile() []byte {
-	cert, err := os.ReadFile("/tmp/csr-signer-ca/tls.crt")
+	cert, err := os.ReadFile(fmt.Sprintf("/tmp/csr-signer-ca/%s", certs.TLSCertFile))
 	if err != nil {
 		return nil
 	}
@@ -129,13 +131,13 @@ func GetOpenshiftCSRSignerCAFromFile() []byte {
 
 // GetPublicCertFilePath return the path to the certificate file based for the serviceName
 func GetPublicCertFilePath(serviceName string) string {
-	publicCertPath := fmt.Sprintf("/tmp/%s/public.crt", serviceName)
+	publicCertPath := fmt.Sprintf("/tmp/%s/%s", serviceName, certs.PublicCertFile)
 	return publicCertPath
 }
 
 // GetPrivateKeyFilePath return the path to the key file based for the serviceName
 func GetPrivateKeyFilePath(serviceName string) string {
-	privateKey := fmt.Sprintf("/tmp/%s/private.key", serviceName)
+	privateKey := fmt.Sprintf("/tmp/%s/%s", serviceName, certs.PrivateKeyFile)
 	return privateKey
 }
 

--- a/pkg/certs/const.go
+++ b/pkg/certs/const.go
@@ -35,6 +35,9 @@ const (
 	// PrivateKeyFile Private key file for HTTPS.
 	PrivateKeyFile = "private.key"
 
+	// CAPublicCertFile  Public certificate file for Certificate authority.
+	CAPublicCertFile = "ca.crt"
+
 	// TLSKeyFile Private key file for HTTPS.
 	TLSKeyFile = "tls.key"
 )

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -36,15 +36,6 @@ const (
 	OperatorRuntimeOpenshift Runtime = "OPENSHIFT"
 	// OperatorRuntimeRancher is the Rancher runtime flag
 	OperatorRuntimeRancher Runtime = "RANCHER"
-
-	// TLSCRT is  name of the field containing tls certificate in secret
-	TLSCRT = "tls.crt"
-
-	// CACRT name of the field containing ca certificate in secret
-	CACRT = "ca.crt"
-
-	// PublicCRT name of the field containing public certificate in secret
-	PublicCRT = "public.crt"
 )
 
 // Runtimes is a map of the supported Kubernetes runtimes

--- a/pkg/controller/console.go
+++ b/pkg/controller/console.go
@@ -100,12 +100,12 @@ func (c *Controller) checkConsoleSvc(ctx context.Context, tenant *miniov2.Tenant
 
 // generateConsoleTLSCert Issues the Operator Console TLS Certificate
 func (c *Controller) generateConsoleTLSCert() (*string, *string) {
-	return c.generateTLSCert("console", OperatorConsoleTLSSecretName, getConsoleDeploymentName())
+	return c.generateTLSCertificateForService("console", OperatorConsoleTLSSecretName, getConsoleDeploymentName())
 }
 
 func (c *Controller) recreateOperatorConsoleCertsIfRequired(ctx context.Context) error {
 	namespace := miniov2.GetNSFromFile()
-	operatorConsoleTLSSecret, err := c.getTLSSecret(ctx, namespace, OperatorConsoleTLSSecretName)
+	operatorConsoleTLSSecret, err := c.getCertificateSecret(ctx, namespace, OperatorConsoleTLSSecretName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			klog.V(2).Info("TLS certificate not found. Generating one.")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -148,6 +148,7 @@ func StartOperator(kubeconfig string) {
 		klog.Infof("Watching only namespaces: %s", strings.Join(namespaces.ToSlice(), ","))
 	}
 
+	// kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, time.Second*30, kubeinformers.WithNamespace(v2.GetNSFromFile()))
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	minioInformerFactory := informers.NewSharedInformerFactory(controllerClient, time.Second*30)
 	podName := os.Getenv(HostnameEnv)
@@ -163,16 +164,12 @@ func StartOperator(kubeconfig string) {
 		k8sClient,
 		controllerClient,
 		promClient,
-		kubeInformerFactory.Apps().V1().StatefulSets(),
-		kubeInformerFactory.Apps().V1().Deployments(),
-		kubeInformerFactory.Core().V1().Pods(),
-		minioInformerFactory.Minio().V2().Tenants(),
-		minioInformerFactory.Sts().V1beta1().PolicyBindings(),
-		kubeInformerFactory.Core().V1().Services(),
 		hostsTemplate,
 		pkg.Version,
+		kubeInformerFactory,
+		minioInformerFactory.Minio().V2().Tenants(),
+		minioInformerFactory.Sts().V1beta1().PolicyBindings(),
 		minioInformerFactory.Job().V1alpha1().MinIOJobs(),
-		kubeInformerFactory.Batch().V1().Jobs(),
 	)
 
 	go kubeInformerFactory.Start(stopCh)

--- a/pkg/controller/csr.go
+++ b/pkg/controller/csr.go
@@ -29,6 +29,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/minio/operator/pkg/certs"
+
 	"github.com/minio/operator/pkg/controller/certificates"
 
 	certificatesV1 "k8s.io/api/certificates/v1"
@@ -257,8 +259,8 @@ func (c *Controller) createSecret(ctx context.Context, tenant *miniov2.Tenant, l
 			},
 		},
 		Data: map[string][]byte{
-			"private.key": pkBytes,
-			"public.crt":  certBytes,
+			certs.PrivateKeyFile: pkBytes,
+			certs.PublicCertFile: certBytes,
 		},
 	}
 	_, err := c.kubeClientSet.CoreV1().Secrets(tenant.Namespace).Create(ctx, secret, metav1.CreateOptions{})

--- a/pkg/controller/custom.go
+++ b/pkg/controller/custom.go
@@ -24,15 +24,17 @@ import (
 	"math"
 	"time"
 
+	"github.com/minio/operator/pkg/certs"
+
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var secretTypePublicKeyNameMap = map[string]string{
-	"kubernetes.io/tls":        "tls.crt",
-	"cert-manager.io/v1":       "tls.crt",
-	"cert-manager.io/v1alpha2": "tls.crt",
+	"kubernetes.io/tls":        certs.TLSCertFile,
+	"cert-manager.io/v1":       certs.TLSCertFile,
+	"cert-manager.io/v1alpha2": certs.TLSCertFile,
 	// Add newer secretTypes and their corresponding values in future
 }
 
@@ -51,7 +53,7 @@ func (c *Controller) getCustomCertificates(ctx context.Context, tenant *miniov2.
 
 	for certType, secrets := range secretsMap {
 		certificates = nil
-		publicKey := "public.crt"
+		publicKey := certs.PublicCertFile
 		// Iterate over TLS secrets and build array of CertificateInfo structure
 		// that will be used to display information about certs
 		for _, secret := range secrets {

--- a/pkg/controller/kes.go
+++ b/pkg/controller/kes.go
@@ -26,6 +26,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/minio/operator/pkg/certs"
+
 	"github.com/minio/operator/pkg/controller/certificates"
 
 	corev1 "k8s.io/api/core/v1"
@@ -326,9 +328,9 @@ func (c *Controller) getCertIdentity(ns string, cert *miniov2.LocalCertificateRe
 	}
 	// Store the Identity to be used later during KES container creation
 	if secret.Type == "kubernetes.io/tls" || secret.Type == "cert-manager.io/v1alpha2" || secret.Type == "cert-manager.io/v1" {
-		certbytes = secret.Data["tls.crt"]
+		certbytes = secret.Data[certs.TLSCertFile]
 	} else {
-		certbytes = secret.Data["public.crt"]
+		certbytes = secret.Data[certs.PublicCertFile]
 	}
 
 	// parse the certificate here to generate the identity for this certifcate.

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1412,13 +1412,15 @@ func (c *Controller) handleSecret(obj interface{}, oldObj interface{}) {
 	if secret.Namespace == ns {
 		// a secret with prefix "operator-ca-tls" changed, reload all trusted CA certificates
 		if strings.HasPrefix(secret.Name, OperatorCATLSSecretName) {
-			klog.Infof("secret '%s' found, adding TLS certs in it to trusted CA's", secret.Name)
+			klog.Infof("Secret '%s/%s' changed", secret.Namespace, secret.Name)
 			var oldSecret *corev1.Secret
-			if oldSecret != nil {
+			if oldObj != nil {
 				oldSecret = oldObj.(*corev1.Secret)
 			}
 			// Add new certificates to Transport Certs if any changed
-			c.TrustTLSCertificatesInSecretIfChanged(secret, oldSecret)
+			if !c.TrustTLSCertificatesInSecretIfChanged(secret, oldSecret) {
+				klog.Infof("No new certificate was added from secret '%s/%s'", secret.Name, secret.Name)
+			}
 		}
 	}
 }

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -232,13 +232,14 @@ func NewController(
 	tenantInformer informers.TenantInformer,
 	policyBindingInformer stsInformers.PolicyBindingInformer,
 	minioJobInformer jobinformers.MinIOJobInformer,
+	kubeInformerFactoryInOperatorNamespace kubeinformers.SharedInformerFactory,
 ) *Controller {
 	statefulSetInformer := kubeInformerFactory.Apps().V1().StatefulSets()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
 	podInformer := kubeInformerFactory.Core().V1().Pods()
 	serviceInformer := kubeInformerFactory.Core().V1().Services()
 	jobInformer := kubeInformerFactory.Batch().V1().Jobs()
-	secretInformer := kubeInformerFactory.Core().V1().Secrets()
+	secretInformer := kubeInformerFactoryInOperatorNamespace.Core().V1().Secrets()
 
 	// Create event broadcaster
 	// Add minio-controller types to the default Kubernetes Scheme so Events can be

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1416,7 +1416,9 @@ func (c *Controller) handleSecret(obj interface{}, oldObj interface{}) {
 			klog.Infof("Secret '%s/%s' changed", secret.Namespace, secret.Name)
 			var oldSecret *corev1.Secret
 			if oldObj != nil {
-				oldSecret = oldObj.(*corev1.Secret)
+				if oldCasted, ok := oldObj.(*corev1.Secret); ok {
+					oldSecret = oldCasted
+				}
 			}
 			// Add new certificates to Transport Certs if any changed
 			if !c.TrustTLSCertificatesInSecretIfChanged(secret, oldSecret) {

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -248,18 +248,16 @@ func (c *Controller) trustIfChanged(newSecret *corev1.Secret, oldSecret *corev1.
 				if err := c.addTLSCertificatesToTrustInTransport(newPublicCert); err == nil {
 					klog.Infof("Added certificates in field '%s' of '%s/%s' secret to trusted RootCA's", fieldToCompare, newSecret.Namespace, newSecret.Name)
 					return true
-				} else {
-					klog.Errorf("Failed adding certs in field '%s' of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
 				}
+				klog.Errorf("Failed adding certs in field '%s' of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
 			}
 		} else {
 			// If filed was not present in old secret but is in new secret then is an addition, we trust it
 			if err := c.addTLSCertificatesToTrustInTransport(newPublicCert); err == nil {
 				klog.Infof("Added certificates in field '%s' of '%s/%s' secret to trusted RootCA's", fieldToCompare, newSecret.Namespace, newSecret.Name)
 				return true
-			} else {
-				klog.Errorf("Failed adding certs in field %s of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
 			}
+			klog.Errorf("Failed adding certs in field %s of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
 		}
 	}
 	return false
@@ -271,9 +269,8 @@ func (c *Controller) trustPEMInSecretField(secret *corev1.Secret, fieldToCompare
 		if err := c.addTLSCertificatesToTrustInTransport(newPublicCert); err == nil {
 			klog.Infof("Added certificates in field '%s' of '%s/%s' secret to trusted RootCA's", fieldToCompare, secret.Namespace, secret.Name)
 			return true
-		} else {
-			klog.Errorf("Failed adding certs in field '%s' of '%s/%s' secret: %v", fieldToCompare, secret.Namespace, secret.Name, err)
 		}
+		klog.Errorf("Failed adding certs in field '%s' of '%s/%s' secret: %v", fieldToCompare, secret.Namespace, secret.Name, err)
 	}
 	return false
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -252,12 +252,12 @@ func (c *Controller) trustIfChanged(newSecret *corev1.Secret, oldSecret *corev1.
 				klog.Errorf("Failed adding certs in field '%s' of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
 			}
 		} else {
-			// If filed was not present in old secret but is in new secret then is an addition, we trust it
+			// If field was not present in old secret but is in new secret then is an addition, we trust it
 			if err := c.addTLSCertificatesToTrustInTransport(newPublicCert); err == nil {
 				klog.Infof("Added certificates in field '%s' of '%s/%s' secret to trusted RootCA's", fieldToCompare, newSecret.Namespace, newSecret.Name)
 				return true
 			}
-			klog.Errorf("Failed adding certs in field %s of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
+			klog.Errorf("Failed adding certificates in field %s of '%s/%s' secret: %v", fieldToCompare, newSecret.Namespace, newSecret.Name, err)
 		}
 	}
 	return false
@@ -270,7 +270,7 @@ func (c *Controller) trustPEMInSecretField(secret *corev1.Secret, fieldToCompare
 			klog.Infof("Added certificates in field '%s' of '%s/%s' secret to trusted RootCA's", fieldToCompare, secret.Namespace, secret.Name)
 			return true
 		}
-		klog.Errorf("Failed adding certs in field '%s' of '%s/%s' secret: %v", fieldToCompare, secret.Namespace, secret.Name, err)
+		klog.Errorf("Failed adding certificates in field '%s' of '%s/%s' secret: %v", fieldToCompare, secret.Namespace, secret.Name, err)
 	}
 	return false
 }
@@ -278,7 +278,7 @@ func (c *Controller) trustPEMInSecretField(secret *corev1.Secret, fieldToCompare
 func (c *Controller) addTLSCertificatesToTrustInTransport(certificateData []byte) error {
 	var x509Certs []*x509.Certificate
 	current := certificateData
-	// A single PEM file could contain more than one certificate, keeping track of the index to help debugging
+	// A single PEM file could contain more than one certificates, keeping track of the index to help debugging
 	certIndex := 1
 	for len(current) > 0 {
 		var pemBlock *pem.Block

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -214,7 +214,7 @@ func (c *Controller) TrustTLSCertificatesInSecretIfChanged(newSecret *corev1.Sec
 	if oldSecret == nil {
 		// secret did not exist before, we trust all certs in it
 		c.trustPEMInSecretField(newSecret, certs.PublicCertFile)
-		c.trustPEMInSecretField(newSecret, certs.PrivateKeyFile)
+		c.trustPEMInSecretField(newSecret, certs.TLSCertFile)
 		c.trustPEMInSecretField(newSecret, certs.CAPublicCertFile)
 	} else {
 		// compare to add to trust only certs that changed

--- a/pkg/controller/sts.go
+++ b/pkg/controller/sts.go
@@ -400,7 +400,7 @@ func IsSTSEnabled() bool {
 
 // generateConsoleTLSCert Issues the Operator Console TLS Certificate
 func (c *Controller) generateSTSTLSCert() (*string, *string) {
-	return c.generateTLSCert("sts", STSTLSSecretName, getOperatorDeploymentName())
+	return c.generateTLSCertificateForService("sts", STSTLSSecretName, getOperatorDeploymentName())
 }
 
 // waitSTSTLSCert Waits for the Operator leader to issue the TLS Certificate for STS

--- a/pkg/resources/statefulsets/kes-statefulset.go
+++ b/pkg/resources/statefulsets/kes-statefulset.go
@@ -17,6 +17,8 @@ package statefulsets
 import (
 	"sort"
 
+	"github.com/minio/operator/pkg/certs"
+
 	operatorApi "github.com/minio/operator/api"
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -201,8 +203,8 @@ func NewForKES(t *miniov2.Tenant, serviceName string) *appsv1.StatefulSet {
 	var clientCertSecret string
 
 	serverCertPaths := []corev1.KeyToPath{
-		{Key: "public.crt", Path: certPath},
-		{Key: "private.key", Path: keyPath},
+		{Key: certs.PublicCertFile, Path: certPath},
+		{Key: certs.PrivateKeyFile, Path: keyPath},
 	}
 
 	configPath := []corev1.KeyToPath{
@@ -216,8 +218,8 @@ func NewForKES(t *miniov2.Tenant, serviceName string) *appsv1.StatefulSet {
 		// "cert-manager.io/v1alpha2" because of same keys in both.
 		if t.Spec.KES.ExternalCertSecret.Type == "kubernetes.io/tls" || t.Spec.KES.ExternalCertSecret.Type == "cert-manager.io/v1alpha2" || t.Spec.KES.ExternalCertSecret.Type == "cert-manager.io/v1" {
 			serverCertPaths = []corev1.KeyToPath{
-				{Key: "tls.crt", Path: certPath},
-				{Key: "tls.key", Path: keyPath},
+				{Key: certs.TLSCertFile, Path: certPath},
+				{Key: certs.TLSKeyFile, Path: keyPath},
 			}
 		}
 	} else {


### PR DESCRIPTION
Listen for secret changes in the operator namespace and trust TLS certificates stored in secrets with the prefix "operator-ca-tls"

* No longer copy the secret `operator-ca-tls` from the operator namespace to the tenants namespace. Since [PR https://github.com/minio/operator/pull/1847](https://github.com/minio/operator/pull/1847) the secret `operator-ca-tls` is no longer mounted in the tenant, so there is no need to keep a copy in tenant namespace.
* `queue.NewNamedRateLimitingQueue` is deprecated and has been replaced with the recommended `queue.NewRateLimitingQueueWithConfig`.
* Remove the duplicated method `getTLSSecret` and invoke `getCertificateSecret` instead.
* Rename [generateTLSCert](https://github.com/minio/operator/blob/1c2fa4f402cc2c91c9903e6da6e9a693c92b65e4/pkg/controller/tls.go#L108) to `generateTLSCertificateForService` for better understanding.
* Remove duplicated constants for 'public.crt', 'tls.crt', and 'ca.crt' in the `github.com/minio/operator/pkg/common` namespace.
* Replace hardcoded strings 'public.crt', 'tls.crt', and 'ca.crt' with constants in the `github.com/minio/operator/pkg/certs` namespace.

Signed-off-by: pjuarezd <pjuarezd@users.noreply.github.com>