### PR TITLE
Fix TenantCapacity usage

### DIFF
--- a/web-app/src/screens/Console/Common/UsageBarWrapper/SummaryUsageBar.tsx
+++ b/web-app/src/screens/Console/Common/UsageBarWrapper/SummaryUsageBar.tsx
@@ -131,7 +131,10 @@ const SummaryUsageBar = ({
       ) : (
         <TenantCapacityMain>
           <TenantCapacity
-            totalCapacity={tenant.status?.usage?.raw || 0}
+            totalCapacity={
+              (tenant.status?.usage?.capacity || 0) +
+              (tenant.status?.usage?.capacity_usage || 0)
+            }
             usedSpaceVariants={spaceVariants}
             statusClass={""}
             render={"bar"}

--- a/web-app/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
+++ b/web-app/src/screens/Console/Tenants/ListTenants/TenantListItem.tsx
@@ -258,7 +258,9 @@ const TenantListItem = ({ tenant }: { tenant: TenantList }) => {
             <Grid container>
               <Grid item xs={2}>
                 <TenantCapacity
-                  totalCapacity={tenant.capacity || 0}
+                  totalCapacity={
+                    (tenant.capacity || 0) + (tenant.capacity_usage || 0)
+                  }
                   usedSpaceVariants={spaceVariants}
                   statusClass={healthStatusToClass(tenant.health_status!)}
                 />


### PR DESCRIPTION
#### Issue
The current usage of the `TenantCapacity` component works on the formula `capacity_usage/capacity_raw`. 
`capacity_usage` is the sum of all the used space on all disks as calculated by the `madmin.AdminClient.StorageInfo` function
`capacity_raw` is the sum of all the PVC capacities on each volume on each server.

Since `capacity_usage` can be greater that `capacity_raw`, the resulting TenantCapacity component will show 100% usage, visually showing the tenant as out of storage.

#### Fix
A better comparison would be `capacity_usage/(capacity+capacity_usage)` where `capacity` is the sum of all the available space on all disks as calculated by the `madmin.AdminClient.StorageInfo` function.

#### Test
Create a MinIO operator tenant.
Create and populate a bucket.
Observe the `TenantCapacity` component correctly indicate the proportion of usage of the available storage; and not exceed 100% while approaching it.