### PR TITLE
Add kubectl apply to kubectl kustomize in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ for [kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kusto
 use that to install MiniO Operator.
 
 ```sh
-kubectl kustomize github.com/minio/operator\?ref=v6.0.3
+kubectl kustomize github.com/minio/operator\?ref=v6.0.3 | kubectl apply -f -
 ```
 
 Run the following command to verify the status of the Operator:


### PR DESCRIPTION
This Pull Request updates the deployment command in the README.md file to correctly apply the Kustomize output to the cluster. The kustomize command by itself does not install the operator. What it does is generate the Kubernetes manifest files for the operator. To actually install the operator, you would typically pipe the output of this command to kubectl apply.