### PR TITLE
Release Operator v6.0.1 correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ for [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kusto
 use that to install MiniO Operator.
 
 ```sh
-kubectl kustomize github.com/minio/operator\?ref=v6.0.0
+kubectl kustomize github.com/minio/operator\?ref=v6.0.1
 ```
 
 Run the following command to verify the status of the Operator:

--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -253,7 +253,7 @@ spec:
   ## Audit Logs will be deprecated soon, commenting out for now!.
   ## LogSearch API setup for MinIO Tenant.
   # log:
-  #   image: "" # defaults to minio/operator:v6.0.0
+  #   image: "" # defaults to minio/operator:v6.0.1
   #   env: [ ]
   #   resources: { }
   #   nodeSelector: { }

--- a/helm/operator/Chart.yaml
+++ b/helm/operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for MinIO Operator
 name: operator
-version: 6.0.0
-appVersion: v6.0.0
+version: 6.0.1
+appVersion: v6.0.1
 keywords:
   - storage
   - object-storage

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -32,14 +32,14 @@ operator:
   ###
   # Specify the Operator container image to use for the deployment.
   # ``image.tag``
-  # For example, the following sets the image to the ``quay.io/minio/operator`` repo and the v6.0.0 tag.
+  # For example, the following sets the image to the ``quay.io/minio/operator`` repo and the v6.0.1 tag.
   # The container pulls the image if not already present:
   #
   # .. code-block:: yaml
   #
   #    image:
   #      repository: quay.io/minio/operator
-  #      tag: v6.0.0
+  #      tag: v6.0.1
   #      pullPolicy: IfNotPresent
   #
   # The chart also supports specifying an image based on digest value:
@@ -53,20 +53,20 @@ operator:
   #
   image:
     repository: quay.io/minio/operator
-    tag: v6.0.0
+    tag: v6.0.1
     pullPolicy: IfNotPresent
   ###
   # Specify the sidecar container image to deploy on tenant pods for init container and sidecar.
   # Only need to change this if want to use a different version that the default, or want to set a custom registry.
   # ``sidecarImage.tag``
-  # For example, the following sets the image to the ``quay.io/minio/operator-sidecar`` repo and the v6.0.0 tag.
+  # For example, the following sets the image to the ``quay.io/minio/operator-sidecar`` repo and the v6.0.1 tag.
   # The container pulls the image if not already present:
   #
   # .. code-block:: yaml
   #
   #    sidecarImage:
   #      repository: quay.io/minio/operator-sidecar
-  #      tag: v6.0.0
+  #      tag: v6.0.1
   #      pullPolicy: IfNotPresent
   #
   # The chart also supports specifying an image based on digest value:

--- a/helm/tenant/Chart.yaml
+++ b/helm/tenant/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for MinIO Operator
 name: tenant
-version: 6.0.0
-appVersion: v6.0.0
+version: 6.0.1
+appVersion: v6.0.1
 keywords:
   - storage
   - object-storage

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,5 +1,5 @@
 ###
-# WARNING: '.secrets' is deprecated since v6.0.0 and will be removed in next minor release (i.e. v5.1.0).
+# WARNING: '.secrets' is deprecated since v6.0.1 and will be removed in next minor release (i.e. v5.1.0).
 # WARNING: Please use '.tenant.configSecret' instead.
 # Root key for dynamically creating a secret for use with configuring root MinIO User
 # Specify the ``name`` and then a list of environment variables. 
@@ -48,7 +48,7 @@ tenant:
   ###
   # Specify the Operator container image to use for the deployment.
   # ``image.tag`` 
-  # For example, the following sets the image to the ``quay.io/minio/operator`` repo and the v6.0.0 tag.
+  # For example, the following sets the image to the ``quay.io/minio/operator`` repo and the v6.0.1 tag.
   # The container pulls the image if not already present:
   #
   # .. code-block:: yaml

--- a/release.sh
+++ b/release.sh
@@ -49,7 +49,7 @@ files=(
   "testing/console-tenant+kes.sh"
 )
 
-CURRENT_RELEASE="v5.0.15"
+CURRENT_RELEASE=$(get_latest_release minio/operator)
 CURRENT_RELEASE="${CURRENT_RELEASE:1}"
 
 echo "MinIO: $MINIO_RELEASE"

--- a/resources/base/deployment.yaml
+++ b/resources/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: minio-operator
       containers:
         - name: minio-operator
-          image: minio/operator:v6.0.0
+          image: minio/operator:v6.0.1
           imagePullPolicy: IfNotPresent
           args:
             - controller


### PR DESCRIPTION
This PR does a correction in hardcoded version in release.sh https://github.com/minio/operator/blob/10d1190cb8aff9409eb03a7894a3b041f64ce035/release.sh#L52
Instead should be pulling the previous release from github
```sh
CURRENT_RELEASE=$(get_latest_release minio/operator)
```
