### PR TITLE
Allow Tolerations to have Seconds undefined

### DIFF
--- a/web-app/src/screens/Console/Common/TolerationSelector/TolerationSelector.tsx
+++ b/web-app/src/screens/Console/Common/TolerationSelector/TolerationSelector.tsx
@@ -181,16 +181,20 @@ const TolerationSelector = ({
               <Grid item xs className={"fieldContainer"}>
                 <InputBox
                   id={`seconds-${index}`}
-                  label={""}
                   name={`seconds-${index}`}
-                  value={tolerationSeconds?.toString() || "0"}
+                  value={
+                    // treat the NaN cases
+                    !isNaN(parseFloat(tolerationSeconds?.toString() || ""))
+                      ? tolerationSeconds?.toString()
+                      : undefined
+                  }
                   onChange={(e) => {
                     if (e.target.validity.valid) {
                       onSecondsChange(parseInt(e.target.value));
                     }
                   }}
                   index={index}
-                  pattern={"[0-9]*"}
+                  pattern={"[0-9]+"}
                   overlayObject={
                     <InputUnitMenu
                       id={`seconds-${index}`}

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/Affinity.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/Affinity.tsx
@@ -451,11 +451,15 @@ const Affinity = () => {
                         onValueChange={(value) => {
                           updateToleration(i, "value", value);
                         }}
-                        tolerationSeconds={tol.tolerationSeconds?.seconds || 0}
+                        tolerationSeconds={tol.tolerationSeconds?.seconds}
                         onSecondsChange={(value) => {
-                          updateToleration(i, "tolerationSeconds", {
-                            seconds: value,
-                          });
+                          if (isNaN(value)) {
+                            updateToleration(i, "tolerationSeconds", undefined);
+                          } else {
+                            updateToleration(i, "tolerationSeconds", {
+                              seconds: value,
+                            });
+                          }
                         }}
                         index={i}
                       />

--- a/web-app/src/screens/Console/Tenants/AddTenant/createTenantSlice.ts
+++ b/web-app/src/screens/Console/Tenants/AddTenant/createTenantSlice.ts
@@ -324,7 +324,6 @@ const initialState: ICreateTenant = {
   tolerations: [
     {
       key: "",
-      tolerationSeconds: { seconds: 0 },
       value: "",
       effect: ITolerationEffect.NoSchedule,
       operator: ITolerationOperator.Equal,
@@ -658,7 +657,6 @@ export const createTenantSlice = createSlice({
         ...state.tolerations,
         {
           key: "",
-          tolerationSeconds: { seconds: 0 },
           value: "",
           effect: ITolerationEffect.NoSchedule,
           operator: ITolerationOperator.Equal,

--- a/web-app/src/screens/Console/Tenants/TenantDetails/Pools/AddPool/PoolPodPlacement.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/Pools/AddPool/PoolPodPlacement.tsx
@@ -463,11 +463,15 @@ const Affinity = () => {
                         onValueChange={(value) => {
                           updateToleration(i, "value", value);
                         }}
-                        tolerationSeconds={tol.tolerationSeconds?.seconds || 0}
+                        tolerationSeconds={tol.tolerationSeconds?.seconds}
                         onSecondsChange={(value) => {
-                          updateToleration(i, "tolerationSeconds", {
-                            seconds: value,
-                          });
+                          if (isNaN(value)) {
+                            updateToleration(i, "tolerationSeconds", undefined);
+                          } else {
+                            updateToleration(i, "tolerationSeconds", {
+                              seconds: value,
+                            });
+                          }
                         }}
                         index={i}
                       />

--- a/web-app/src/screens/Console/Tenants/TenantDetails/Pools/AddPool/addPoolSlice.ts
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/Pools/AddPool/addPoolSlice.ts
@@ -78,7 +78,6 @@ const initialState: IAddPool = {
   tolerations: [
     {
       key: "",
-      tolerationSeconds: { seconds: 0 },
       value: "",
       effect: ITolerationEffect.NoSchedule,
       operator: ITolerationOperator.Equal,
@@ -150,7 +149,6 @@ export const addPoolSlice = createSlice({
     addNewPoolToleration: (state) => {
       state.tolerations.push({
         key: "",
-        tolerationSeconds: { seconds: 0 },
         value: "",
         effect: ITolerationEffect.NoSchedule,
         operator: ITolerationOperator.Equal,

--- a/web-app/src/screens/Console/Tenants/TenantDetails/Pools/Details/PoolDetails.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/Pools/Details/PoolDetails.tsx
@@ -249,7 +249,7 @@ const PoolDetails = () => {
                             <strong>{tolItem.value}</strong> then{" "}
                             <strong>{tolItem.effect}</strong> after{" "}
                             <strong>
-                              {tolItem.tolerationSeconds?.seconds || 0}
+                              {tolItem.tolerationSeconds?.seconds}
                             </strong>{" "}
                             seconds
                           </Fragment>
@@ -258,7 +258,7 @@ const PoolDetails = () => {
                             If <strong>{tolItem.key}</strong> exists then{" "}
                             <strong>{tolItem.effect}</strong> after{" "}
                             <strong>
-                              {tolItem.tolerationSeconds?.seconds || 0}
+                              {tolItem.tolerationSeconds?.seconds}
                             </strong>{" "}
                             seconds
                           </Fragment>

--- a/web-app/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/EditPoolPlacement.tsx
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/EditPoolPlacement.tsx
@@ -460,11 +460,15 @@ const Affinity = () => {
                         onValueChange={(value) => {
                           updateToleration(i, "value", value);
                         }}
-                        tolerationSeconds={tol.tolerationSeconds?.seconds || 0}
+                        tolerationSeconds={tol.tolerationSeconds?.seconds}
                         onSecondsChange={(value) => {
-                          updateToleration(i, "tolerationSeconds", {
-                            seconds: value,
-                          });
+                          if (isNaN(value)) {
+                            updateToleration(i, "tolerationSeconds", undefined);
+                          } else {
+                            updateToleration(i, "tolerationSeconds", {
+                              seconds: value,
+                            });
+                          }
                         }}
                         index={i}
                       />

--- a/web-app/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/editPoolSlice.ts
+++ b/web-app/src/screens/Console/Tenants/TenantDetails/Pools/EditPool/editPoolSlice.ts
@@ -60,7 +60,6 @@ const initialState: IEditPool = {
     tolerations: [
       {
         key: "",
-        tolerationSeconds: { seconds: 0 },
         value: "",
         effect: ITolerationEffect.NoSchedule,
         operator: ITolerationOperator.Equal,
@@ -82,7 +81,6 @@ export const editPoolSlice = createSlice({
       let tolerations: ITolerationModel[] = [
         {
           key: "",
-          tolerationSeconds: { seconds: 0 },
           value: "",
           effect: ITolerationEffect.NoSchedule,
           operator: ITolerationOperator.Equal,
@@ -232,12 +230,12 @@ export const editPoolSlice = createSlice({
 
       editPoolTolerationValue[action.payload.index] =
         action.payload.tolerationValue;
+
       state.fields.tolerations = editPoolTolerationValue;
     },
     addNewEditPoolToleration: (state) => {
       state.fields.tolerations.push({
         key: "",
-        tolerationSeconds: { seconds: 0 },
         value: "",
         effect: ITolerationEffect.NoSchedule,
         operator: ITolerationOperator.Equal,


### PR DESCRIPTION
fixes: https://github.com/minio/operator/issues/1595
fixes: https://github.com/minio/operator/issues/1298

Since Effect can't be other than NoExecute when Toleration Seconds are set, we need to allow Seconds to be undefined.
We address this by doing the validation in the BE and returning an error.


### Test steps
- Add a Tenant instance defining some Tolerations
- Set one toleration without seconds
- Set one with seconds set
- They should show up on the Settings
- Go to Settings and check you can also add and update tolerations with and without seconds and exposing the corresponding error.
