### PR TITLE
update go to 1.22.5 to fix vulnerable package net/http

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/operator
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/minio/operator
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.22.5
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/operator
 
-go 1.22.5
+go 1.22
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/sidecar/go.mod
+++ b/sidecar/go.mod
@@ -1,8 +1,6 @@
 module github.com/minio/operator/sidecar
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.22.5
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/sidecar/go.mod
+++ b/sidecar/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/operator/sidecar
 
-go 1.22.5
+go 1.22
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/sidecar/go.mod
+++ b/sidecar/go.mod
@@ -1,6 +1,6 @@
 module github.com/minio/operator/sidecar
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
```
Vulnerability #1: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5
```