### PR TITLE
Adding 1 second delay between pod health checks requeue

### DIFF
--- a/pkg/controller/monitoring.go
+++ b/pkg/controller/monitoring.go
@@ -289,7 +289,7 @@ func (c *Controller) syncHealthCheckHandler(key string) (Result, error) {
 
 	// Add tenant to the health check queue again until is green again
 	if tenant != nil && tenant.Status.HealthStatus != miniov2.HealthStatusGreen {
-		c.healthCheckQueue.Add(key)
+		c.healthCheckQueue.AddAfter(key, 1*time.Second)
 	}
 
 	return WrapResult(Result{}, nil)

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"time"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
 	"github.com/minio/operator/pkg/utils"
@@ -40,5 +41,5 @@ func (c *Controller) handlePodChange(obj interface{}) {
 	}
 
 	key := fmt.Sprintf("%s/%s", object.GetNamespace(), instanceName)
-	c.healthCheckQueue.Add(key)
+	c.healthCheckQueue.AddAfter(key, 1*time.Second)
 }


### PR DESCRIPTION
Right now is running too often causing a lot of logs in Operator too quick, usually MinIO will take some seconds to restart.

Operator showing the following error tens of time per second
```
I0613 16:45:56.643423       1 monitoring.go:123] 'tenant-1/myminio' Failed to get cluster health: Get "https://minio.tenant-1.svc.cluster.local/minio/health/cluster": dial tcp 10.96.194.110:443: i/o timeout
```