### PR TITLE
Fix sidecar probing with multiple certs (#2239)

### DIFF
--- a/sidecar/pkg/sidecar/sidecar_utils.go
+++ b/sidecar/pkg/sidecar/sidecar_utils.go
@@ -78,7 +78,7 @@ func StartSideCar(tenantName string, secretName string) {
 
 	controller := NewSideCarController(kubeClient, controllerClient, namespace, tenantName, secretName)
 	controller.ws = configureWebhookServer(controller)
-	controller.probeServer = configureProbesServer(controller, tenant.TLS())
+	controller.probeServer = configureProbesServer(tenant)
 	controller.sidecar = configureSidecarServer(controller)
 
 	stopControllerCh := make(chan struct{})


### PR DESCRIPTION
Fixes #2239.

Note that this will also hit the `HEAD /minio/health/live` endpoint for probing instead of `GET /` to reduce the amount of list bucket failures.