### PR TITLE
Remove deprecated `.secret` from tenant Helm chart

### DIFF
--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -1,21 +1,10 @@
 {{- if (.Values.secrets) }}
-{{- print "# WARNING: '.secrets' is deprecated since v5.0.15 and will be removed in next minor release (i.e. v5.1.0). Please use '.tenant.configSecret' instead." }}
-{{- end }}
-{{- if and (.Values.secrets) (.Values.tenant.configSecret) }}
-{{- fail "ERROR: '.secrets' and '.tenant.configSecret' are mutually exclusive. Please use 'tenant.configSecret' instead." }}
-{{- end }}
-{{- if and (.Values.secrets) (not (.Values.secrets).existingSecret) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ dig "secrets" "name" "" (.Values | merge (dict)) }}
-type: Opaque
-stringData:
-  config.env: |-
-    export MINIO_ROOT_USER={{ .Values.secrets.accessKey | quote }}
-    export MINIO_ROOT_PASSWORD={{ .Values.secrets.secretKey | quote }}
-{{- end }}
-{{- if and (.Values.tenant.configSecret) (not (.Values.tenant.configSecret).existingSecret) }}
+{{- fail "# ERROR: '.secrets' is deprecated since v5.0.15 and has been removed. Please use '.tenant.configSecret' instead." }}
+{{- else }}
+{{- if not (.Values.tenant.configSecret) }}
+{{- fail "# ERROR: '.tenant.configSecret' should be set." }}
+{{- else }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,4 +14,7 @@ stringData:
   config.env: |-
     export MINIO_ROOT_USER={{ .Values.tenant.configSecret.accessKey | quote }}
     export MINIO_ROOT_PASSWORD={{ .Values.tenant.configSecret.secretKey | quote }}
+
 {{- end }}
+{{- end }}
+

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -1,43 +1,3 @@
-###
-# WARNING: '.secrets' is deprecated since v6.0.2 and will be removed in next minor release (i.e. v5.1.0).
-# WARNING: Please use '.tenant.configSecret' instead.
-# Root key for dynamically creating a secret for use with configuring root MinIO User
-# Specify the ``name`` and then a list of environment variables. 
-#
-# .. important::
-#
-#    Do not use this in production environments. 
-#    This field is intended for use with rapid development or testing only.
-# 
-# For example:
-#
-# .. code-block:: yaml
-#
-#    name: myminio-env-configuration
-#    accessKey: minio
-#    secretKey: minio123
-#
-secrets:
-  name: myminio-env-configuration
-  accessKey: minio 
-  secretKey: minio123
-  ###
-  # If this variable is set, then enable the usage of an existing Kubernetes secret to set environment variables for the Tenant.
-  # The existing Kubernetes secret name must be placed under .tenant.configuration.name e.g. existing-minio-env-configuration
-  # The secret must contain a key ``config.env``.
-  # The values should be a series of export statements to set environment variables for the Tenant.
-  # For example:
-  #
-  # .. code-block:: shell
-  #
-  #    stringData:
-  #       config.env: |-
-  #         export MINIO_ROOT_USER=ROOTUSERNAME
-  #         export MINIO_ROOT_PASSWORD=ROOTUSERPASSWORD
-  #
-  #existingSecret:
-  #  name: enabled
-###
 # Root key for MinIO Tenant Chart
 tenant:
   ###
@@ -104,10 +64,10 @@ tenant:
   #    accessKey: minio
   #    secretKey: minio123
   #
-  # configSecret:
-  #   name: myminio-env-configuration
-  #   accessKey: minio
-  #   secretKey: minio123
+  configSecret:
+    name: myminio-env-configuration
+    accessKey: minio
+    secretKey: minio123
   ###
   # If this variable is set to true, then enable the usage of an existing Kubernetes secret to set environment variables for the Tenant.
   # The existing Kubernetes secret name must be placed under .tenant.configuration.name e.g. existing-minio-env-configuration


### PR DESCRIPTION
The `.secret` value in the tenant Helm chart has been deprecated in the v5 charts, so it should have been removed in v6. That also fixes https://github.com/minio/operator/issues/2255.

To prevent that secrets are created with unexpected values (i.e. when the end-user still uses the deprecated `.secrets` value), then it will show a message that the user should use `.tenant.configSecret` instead and abort.