### PR TITLE
fix: multi controller run concurrently after leadership lost

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -207,6 +207,10 @@ func setupSignalHandler() (stopCh <-chan struct{}) {
 	return stop
 }
 
+func shutdown() error {
+	return syscall.Kill(os.Getpid(), syscall.SIGTERM)
+}
+
 // Result contains the result of a sync invocation.
 type Result struct {
 	// Requeue tells the Controller to requeue the reconcile key.  Defaults to false.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -207,10 +207,6 @@ func setupSignalHandler() (stopCh <-chan struct{}) {
 	return stop
 }
 
-func shutdown() error {
-	return syscall.Kill(os.Getpid(), syscall.SIGTERM)
-}
-
 // Result contains the result of a sync invocation.
 type Result struct {
 	// Requeue tells the Controller to requeue the reconcile key.  Defaults to false.

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -497,7 +497,7 @@ func leaderRun(ctx context.Context, c *Controller, threadiness int, stopCh <-cha
 				go c.startSTSAPIServer(ctx, notificationChannel)
 			}
 		case err := <-upgradeServerChannel:
-			if err != http.ErrServerClosed {
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				klog.Errorf("Upgrade Server stopped: %v, going to restart", err)
 				upgradeServerChannel = c.startUpgradeServer()
 			}
@@ -584,13 +584,24 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 				leaderRun(ctx, c, threadiness, stopCh, notificationChannel)
 			},
 			OnStoppedLeading: func() {
-				// we can do cleanup here
-				klog.Infof("leader lost: %s", c.podName)
-				// When we lose leadership, we should do cleanup, such as stop the controller.
-				if err := shutdown(); err != nil {
-					klog.Errorf("error shutting down: %v", err)
-				}
+				klog.Infof("leader lost, removing any leader labels that I '%s' might have", c.podName)
+				p := []patchAnnotation{{
+					Op:   "remove",
+					Path: "/metadata/labels/operator",
+				}}
 
+				payloadBytes, err := json.Marshal(p)
+				if err != nil {
+					klog.Errorf("failed to marshal patch: %#v", err)
+				} else {
+					c.kubeClientSet.CoreV1().Pods(leaseLockNamespace).Patch(ctx, c.podName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
+				}
+				// Even if Stop() is called twice, stopping it here ensures the sync handler no longer is handling events,
+				// in case SIGTERM fails or the controller takes longer to exit.
+				c.Stop()
+				if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+					klog.Errorf("error sending SIGTERM: %v", err)
+				}
 			},
 			OnNewLeader: func(identity string) {
 				// we're notified when new leader elected


### PR DESCRIPTION
## Reproduction Steps:
1. Start two operators locally, named minio-operator-1 and minio-operator-2.
2. minio-operator-1 holds the lease for minio-operator-lock.
3. Manually change the HOLDER of minio-operator-lock to minio-operator-2.
4. The leader is now minio-operator-2.

At this point, the logs for minio-operator-1 show the following:
<img width="1347" alt="截屏2024-09-03 16 34 51" src="https://github.com/user-attachments/assets/bbee872a-a20a-4a84-a1bb-0079f3125377">

The main-controller continues to run even after losing leadership.

## After the PR

Follow the same steps as above.

Now, the logs for minio-operator-1 show the following:
<img width="1222" alt="截屏2024-09-03 16 57 17" src="https://github.com/user-attachments/assets/761ead5b-df1a-48cd-84ca-a52f9c42d5dc">

minio-operator-1 stops and exits. If we run it in Kubernetes, the container will restart and attempt to acquire the lease. It will then detect that minio-operator-2 has become the leader and will remain inactive with no controller running. That's what we want.