### PR TITLE
Fix Tenant PodInformer for Tenant Status and remove recurrent job

### DIFF
--- a/api/pod-handlers.go
+++ b/api/pod-handlers.go
@@ -169,7 +169,7 @@ func getDeletePodResponse(session *models.Principal, params operator_api.DeleteP
 		return ErrorWithContext(ctx, err)
 	}
 	listOpts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("v1.min.io/tenant=%s", params.Tenant),
+		LabelSelector: fmt.Sprintf("%s=%s", miniov2.TenantLabel, params.Tenant),
 		FieldSelector: fmt.Sprintf("metadata.name=%s%s", params.Tenant, params.PodName[len(params.Tenant):]),
 	}
 	if err = clientset.CoreV1().Pods(params.Namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, listOpts); err != nil {
@@ -531,7 +531,7 @@ func generateTenantLogReport(ctx context.Context, coreInterface v1.CoreV1Interfa
 		return []byte{}, ErrorWithContext(ctx, errors.New("Namespace and Tenant name cannot be empty"))
 	}
 	podListOpts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("v1.min.io/tenant=%s", tenantName),
+		LabelSelector: fmt.Sprintf("%s=%s", miniov2.TenantLabel, tenantName),
 	}
 	pods, err := coreInterface.Pods(namespace).List(ctx, podListOpts)
 	if err != nil {

--- a/api/volumes.go
+++ b/api/volumes.go
@@ -120,7 +120,7 @@ func getPVCsResponse(session *models.Principal, params operator_api.ListPVCsPara
 			Status:       status,
 			StorageClass: *pvc.Spec.StorageClassName,
 			Volume:       pvc.Spec.VolumeName,
-			Tenant:       pvc.Labels["v1.min.io/tenant"],
+			Tenant:       pvc.Labels[miniov2.TenantLabel],
 		}
 		ListPVCs = append(ListPVCs, &pvcResponse)
 	}
@@ -142,7 +142,7 @@ func getPVCsForTenantResponse(session *models.Principal, params operator_api.Lis
 
 	// Filter Tenant PVCs. They keep their v1 tenant annotation
 	listOpts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("v1.min.io/tenant=%s", params.Tenant),
+		LabelSelector: fmt.Sprintf("%s=%s", miniov2.TenantLabel, params.Tenant),
 	}
 
 	// List all PVCs
@@ -167,7 +167,7 @@ func getPVCsForTenantResponse(session *models.Principal, params operator_api.Lis
 			Status:       status,
 			StorageClass: *pvc.Spec.StorageClassName,
 			Volume:       pvc.Spec.VolumeName,
-			Tenant:       pvc.Labels["v1.min.io/tenant"],
+			Tenant:       pvc.Labels[miniov2.TenantLabel],
 		}
 		ListPVCs = append(ListPVCs, &pvcResponse)
 	}
@@ -188,7 +188,7 @@ func getDeletePVCResponse(session *models.Principal, params operator_api.DeleteP
 		return ErrorWithContext(ctx, err)
 	}
 	listOpts := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("v1.min.io/tenant=%s", params.Tenant),
