### PR TITLE
Fix certmanager test to use the `:noop` tagged image

### DIFF
--- a/examples/kustomization/tenant-certmanager/tenant-certmanager-issuer.yaml
+++ b/examples/kustomization/tenant-certmanager/tenant-certmanager-issuer.yaml
@@ -4,4 +4,5 @@ metadata:
   name: tenant-certmanager-issuer
   namespace: tenant-certmanager
 spec:
-  selfSigned: { }
+  ca:
+    secretName: tenant-certmanager-ca-tls

--- a/testing/certmanager/operator/deployment.yaml
+++ b/testing/certmanager/operator/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-operator
+  namespace: minio-operator
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      name: minio-operator
+  template:
+    metadata:
+      labels:
+        name: minio-operator
+    spec:
+      serviceAccountName: minio-operator
+      containers:
+        - name: minio-operator
+          image: minio/operator:noop
+          env:
+            - name: OPERATOR_SIDECAR_IMAGE
+              value: minio/operator-sidecar:noop

--- a/testing/certmanager/operator/kustomization.yaml
+++ b/testing/certmanager/operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../examples/kustomization/operator-certmanager
+
+patches:
+  - path: deployment.yaml

--- a/testing/common.sh
+++ b/testing/common.sh
@@ -577,7 +577,7 @@ function install_operator() {
     value=minio-operator
   elif [ "$1" = "certmanager" ]; then
     echo "Installing Current Operator with certmanager"
-    try kubectl apply -k "${SCRIPT_DIR}/../examples/kustomization/operator-certmanager"
+    try kubectl apply -k "${SCRIPT_DIR}/../testing/certmanager/operator"
     echo "key, value for pod selector in kustomize test"
     key=name
     value=minio-operator


### PR DESCRIPTION
This Fixes the automated test for Cert Manager:

* Test was not running with current code, instead was pulling latest released Operator image
* Test was failing because Operator could not trust the MinIO TLS certificate, is fixed by Issuing the certificate with a CA (Certificate Authority) and pass that CA to Operator to be trusted.