### PR TITLE
fix: Avoid system cfg changed can't restart

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1329,6 +1329,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 			return WrapResult(Result{}, err)
 		}
 		if !maps.Equal(expectSystemCfg, existSystemCfg) {
+			// delete pdb to let deleted all the statefulSet pods
 			err = c.DeletePDB(ctx, tenant)
 			if err != nil {
 				return Result{}, err

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1329,6 +1329,10 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 			return WrapResult(Result{}, err)
 		}
 		if !maps.Equal(expectSystemCfg, existSystemCfg) {
+			err = c.DeletePDB(ctx, tenant)
+			if err != nil {
+				return Result{}, err
+			}
 			// found all existing statefulSet pods and delete them
 			err = c.DeletePodsByStatefulSet(ctx, existingStatefulSet)
 			if err != nil {

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1320,21 +1320,21 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 
 		// check if the system config has changed
 		// if changed, minio request the systemCfg must be the same to restart.
-		expectSystemCfg, err := c.getSystemCfgFromStatefulSet(ctx, expectedStatefulSet)
+		expectedSystemCfg, err := c.getSystemCfgFromStatefulSet(ctx, expectedStatefulSet)
 		if err != nil {
 			return WrapResult(Result{}, err)
 		}
-		existSystemCfg, err := c.getSystemCfgFromStatefulSet(ctx, existingStatefulSet)
+		existingSystemCfg, err := c.getSystemCfgFromStatefulSet(ctx, existingStatefulSet)
 		if err != nil {
 			return WrapResult(Result{}, err)
 		}
-		if !maps.Equal(expectSystemCfg, existSystemCfg) {
-			// delete pdb to let deleted all the statefulSet pods
+		if !maps.Equal(expectedSystemCfg, existingSystemCfg) {
+			// delete pdb to let all the statefulSet pods get deleted
 			err = c.DeletePDB(ctx, tenant)
 			if err != nil {
 				return Result{}, err
 			}
-			// found all existing statefulSet pods and delete them
+			// find all existing statefulSet pods and delete them
 			err = c.DeletePodsByStatefulSet(ctx, existingStatefulSet)
 			if err != nil {
 				return WrapResult(Result{}, err)

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"time"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
@@ -27,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -56,8 +56,7 @@ func (c *Controller) DeletePodsByStatefulSet(ctx context.Context, sts *appsv1.St
 	}
 	client.MatchingLabels(sts.Spec.Template.Labels).ApplyToList(listOpt)
 	podList := &corev1.PodList{}
-	err = c.k8sClient.List(ctx, podList, listOpt)
-	if err != nil {
+	if err := c.k8sClient.List(ctx, podList, listOpt); err != nil {
 		return err
 	}
 	for _, item := range podList.Items {

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog/v2"
 	"time"
 
 	miniov2 "github.com/minio/operator/pkg/apis/minio.min.io/v2"
@@ -60,10 +61,12 @@ func (c *Controller) DeletePodsByStatefulSet(ctx context.Context, sts *appsv1.St
 		return err
 	}
 	for _, item := range podList.Items {
-		err = c.k8sClient.Delete(ctx, &item)
-		// Ignore Not Found
-		if client.IgnoreNotFound(err) != nil {
-			log.Printf("unable to restart %s/%s (ignored): %s",  item.Namespace, item.Name, err)
+		if item.DeletionTimestamp == nil {
+			err = c.k8sClient.Delete(ctx, &item)
+			// Ignore Not Found
+			if client.IgnoreNotFound(err) != nil {
+				klog.Infof("unable to restart %s/%s (ignored): %s", item.Namespace, item.Name, err)
+			}
 		}
 	}
 	return

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -61,11 +61,9 @@ func (c *Controller) DeletePodsByStatefulSet(ctx context.Context, sts *appsv1.St
 	}
 	for _, item := range podList.Items {
 		err = c.k8sClient.Delete(ctx, &item)
-		if err != nil {
-			// Ignore Not Found
-			if client.IgnoreNotFound(err) != nil {
-				return err
-			}
+		// Ignore Not Found
+		if client.IgnoreNotFound(err) != nil {
+			log.Printf("unable to restart %s/%s (ignored): %s",  item.Namespace, item.Name, err)
 		}
 	}
 	return

--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -94,7 +94,6 @@ func poolSSMatchesSpec(expectedStatefulSet, existingStatefulSet *appsv1.Stateful
 }
 
 // getSystemCfgFromStatefulSet gets the MinIO environment variables from a statefulset
-// set getServerSystemCfg at minio
 func (c *Controller) getSystemCfgFromStatefulSet(ctx context.Context, sts *appsv1.StatefulSet) (systemCfg map[string]string, err error) {
 	systemCfg = make(map[string]string)
 	for _, container := range sts.Spec.Template.Spec.Containers {

--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -114,7 +114,7 @@ func (c *Controller) getSystemCfgFromStatefulSet(ctx context.Context, sts *appsv
 						if err != nil {
 							return nil, err
 						}
-						systemCfg[e.Name] = string(configMap.Data[e.ValueFrom.ConfigMapKeyRef.Key])
+						systemCfg[e.Name] = configMap.Data[e.ValueFrom.ConfigMapKeyRef.Key]
 					default:
 						return nil, fmt.Errorf("unsupported env var %s", e.Name)
 					}

--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -96,6 +96,7 @@ func poolSSMatchesSpec(expectedStatefulSet, existingStatefulSet *appsv1.Stateful
 // getSystemCfgFromStatefulSet gets the MinIO environment variables from a statefulset
 // set getServerSystemCfg at minio
 func (c *Controller) getSystemCfgFromStatefulSet(ctx context.Context, sts *appsv1.StatefulSet) (systemCfg map[string]string, err error) {
+	systemCfg = make(map[string]string)
 	for _, container := range sts.Spec.Template.Spec.Containers {
 		if container.Name == miniov2.MinIOServerName {
 			for _, e := range container.Env {


### PR DESCRIPTION
fix: Avoid system cfg changed can't restart
how to test:
1. deploy 4*1 tenant.
2. wait green
3. add the env like `MINIO_LOGGER_WEBHOOK_ENDPOINT_` to tenant
4. now will restart all the pod in one batch. Before one by one , but the restart pod will get this 
```log
{"level":"INFO","time":"2024-08-05T19:05:07.791137217Z","message":"Following servers have mismatching configuration [https://minio-pool-0-3.na-minio-hl.na-test-minio.svc.cluster.local:9000-\u003ehttps://minio-pool-0-1.na-minio-hl.na-test-minio.svc.cluster.local:9000 has incorrect configuration: Expected MINIO_* environment name and values across all servers to be same: Mismatching environment values: [MINIO_LOGGER_WEBHOOK_ENDPOINT_].]"}
```
And got stuck for this pod will never be ready. 