### PR TITLE
Relax tenant listing limitation to permit search and edit

### DIFF
--- a/api/tenant-handlers.go
+++ b/api/tenant-handlers.go
@@ -568,9 +568,7 @@ func updateTenantIdentityProvider(ctx context.Context, operatorClient OperatorCl
 }
 
 func listTenants(ctx context.Context, operatorClient OperatorClientI, namespace string, limit *int32) (*models.ListTenantsResponse, error) {
-	listOpts := metav1.ListOptions{
-		Limit: 10,
-	}
+	listOpts := metav1.ListOptions{}
 
 	if limit != nil {
 		listOpts.Limit = int64(*limit)


### PR DESCRIPTION
#### Issue
See https://github.com/minio/operator/issues/2189


#### Fix
Remove the hardcoded 10 tenant limit from the UI. This fix will now permit the searching and editing of previously UI-inaccessible tenants.
Since the underlying component is a React `InfiniteLoader`, minimally rendering each tenant just-in-time, this should not adversely affect users with large number of tenants. 


#### How to test
1.- Deploy the minio operator using any of the methods here: https://min.io/docs/minio/kubernetes/upstream/operations/installation.html

2.- Deploy various minio tenants using https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-minio-tenant-helm.html#deploy-a-minio-tenant-using-helm-charts
Note: the Helm archive values.yaml may be modified and rearchived to allow to a minimal minio tenant (e.g. 1 drive 1 server 10 Mi storage)
The following command spawns 20 tenants for testing:
```
for i in {1..20}; do helm install --namespace test-$i --create-namespace test-$i tenant-5.0.15-10Mi.tgz; done
```


https://github.com/minio/operator/assets/16472240/2c551014-448e-4286-8756-49ce8f28808e

fixes https://github.com/minio/operator/issues/2189