### PR TITLE
Remove govulncheck as a pre-requirement to run all other functional tests

### DIFF
--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -180,7 +180,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - lint
-      - vulnerable-dependencies-checks
       - govet
       - shellcheck
     strategy:

--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -206,7 +206,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - lint-sidecar
-      - vulnerable-dependencies-checks-sidecar
       - govet-sidecar
     strategy:
       matrix:

--- a/.github/workflows/kubernetes-tests.yml
+++ b/.github/workflows/kubernetes-tests.yml
@@ -85,7 +85,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - lint
-      - vulnerable-dependencies-checks
       - govet
     strategy:
       matrix:
@@ -161,7 +160,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs:
       - lint-sidecar
-      - vulnerable-dependencies-checks-sidecar
       - govet-sidecar
     strategy:
       matrix:


### PR DESCRIPTION
I think it is OK to keep that test as failed, but this should not prevent other functional tests from running and notify us on a potentially introduced bug.