### PR TITLE
Improve error message when scanning through the tar file

### DIFF
--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -270,7 +270,7 @@ func ExtractTar(filesToExtract []string, basePath, tarFileName string) error {
 
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return fmt.Errorf("Tar file contains only %d from the %d files", len(filesToExtract)-success, len(filesToExtract))
+				return fmt.Errorf("Tar file contains only %d out of %d files", len(filesToExtract)-success, len(filesToExtract))
 			}
 			return fmt.Errorf("Tar file extraction failed for file index: %d, with: %w", success, err)
 		}

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -269,6 +269,9 @@ func ExtractTar(filesToExtract []string, basePath, tarFileName string) error {
 		}
 
 		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return fmt.Errorf("Tar file contains only %d from the %d files", len(filesToExtract)-success, len(filesToExtract))
+			}
 			return fmt.Errorf("Tar file extraction failed for file index: %d, with: %w", success, err)
 		}
 		if header.Typeflag == tar.TypeReg {


### PR DESCRIPTION
The error `Tar file extraction failed for file index: 2, with: EOF` isn't very descriptive. This PR will return a more appropriate error when scanning the tar file, without finding the correct files.