### PR TITLE
Fix tags and references

### DIFF
--- a/helm/operator/templates/job.min.io_jobs.yaml
+++ b/helm/operator/templates/job.min.io_jobs.yaml
@@ -1080,7 +1080,7 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
               mcImage:
-                default: quay.io/minio/mc:RELEASE.2024-08-17T01-24-54Z
+                default: quay.io/minio/mc:RELEASE.2024-08-17T11-33-50Z
                 type: string
               securityContext:
                 properties:

--- a/helm/operator/templates/sts.min.io_policybindings.yaml
+++ b/helm/operator/templates/sts.min.io_policybindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    operator.min.io/version: v5.0.15
+    operator.min.io/version: v6.0.3
   name: policybindings.sts.min.io
 spec:
   group: sts.min.io

--- a/resources/base/crds/job.min.io_miniojobs.yaml
+++ b/resources/base/crds/job.min.io_miniojobs.yaml
@@ -1080,7 +1080,7 @@ spec:
                   x-kubernetes-map-type: atomic
                 type: array
               mcImage:
-                default: quay.io/minio/mc:RELEASE.2024-08-17T01-24-54Z
+                default: quay.io/minio/mc:RELEASE.2024-08-17T11-33-50Z
                 type: string
               securityContext:
                 properties:

--- a/resources/base/crds/sts.min.io_policybindings.yaml
+++ b/resources/base/crds/sts.min.io_policybindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    operator.min.io/version: v5.0.15
+    operator.min.io/version: v6.0.3
   name: policybindings.sts.min.io
 spec:
   group: sts.min.io


### PR DESCRIPTION
This update is the result of the command `make regen-crd`:

* Set `operator.min.io/version` to be release v6.0.3

* Update mc release version to `quay.io/minio/mc:RELEASE.2024-08-17T11-33-50Z`