### PR TITLE
Remove index-based pool name verification

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -413,13 +413,8 @@ func (t *Tenant) GenBearerToken(accessKey, secretKey string) string {
 // MinIOHosts returns the domain names in ellipses format created for current Tenant
 func (t *Tenant) MinIOHosts() (hosts []string) {
 	// Create the ellipses style URL
-	for pi, pool := range t.Spec.Pools {
-		// determine the proper statefulset name
+	for _, pool := range t.Spec.Pools {
 		ssName := t.PoolStatefulsetName(&pool)
-		if len(t.Status.Pools) > pi {
-			ssName = t.Status.Pools[pi].SSName
-		}
-
 		if pool.Servers == 1 {
 			hosts = append(hosts, fmt.Sprintf("%s-%s.%s.%s.svc.%s", ssName, "0", t.MinIOHLServiceName(), t.Namespace, GetClusterDomain()))
 		} else {


### PR DESCRIPTION
This PR Is the continuation of [bugfix: set pool status based on name rather than index based #2161
](https://github.com/minio/operator/pull/2161:) fixes bug:

## Pools names duplicated and miscreated MINIO_ARGS
Generate Minio Host names based in the `spec.status` leads to duplicated pool names when a pools are decomissioned

Steps to reproduce:

1) Clone from master and build operator container and sidecar
2) Create a Tenant, wait for it to initialize
3) Add a second pool, name it `pool-1`, make sure the pool is the second in the `spec.pools` list
3) Add a third pool, make sure the new pool has the name `pool-2`.

Notice:
* There is 3 Pools, added in the following order:
pool-0
pool-1
pool-2

<details>
  <summary> This is an example tenant pools (click to expand) </summary>

```yaml
pools:
  - containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
      seccompProfile:
        type: RuntimeDefault
    name: "pool-0"
    resources:
      requests:
        cpu: "1"
        memory: 2Gi
    runtimeClassName: ""
    securityContext:
      fsGroup: 1000
      fsGroupChangePolicy: OnRootMismatch
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
    servers: 4
    volumeClaimTemplate:
      metadata:
        creationTimestamp: null
        name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: "6710886400"
        storageClassName: standard
      status: {}
    volumesPerServer: 4
  - containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
      seccompProfile:
        type: RuntimeDefault
    name: "pool-1"
    resources:
      requests:
        cpu: "1"
        memory: 2Gi
    runtimeClassName: ""
    securityContext:
      fsGroup: 1000
      fsGroupChangePolicy: OnRootMismatch
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
    servers: 4
    volumeClaimTemplate:
      metadata:
        creationTimestamp: null
        name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: "6710886400"
        storageClassName: standard
      status: {}
    volumesPerServer: 4
  - containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
      seccompProfile:
        type: RuntimeDefault
    name: "pool-2"
    resources:
      requests:
        cpu: "1"
        memory: 2Gi
    runtimeClassName: ""
    securityContext:
      fsGroup: 1000
      fsGroupChangePolicy: OnRootMismatch
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
    servers: 4
    volumeClaimTemplate:
      metadata:
        creationTimestamp: null
        name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: "6710886400"
        storageClassName: standard
      status: {}
    volumesPerServer: 4
```
</details>

* Notice the `MINIO_ARGS` env variable value is as follows (get a shell in a minio container and cat `/tmp/minio/config.env`):

```
export MINIO_ARGS="https://myminio-pool-0-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} https://myminio-pool-1-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} https://myminio-pool-2-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1}"
```

4) Decomission pool `pool-1`

```
mc admin decommission start ALIAS https://myminio-pool-1-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} --insecure
```
Wait for decomission to finish

```
 mc admin decommission status ALIAS --insecure                                                                                     
┌─────┬───────────────────────────────────────────────────────────────────────────────────────┬────────────────────────┬──────────┐
│ ID  │ Pools                                                                                 │ Raw Drives Usage       │ Status   │
│ 1st │ https://myminio-pool-0-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} │ 43.5% (total: 333 GiB) │ Active   │
│ 2nd │ https://myminio-pool-1-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} │ 43.5% (total: 333 GiB) │ Complete │
│ 3rd │ https://myminio-pool-2-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} │ 43.5% (total: 333 GiB) │ Active   │
└─────┴───────────────────────────────────────────────────────────────────────────────────────┴────────────────────────┴──────────┘
```

5) Remove `pool-1` from the tenant yaml

<details>
  <summary> example Tenant (click to expand) </summary>

```yaml
apiVersion: minio.min.io/v2
kind: Tenant
metadata:
  annotations:
    prometheus.io/path: /minio/v2/metrics/cluster
    prometheus.io/port: "9000"
    prometheus.io/scrape: "true"
  labels:
    app: minio
  name: myminio
  namespace: tenant-lite
spec:
  configuration:
    name: storage-configuration
  features:
    bucketDNS: false
  image: quay.io/minio/minio:RELEASE.2024-07-16T23-46-41Z
  imagePullSecret:
    name: ""
  mountPath: /export
  podManagementPolicy: Parallel
  pools:
  - containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
      seccompProfile:
        type: RuntimeDefault
    name: pool-0
    servers: 4
    volumeClaimTemplate:
      metadata:
        name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 2Gi
    volumesPerServer: 2
  - containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - ALL
      runAsGroup: 1000
      runAsNonRoot: true
      runAsUser: 1000
      seccompProfile:
        type: RuntimeDefault
    name: pool-2
    servers: 4
    volumeClaimTemplate:
      metadata:
        name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 2Gi
    volumesPerServer: 2
  priorityClassName: ""
  requestAutoCert: true
  serviceAccountName: ""
  subPath: ""
  users:
  - name: storage-user
```
</details>

6) **Here is the Bug:** Because the list of `MINIO_ARGS` is built from the `.spec.status`, the pool `pool-1` should not appear, but instead Operator names `pool-2` as `pool-1` when forming the `MINIO_ARGS`. 

```
export MINIO_ARGS="https://myminio-pool-0-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} https://myminio-pool-1-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1}"
```


With this fix the Pool names are propery labeled as `pool-0` and `pool-2`

```
"https://myminio-pool-0-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1} https://myminio-pool-2-{0...3}.myminio-hl.tenant-lite.svc.cluster.local/export{0...1}",
```

