### PR TITLE
fix: panic when remove mutli pools

### DIFF
--- a/pkg/controller/decomission.go
+++ b/pkg/controller/decomission.go
@@ -99,7 +99,7 @@ func (c *Controller) checkForPoolDecommission(ctx context.Context, key string, t
 					if pstatus.State == miniov2.PoolInitialized {
 						initializedPool = pool
 					}
-					continue
+					break
 				}
 			}
 			if !found {


### PR DESCRIPTION
fix: panic when remove mutli pools
before: `pool-0`, `poo-1`,`poo-2`
after: `pool-1`
```log
goroutine 81 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x2e6c820, 0xc001686e70})
	/workspace/go/pkg/mod/k8s.io/apimachinery@v0.30.2/pkg/util/runtime/runtime.go:75 +0xf4
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x0})
	/workspace/go/pkg/mod/k8s.io/apimachinery@v0.30.2/pkg/util/runtime/runtime.go:49 +0xb6
panic({0x2e6c820?, 0xc001686e70?})
	/workspace/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.windows-amd64/src/runtime/panic.go:770 +0x136
github.com/minio/operator/pkg/controller.(*Controller).checkForPoolDecommission(0xc000bfc580, {0x3206528, 0x41ba9a0}, {0xc000a12060, 0x16}, 0xc00062f808, 0xc000f14330)
	/workspace/go/src/operator/pkg/controller/decomission.go:106 +0x1d58
github.com/minio/operator/pkg/controller.(*Controller).syncHandler(0xc000bfc580, {0xc000a12060, 0x16})
	/workspace/go/src/operator/pkg/controller/main-controller.go:836 +0x1274
```
simply code to test what happened.
```go
package main

func main() {
	testSlice := []int{0, 1, 2}
	for _, v := range testSlice {
		found := false
		if v%2 == 0 {
			found = true
		}
		if found {
			testSlice = append(testSlice[:v], testSlice[v+1:]...)
		}
	}
}
```