### PR TITLE
Document default MC image for MinIOJob CRD

### DIFF
--- a/docs/job_crd.adoc
+++ b/docs/job_crd.adoc
@@ -6,6 +6,7 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-05-01T01-11-10Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-04-12T13-50-00Z]
+:mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:latest]
 
 
 [id="{anchor_prefix}-job-min-io-v1alpha1"]
@@ -32,10 +33,7 @@ CommandSpec (`spec`) defines the configuration of a MinioClient Command.
 | Field | Description
 
 |*`op`* __string__ 
-|*Required* +
-
-
-Operation is the MinioClient Action
+|Operation is the MinioClient Action
 
 |*`name`* __string__ 
 |Name is the Command Name, optional, required if want to reference it with `DependsOn`
@@ -197,7 +195,7 @@ Either `stopOnFailure` or `continueOnFailure`, defaults to `continueOnFailure`.
 Commands List of MinioClient commands
 
 |*`mcImage`* __string__ 
-|mc job image
+|The Docker image to use when deploying `mc` pods. Defaults to {mc-image}. +
 
 |*`imagePullPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#pullpolicy-v1-core[$$PullPolicy$$]__ 
 |*Optional* +

--- a/docs/policybinding_crd.adoc
+++ b/docs/policybinding_crd.adoc
@@ -6,6 +6,7 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-05-01T01-11-10Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-04-12T13-50-00Z]
+:mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:latest]
 
 
 [id="{anchor_prefix}-sts-min-io-v1beta1"]

--- a/docs/templates/asciidoctor/gv_list.tpl
+++ b/docs/templates/asciidoctor/gv_list.tpl
@@ -9,6 +9,7 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-05-01T01-11-10Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-04-12T13-50-00Z]
+:mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:latest]
 
 {{ range $groupVersions }}
 {{ template "gvDetails" . }}

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -6,6 +6,7 @@
 
 :minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2024-05-01T01-11-10Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2024-04-12T13-50-00Z]
+:mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:latest]
 
 
 [id="{anchor_prefix}-minio-min-io-v2"]

--- a/pkg/apis/job.min.io/v1alpha1/types.go
+++ b/pkg/apis/job.min.io/v1alpha1/types.go
@@ -94,7 +94,7 @@ type MinIOJobSpec struct {
 	// Commands List of MinioClient commands
 	Commands []CommandSpec `json:"commands"`
 
-	// mc job image
+	// The Docker image to use when deploying `mc` pods. Defaults to {mc-image}. +
 	// +optional
 	// +kubebuilder:default="quay.io/minio/mc:latest"
 	MCImage string `json:"mcImage,omitempty"`

--- a/release.sh
+++ b/release.sh
@@ -10,14 +10,19 @@ get_latest_release() {
 
 MINIO_RELEASE=$(get_latest_release minio/minio)
 KES_RELEASE=$(get_latest_release minio/kes)
+MC_RELEASE=$(get_latest_release minio/mc)
 
 KES_CURRENT_RELEASE=$(sed -nr 's/.*(minio\/kes\:)([v]?.*)"/\2/p' pkg/apis/minio.min.io/v2/constants.go)
+
+MC_CURRENT_RELEASE=$(sed -nr 's/.*(minio\/mc\:)([v]?.*)"/\2/p' pkg/utils/miniojob/types.go)
 
 files=(
   "README.md"
   "api/consts.go"
+  "pkg/apis/job.min.io/v1alpha1/types.go"
   "docs/tenant_crd.adoc"
   "docs/policybinding_crd.adoc"
+  "docs/job_crd.adoc"
   "docs/templates/asciidoctor/gv_list.tpl"
   "examples/kustomization/base/tenant.yaml"
   "examples/kustomization/tenant-certmanager-kes/tenant.yaml"
@@ -50,6 +55,7 @@ for file in "${files[@]}"; do
   sed -i -e "s/${CURRENT_RELEASE}/${RELEASE}/g" "$file"
   sed -i -e "s/RELEASE\.[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]-[0-9][0-9]-[0-9][0-9]Z/${MINIO_RELEASE}/g" "$file"
   sed -i -e "s/${KES_CURRENT_RELEASE}/${KES_RELEASE}/g" "$file"
+  sed -i -e "s/${MC_CURRENT_RELEASE}/${MC_RELEASE}/g" "$file"
 done
 
 annotations_files=(


### PR DESCRIPTION
* Document default MC image in the adocs
* Add release script section to set a defined mc image instead of 'latest'

When we create the release PR, the default `latest` mc image tag will be replaced by the date format of the latest mc relaesed image

```
RELEASE=v6.0.0 make release
```