### PR TITLE
feat: support command for minioJob

### DIFF
--- a/helm/operator/templates/job.min.io_jobs.yaml
+++ b/helm/operator/templates/job.min.io_jobs.yaml
@@ -43,6 +43,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    command:
+                      items:
+                        type: string
+                      type: array
                     dependsOn:
                       items:
                         type: string

--- a/pkg/apis/job.min.io/v1alpha1/types.go
+++ b/pkg/apis/job.min.io/v1alpha1/types.go
@@ -142,7 +142,7 @@ type CommandSpec struct {
 	// +optional
 	Args map[string]string `json:"args,omitempty"`
 
-	// Command custom command to run
+	// Command Execute All User-Defined Commands
 	// +optional
 	Command []string `json:"command,omitempty"`
 

--- a/pkg/apis/job.min.io/v1alpha1/types.go
+++ b/pkg/apis/job.min.io/v1alpha1/types.go
@@ -142,6 +142,10 @@ type CommandSpec struct {
 	// +optional
 	Args map[string]string `json:"args,omitempty"`
 
+	// Command custom command to run
+	// +optional
+	Command []string `json:"command,omitempty"`
+
 	// DependsOn List of named `command` in this MinioJob that have to be scheduled and executed before this command runs
 	// +optional
 	DependsOn []string `json:"dependsOn,omitempty"`

--- a/pkg/controller/job-controller.go
+++ b/pkg/controller/job-controller.go
@@ -120,6 +120,7 @@ func NewJobController(
 			}
 			controller.enqueueJob(new)
 		},
+		DeleteFunc: controller.enqueueJob,
 	})
 
 	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/utils/miniojob/types.go
+++ b/pkg/utils/miniojob/types.go
@@ -136,9 +136,9 @@ func (jobCommand *MinIOIntervalJobCommand) createJob(ctx context.Context, k8sCli
 		commands = append(commands, strings.SplitN(jobCommand.MCOperation, "/", -1)...)
 		commands = append(commands, strings.SplitN(jobCommand.Command, " ", -1)...)
 		for _, command := range commands {
-			trimCommand := strings.TrimSpace(command)
-			if trimCommand != "" {
-				jobCommands = append(jobCommands, trimCommand)
+			trimmedCommand := strings.TrimSpace(command)
+			if trimmedCommand != "" {
+				jobCommands = append(jobCommands, trimmedCommand)
 			}
 		}
 		jobCommands = append(jobCommands, "--insecure")

--- a/pkg/utils/miniojob/types.go
+++ b/pkg/utils/miniojob/types.go
@@ -131,16 +131,20 @@ func (jobCommand *MinIOIntervalJobCommand) createJob(ctx context.Context, k8sCli
 	}
 	jobCommand.mutex.RUnlock()
 	jobCommands := []string{}
-	commands := []string{"mc"}
-	commands = append(commands, strings.SplitN(jobCommand.MCOperation, "/", -1)...)
-	commands = append(commands, strings.SplitN(jobCommand.Command, " ", -1)...)
-	for _, command := range commands {
-		trimCommand := strings.TrimSpace(command)
-		if trimCommand != "" {
-			jobCommands = append(jobCommands, trimCommand)
+	if len(jobCommand.CommandSpec.Command) == 0 {
+		commands := []string{"mc"}
+		commands = append(commands, strings.SplitN(jobCommand.MCOperation, "/", -1)...)
+		commands = append(commands, strings.SplitN(jobCommand.Command, " ", -1)...)
+		for _, command := range commands {
+			trimCommand := strings.TrimSpace(command)
+			if trimCommand != "" {
+				jobCommands = append(jobCommands, trimCommand)
+			}
 		}
+		jobCommands = append(jobCommands, "--insecure")
+	} else {
+		jobCommands = append(jobCommands, jobCommand.CommandSpec.Command...)
 	}
-	jobCommands = append(jobCommands, "--insecure")
 	mcImage := jobCR.Spec.MCImage
 	if mcImage == "" {
 		mcImage = DefaultMCImage
@@ -340,30 +344,32 @@ func (intervalJob *MinIOIntervalJob) CreateCommandJob(ctx context.Context, k8sCl
 
 // GenerateMinIOIntervalJobCommand - generate command
 func GenerateMinIOIntervalJobCommand(commandSpec v1alpha1.CommandSpec, commandIndex int) (*MinIOIntervalJobCommand, error) {
-	mcCommand, found := OperationAliasToMC(commandSpec.Operation)
-	if !found {
-		return nil, fmt.Errorf("operation %s is not supported", commandSpec.Operation)
-	}
-	argsFuncs, found := JobOperation[mcCommand]
-	if !found {
-		return nil, fmt.Errorf("operation %s is not supported", mcCommand)
-	}
-	commands := []string{}
-	for _, argsFunc := range argsFuncs {
-		jobArg, err := argsFunc(commandSpec.Args)
-		if err != nil {
-			return nil, err
-		}
-		if jobArg.Command != "" {
-			commands = append(commands, jobArg.Command)
-		}
-
-	}
 	jobCommand := &MinIOIntervalJobCommand{
 		JobName:     commandSpec.Name,
-		MCOperation: mcCommand,
-		Command:     strings.Join(commands, " "),
 		CommandSpec: commandSpec,
+	}
+	if len(commandSpec.Command) == 0 {
+		mcCommand, found := OperationAliasToMC(commandSpec.Operation)
+		if !found {
+			return nil, fmt.Errorf("operation %s is not supported", commandSpec.Operation)
+		}
+		argsFuncs, found := JobOperation[mcCommand]
+		if !found {
+			return nil, fmt.Errorf("operation %s is not supported", mcCommand)
+		}
+		commands := []string{}
+		for _, argsFunc := range argsFuncs {
+			jobArg, err := argsFunc(commandSpec.Args)
+			if err != nil {
+				return nil, err
+			}
+			if jobArg.Command != "" {
+				commands = append(commands, jobArg.Command)
+			}
+
+		}
+		jobCommand.MCOperation = mcCommand
+		jobCommand.Command = strings.Join(commands, " ")
 	}
 	// some commands need to have a empty name
 	if jobCommand.JobName == "" {

--- a/resources/base/crds/job.min.io_miniojobs.yaml
+++ b/resources/base/crds/job.min.io_miniojobs.yaml
@@ -43,6 +43,10 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    command:
+                      items:
+                        type: string
+                      type: array
                     dependsOn:
                       items:
                         type: string


### PR DESCRIPTION
feat: support command for minioJob
how to test:
```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: mc-job-sa
  namespace: minio-operator
---
apiVersion: sts.min.io/v1alpha1
kind: PolicyBinding
metadata:
  name: mc-job-bingding
  namespace: minio-operator
spec:
  application:
    serviceaccount: mc-job-sa
    namespace: minio-operator
  policies:
    - consoleAdmin
---
apiVersion: job.min.io/v1alpha1
kind: MinIOJob
metadata:
  name: minio-test-job
  namespace: minio-operator
spec:
  serviceAccountName: mc-job-sa
  tenant:
    name: myminio
    namespace: minio-operator
  commands:
    - op: make-bucket
      args:
        name: memes
    - op: stat
      command:
        - "mc"
        - "stat"
        - "myminio/memes"
        - "--insecure"
```