### PR TITLE
Set a default SecurityContext for all pods in a pool

### DIFF
--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -288,17 +288,15 @@ func poolContainerSecurityContext(pool *miniov2.Pool) *corev1.SecurityContext {
 	runAsNonRoot := true
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 1000
-	if pool != nil {
-		if pool.SecurityContext != nil {
-			if pool.SecurityContext.RunAsNonRoot != nil {
-				runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
-			}
-			if pool.SecurityContext.RunAsUser != nil {
-				runAsUser = *pool.SecurityContext.RunAsUser
-			}
-			if pool.SecurityContext.RunAsGroup != nil {
-				runAsGroup = *pool.SecurityContext.RunAsGroup
-			}
+	if pool != nil && pool.SecurityContext != nil {
+		if pool.SecurityContext.RunAsNonRoot != nil {
+			runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
+		}
+		if pool.SecurityContext.RunAsUser != nil {
+			runAsUser = *pool.SecurityContext.RunAsUser
+		}
+		if pool.SecurityContext.RunAsGroup != nil {
+			runAsGroup = *pool.SecurityContext.RunAsGroup
 		}
 	}
 

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -281,45 +281,38 @@ func poolSecurityContext(pool *miniov2.Pool, status *miniov2.PoolStatus) *corev1
 
 // Builds the security context for containers in a Pool
 func poolContainerSecurityContext(pool *miniov2.Pool) *corev1.SecurityContext {
-	// Default values:
-	// By default, values should be totally empty if not provided
-	// This is specially needed in OpenShift where Security Context Constraints restrict them
-	// if let empty then OCP can pick the values from the constraints defined.
-	containerSecurityContext := corev1.SecurityContext{}
+	// By default, we are opinionated and set the following values to request
+	// kubernetes to run our pods as a non-root user intentionally, we don't need to be root
+	// if the user needs a special security context, it should be specified on the pool's
+	// securityContext
 	runAsNonRoot := true
 	var runAsUser int64 = 1000
 	var runAsGroup int64 = 1000
-	poolSCSet := false
 	if pool != nil {
-		// Values from pool.SecurityContext ONLY if provided
 		if pool.SecurityContext != nil {
 			if pool.SecurityContext.RunAsNonRoot != nil {
 				runAsNonRoot = *pool.SecurityContext.RunAsNonRoot
-				poolSCSet = true
 			}
 			if pool.SecurityContext.RunAsUser != nil {
 				runAsUser = *pool.SecurityContext.RunAsUser
-				poolSCSet = true
 			}
 			if pool.SecurityContext.RunAsGroup != nil {
 				runAsGroup = *pool.SecurityContext.RunAsGroup
-				poolSCSet = true
 			}
-			if poolSCSet {
-				// Only set values if one of above is set otherwise let it empty
-				containerSecurityContext = corev1.SecurityContext{
-					RunAsNonRoot: &runAsNonRoot,
-					RunAsUser:    &runAsUser,
-					RunAsGroup:   &runAsGroup,
-				}
-			}
-		}
-
-		// Values from pool.ContainerSecurityContext if provided
-		if pool.ContainerSecurityContext != nil {
-			containerSecurityContext = *pool.ContainerSecurityContext
 		}
 	}
+
+	containerSecurityContext := corev1.SecurityContext{
+		RunAsNonRoot: &runAsNonRoot,
+		RunAsUser:    &runAsUser,
+		RunAsGroup:   &runAsGroup,
+	}
+
+	// Values from pool.ContainerSecurityContext if provided
+	if pool.ContainerSecurityContext != nil {
+		containerSecurityContext = *pool.ContainerSecurityContext
+	}
+
 	return &containerSecurityContext
 }
 


### PR DESCRIPTION
This reverts https://github.com/minio/operator/pull/1462

We need to have an explicit security context, we don't want to run as root which is the default in kubernetes when running without a security context.

If the user requires a special security context it should specify it in the pool's security context