### PR TITLE
Correcting the name of the variable

### DIFF
--- a/examples/kustomization/operator-external-idp-oid/README.md
+++ b/examples/kustomization/operator-external-idp-oid/README.md
@@ -77,7 +77,7 @@ In OAuth2, scopes defines the specific actions that an application (client) is a
 ### Callback URL
 OpenID uses a "call back" URL to redirect back to the application once the authentication succeeds. This callback URL is set in Operator Console with the `CONSOLE_IDP_CALLBACK` environment variable.
 
-A Callback URL can also be constructed dynamically. To do this, set `CONSOLE_IDP_CALLBACK_DYNAMIC` environment variable to `on` instead of setting a `CONSOLE_IDP_CALBACK`.
+A Callback URL can also be constructed dynamically. To do this, set `CONSOLE_IDP_CALLBACK_DYNAMIC` environment variable to `on` instead of setting a `CONSOLE_IDP_CALLBACK`.
 
 The constructed URL resembles following: `$protocol://$host/oauth_callback`
 


### PR DESCRIPTION
### Objective:

* First of all, thank you @pjuarezd for this documentation, it worked!
* Minor correction: the variable `CONSOLE_IDP_CALBACK` is missing an `L` and should be `CONSOLE_IDP_CALLBACK`.

### User Story:

When I copied the variable name from the documentation, I got stuck for hours with this error:

```
Unable to issue redirect for OAuth 2.0 transaction
```

I even created a Stack Overflow question before I figured it out:

https://stackoverflow.com/questions/78614194/unable-to-issue-redirect-for-oauth-2-0-transaction-when-using-go-project

That said, the correction is very simple and can help other users avoid the problem I had today. 👍