### PR TITLE
security: Using k8s idp instead of providing console-sa

### DIFF
--- a/api/config_test.go
+++ b/api/config_test.go
@@ -19,6 +19,8 @@ package api
 import (
 	"os"
 	"testing"
+
+	xoauth2 "golang.org/x/oauth2"
 )
 
 func Test_getK8sSAToken(t *testing.T) {
@@ -47,7 +49,8 @@ func Test_getK8sSAToken(t *testing.T) {
 					os.Setenv(k, v)
 				}
 			}
-			if got := getK8sSAToken(); got != tt.want {
+			var oauth2Token *xoauth2.Token
+			if got := getK8sSAToken(oauth2Token); got != tt.want {
 				t.Errorf("getK8sSAToken() = %v, want %v", got, tt.want)
 			}
 			if tt.envs != nil {

--- a/api/login.go
+++ b/api/login.go
@@ -184,14 +184,19 @@ func getLoginOauth2AuthResponse(params authApi.LoginOauth2AuthParams) (*models.L
 			KeyFunc: oauth2.DefaultDerivedKey,
 			Client:  oauth2Client,
 		}
+
+		// Pointer to extract the whole token from IdP
+		var oauth2Token *xoauth2.Token
+
 		// Validate user against IDP
-		_, err = verifyUserAgainstIDP(ctx, identityProvider, *lr.Code, requestItems.State)
+		oauth2Token, err = verifyUserAgainstIDP(ctx, identityProvider, *lr.Code, requestItems.State)
 		if err != nil {
 			return nil, ErrorWithContext(ctx, err)
 		}
+
 		// If we pass here that means the IDP correctly authenticate the user with the operator resource
 		// we proceed to use the service account token configured in the operator-console pod
-		creds, err := newConsoleCredentials(getK8sSAToken())
+		creds, err := newConsoleCredentials(getK8sSAToken(oauth2Token))
 		if err != nil {
 			return nil, ErrorWithContext(ctx, err)
 		}


### PR DESCRIPTION
### Objective:

To let Kubernetes and the IdP decide whether access is valid or not, and to remove MinIO from the equation, as shown in the documentation:

https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens

### Advantage:

We no longer use the console-sa token. Instead, we validate the token directly via Kubernetes, which is more secure.

### Examples on how to configure k8s idp:

* https://developer.okta.com/blog/2021/11/08/k8s-api-server-oidc

### Other related docs for testing and development:

* https://github.com/cniackz/public/wiki/How-to-test-IdP-on-k8s-for-code-change
* https://github.com/cniackz/public/wiki/How-to-configure-SSO-in-Operator
* https://github.com/cniackz/public/wiki/IdP-on-k8s

### Note:

This change wasn't easy for me, as I had to fully understand how the IdP works with Kubernetes and our Operator. However, once I grasped it, the change became straightforward to review and test with proper understanding. I hope you find it satisfactory, and I am open to feedback!

### How to test:

https://github.com/cniackz/public/wiki/How-to-test-2166-from-scratch