+		LabelSelector: fmt.Sprintf("%s=%s", miniov2.TenantLabel, params.Tenant),
 		FieldSelector: fmt.Sprintf("metadata.name=%s", params.PVCName),
 	}
 	if err = clientset.CoreV1().PersistentVolumeClaims(params.Namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, listOpts); err != nil {
@@ -237,7 +237,7 @@ func getTenantCSResponse(session *models.Principal, params operator_api.ListTena
 	}
 
 	// Get CSRs by Label "v1.min.io/tenant=" + params.Tenant
-	listByTenantLabel := metav1.ListOptions{LabelSelector: "v1.min.io/tenant=" + params.Tenant}
+	listByTenantLabel := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", miniov2.TenantLabel, params.Tenant)}
 	listResult, listError := clientset.CertificatesV1().CertificateSigningRequests().List(ctx, listByTenantLabel)
 	if listError != nil {
 		return nil, ErrorWithContext(ctx, listError)

--- a/operator-integration/tenant_test.go
+++ b/operator-integration/tenant_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/minio/operator/api/operations"
 	"github.com/minio/operator/models"
+	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -350,7 +351,7 @@ func TestCreateTenant(t *testing.T) {
 	pools := make([]map[string]interface{}, 1)
 	matchExpressions := make([]map[string]interface{}, 2)
 	matchExpressions[0] = map[string]interface{}{
-		"key":      "v1.min.io/tenant",
+		"key":      miniov2.TenantLabel,
 		"operator": "In",
 		"values":   values,
 	}
@@ -489,7 +490,7 @@ func TestDeleteTenant(t *testing.T) {
 	pools := make([]map[string]interface{}, 1)
 	matchExpressions := make([]map[string]interface{}, 2)
 	matchExpressions[0] = map[string]interface{}{
-		"key":      "v1.min.io/tenant",
+		"key":      miniov2.TenantLabel,
 		"operator": "In",
 		"values":   values,
 	}

--- a/pkg/controller/monitoring.go
+++ b/pkg/controller/monitoring.go
@@ -205,6 +205,11 @@ func (c *Controller) updateHealthStatusForTenant(tenant *miniov2.Tenant) error {
 			klog.Infof("'%s/%s' Can't update tenant status with tiers: %v", tenant.Namespace, tenant.Name, err)
 		}
 	}
+	// Add tenant to the health check queue again until is green again
+	if tenant.Status.HealthStatus != miniov2.HealthStatusGreen {
+		key := fmt.Sprintf("%s/%s", tenant.GetNamespace(), tenant.Name)
+		c.healthCheckQueue.Add(key)
+	}
 
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,13 +17,24 @@
 package utils
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/minio/operator/pkg/common"
 
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 // NewUUID - get a random UUID.
@@ -70,4 +81,61 @@ func GetOperatorRuntime() common.Runtime {
 		}
 	}
 	return runtimeReturn
+}
+
+// NewPodInformer creates a Shared Index Pod Informer matching the labelSelector string
+func NewPodInformer(kubeClientSet kubernetes.Interface, labelSelectorString string) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return kubeClientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+					LabelSelector: labelSelectorString,
+				})
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return kubeClientSet.CoreV1().Pods("").Watch(context.Background(), metav1.ListOptions{
+					LabelSelector: labelSelectorString,
+				})
+			},
+		},
+		&corev1.Pod{},  // Resource type
+		time.Second*30, // Resync period
+		cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc, // Index by namespace
+		},
+	)
+}
+
+// LabelSelectorToString gets a string from a labelSelector
+func LabelSelectorToString(labelSelector metav1.LabelSelector) (string, error) {
+	var matchExpressions []string
+	for _, expr := range labelSelector.MatchExpressions {
+		// Handle only Exists expressions
+		matchExpressions = append(matchExpressions, expr.Key)
+	}
+	// Join match labels and match expressions into a single string with a comma separator.
+	labelSelectorString := strings.Join(matchExpressions, ",")
+	// Validate labelSelectorString
+	if _, err := labels.Parse(labelSelectorString); err != nil {
+		return "", err
+	}
+	return labelSelectorString, nil
+}
+
+// CastObjectToMetaV1 gets a metav1.Object from an interface
+func CastObjectToMetaV1(obj interface{}) (metav1.Object, error) {
+	var object metav1.Object
+	var ok bool
+	if object, ok = obj.(metav1.Object); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil, fmt.Errorf("error decoding object, invalid type")
+		}
+		object, ok = tombstone.Obj.(metav1.Object)
+		if !ok {
+			return nil, fmt.Errorf("error decoding object tombstone, invalid type")
+		}
+		klog.V(4).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+	}
+	return object, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -104,22 +103,6 @@ func NewPodInformer(kubeClientSet kubernetes.Interface, labelSelectorString stri
 			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc, // Index by namespace
 		},
 	)
-}
-
-// LabelSelectorToString gets a string from a labelSelector
-func LabelSelectorToString(labelSelector metav1.LabelSelector) (string, error) {
-	var matchExpressions []string
-	for _, expr := range labelSelector.MatchExpressions {
-		// Handle only Exists expressions
-		matchExpressions = append(matchExpressions, expr.Key)
-	}
-	// Join match labels and match expressions into a single string with a comma separator.
-	labelSelectorString := strings.Join(matchExpressions, ",")
-	// Validate labelSelectorString
-	if _, err := labels.Parse(labelSelectorString); err != nil {
-		return "", err
-	}
-	return labelSelectorString, nil
 }
 
 // CastObjectToMetaV1 gets a metav1.Object from an interface


### PR DESCRIPTION
Use PodInformer to Update Tenant status. 
Previous code had both an informer and a recurrent job (every 3 min) but it wasn't working great so this changes so that it updates the tenant status every time there's a change on the pods.
Before informer was reacting on all pods and then filtering them when handling the event, now it only reacts on pods that match the label selector.


### Changes:
 - Use custom informer so that it can react only on pods that contain the Tenant labels
 - Requeues event if tenant is not in green status
 -  Remove recurrent health job 
 - Updates al the places where we had `v1.min.io/tenant` with `miniov2.TenantLabel`

### Test Steps
- Add a Tenant
- Do some changes to the Pod
- Delete the pod
- Tenant Status should be updated on both changes (use node cordon if needed)