### PR TITLE
Allow existing secret

### DIFF
--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -4,6 +4,7 @@
 {{- if not (.Values.tenant.configSecret) }}
 {{- fail "# ERROR: '.tenant.configSecret' should be set." }}
 {{- else }}
+{{- if not (.Values.tenant.configSecret.existingSecret) }}
 
 apiVersion: v1
 kind: Secret
@@ -15,6 +16,14 @@ stringData:
     export MINIO_ROOT_USER={{ .Values.tenant.configSecret.accessKey | quote }}
     export MINIO_ROOT_PASSWORD={{ .Values.tenant.configSecret.secretKey | quote }}
 
+{{- else }}
+{{- if (.Values.tenant.configSecret.accessKey) }}
+{{- fail "# ERROR: cannot set access-key when an existing secret is used" }}
+{{- end }}
+{{- if (.Values.tenant.configSecret.secretKey) }}
+{{- fail "# ERROR: cannot set secret-key when an existing secret is used" }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -68,6 +68,8 @@ tenant:
     name: myminio-env-configuration
     accessKey: minio
     secretKey: minio123
+    #existingSecret: true
+
   ###
   # If this variable is set to true, then enable the usage of an existing Kubernetes secret to set environment variables for the Tenant.
   # The existing Kubernetes secret name must be placed under .tenant.configuration.name e.g. existing-minio-env-configuration


### PR DESCRIPTION
Allow specifying `s.tenant.configSecret.existingSecret` in the Helm chart to prevent creating a new certificate.

Fixes #2297 and #2298.