### PR TITLE
Relax tls limitation on UI that blocks encryption if not enabled

### DIFF
--- a/api/tenant-add-handlers.go
+++ b/api/tenant-add-handlers.go
@@ -118,20 +118,13 @@ func createTenant(ctx context.Context, params operator_api.CreateTenantParams, c
 		}
 	}
 
-	canEncryptionBeEnabled := false
-
 	if tenantReq.EnableTLS != nil {
 		// if enableTLS is defined in the create tenant request we assign the value
 		// to the RequestAutoCert attribute in the tenant spec
 		minInst.Spec.RequestAutoCert = tenantReq.EnableTLS
-		if *tenantReq.EnableTLS {
-			// requestAutoCert is enabled, MinIO will be deployed with TLS enabled and encryption can be enabled
-			canEncryptionBeEnabled = true
-		}
 	}
 	// External server TLS certificates for MinIO
 	if tenantReq.TLS != nil && len(tenantReq.TLS.MinioServerCertificates) > 0 {
-		canEncryptionBeEnabled = true
 		// Certificates used by the MinIO instance
 		externalCertSecretName := fmt.Sprintf("%s-external-server-certificate", tenantName)
 		externalCertSecret, err := createOrReplaceExternalCertSecrets(ctx, clientSet, ns, tenantReq.TLS.MinioServerCertificates, externalCertSecretName, tenantName)
@@ -151,7 +144,7 @@ func createTenant(ctx context.Context, params operator_api.CreateTenantParams, c
 		minInst.Spec.ExternalClientCertSecrets = externalClientCertSecret
 	}
 	// If encryption configuration is present and TLS will be enabled (using AutoCert or External certificates)
-	if tenantReq.Encryption != nil && canEncryptionBeEnabled {
+	if tenantReq.Encryption != nil {
 		// KES client mTLSCertificates used by MinIO instance
 		if tenantReq.Encryption.MinioMtls != nil {
 			tenantExternalClientCertSecretName := fmt.Sprintf("%s-external-client-certificate-kes", tenantName)

--- a/web-app/src/screens/Console/Tenants/AddTenant/Steps/Encryption.tsx
+++ b/web-app/src/screens/Console/Tenants/AddTenant/Steps/Encryption.tsx
@@ -94,13 +94,6 @@ const Encryption = () => {
   const enableAutoCert = useSelector(
     (state: AppState) => state.createTenant.fields.security.enableAutoCert,
   );
-  const enableTLS = useSelector(
-    (state: AppState) => state.createTenant.fields.security.enableTLS,
-  );
-  const minioServerCertificates = useSelector(
-    (state: AppState) =>
-      state.createTenant.certificates.minioServerCertificates,
-  );
   const kesServerCertificate = useSelector(
     (state: AppState) => state.createTenant.certificates.kesServerCertificate,
   );
@@ -122,18 +115,6 @@ const Encryption = () => {
   );
 
   const [validationErrors, setValidationErrors] = useState<any>({});
-
-  let encryptionAvailable = false;
-  if (
-    enableTLS &&
-    (enableAutoCert ||
-      (minioServerCertificates &&
-        minioServerCertificates.filter(
-          (item) => item.encoded_key && item.encoded_cert,
-        ).length > 0))
-  ) {
-    encryptionAvailable = true;
-  }
 
   // Common
   const updateField = useCallback(
@@ -299,7 +280,6 @@ const Encryption = () => {
             updateField("enableEncryption", checked);
           }}
           description=""
-          disabled={!encryptionAvailable}
         />
       </Box>
       <Box className={"muted inputItem"}>


### PR DESCRIPTION
fixes: https://github.com/minio/operator/issues/2191 

CRD still allows you to disable tls while having encryption as well as the Edit UI. 
Seems that Operator already takes care of the TLS creation if encryption is enabled for KES regardless of  whether it's enabled for the tenant or not see [here](https://github.com/minio/operator/blob/master/pkg/controller/kes.go#L162).

This limitation was added on https://github.com/minio/console/pull/540/files#diff-3b60b0a032620e5fa1a8b8dc39485f0f82aef9356f58e5160734851c568c60c9R1168 but there doesn't seem to be a reason on why this was added.  
Same limitation is done in backend.


### Test Steps:
- In kind cluster
- build the assets 
- build the image and upload it to your cluster as defined here https://github.com/minio/operator/blob/master/DEVELOPMENT.md#deploy-operator-in-k8s-with-custom-image-using-kind
- access the UI
- Open Create Tenant flow
- Disable TLS
- Enable Encryption (switch should allow you to enable or disable)