### PR TITLE
Bugfix: Pool name should not be empty

### DIFF
--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3069,6 +3069,7 @@ spec:
                         type: string
                       type: object
                     name:
+                      minLength: 1
                       type: string
                     nodeSelector:
                       additionalProperties:

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -617,7 +617,8 @@ type CustomCertificateConfig struct {
 // See the https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant.html#procedure-command-line[MinIO Operator CRD] reference for the `pools` object for examples and more complete documentation. +
 type Pool struct {
 	// *Required*
-	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Specify the name of the pool. The Operator automatically generates the pool name if this field is omitted.
 	Name string `json:"name"`
 	// *Required*

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3069,6 +3069,7 @@ spec:
                         type: string
                       type: object
                     name:
+                      minLength: 1
                       type: string
                     nodeSelector:
                       additionalProperties:


### PR DESCRIPTION
Starting v5.0.15 Pool Name is required, but the CRD used to allow empty `spec.pools.*.name` field