### PR TITLE
Bring back recurrent Tenant health check job

### DIFF
--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -201,7 +201,7 @@ const tenantKesImageEnv = "TENANT_KES_IMAGE"
 const monitoringIntervalEnv = "MONITORING_INTERVAL"
 
 // DefaultMonitoringInterval is how often we run monitoring on tenants
-const DefaultMonitoringInterval = 3
+const DefaultMonitoringInterval = 5
 
 // PrometheusNamespace is the namespace of the prometheus
 const PrometheusNamespace = "PROMETHEUS_NAMESPACE"

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -470,6 +470,8 @@ func leaderRun(ctx context.Context, c *Controller, threadiness int, stopCh <-cha
 	// Launch a single worker for Health Check reacting to Pod Changes
 	go wait.Until(c.runHealthCheckWorker, time.Second, stopCh)
 
+	// Launch a goroutine to monitor all Tenants
+	go c.recurrentTenantStatusMonitor(stopCh)
 	go c.StartPodInformer(stopCh)
 
 	// 1) we need to make sure we have console TLS certificates (if enabled)


### PR DESCRIPTION
There might be other reasons that make the service stop working,  which not necessarily will make a Pod update/delete. 
Having a recurrent job will address this.

Just bringing it back from https://github.com/minio/operator/pull/2150

- Updated the time interval from 3 min to 5 min
- Removed first check
