### PR TITLE
fix: empty tenant log

### DIFF
--- a/pkg/controller/monitoring.go
+++ b/pkg/controller/monitoring.go
@@ -154,8 +154,10 @@ func (c *Controller) updateHealthStatusForTenant(tenant *miniov2.Tenant) (*minio
 	}
 
 	// partial status update, since the storage info might take a while
-	if tenant, err = c.updatePoolStatus(context.Background(), tenant); err != nil {
+	if tenantUpdate, err := c.updatePoolStatus(context.Background(), tenant); err != nil {
 		klog.Infof("'%s/%s' Can't update tenant status: %v", tenant.Namespace, tenant.Name, err)
+	} else {
+		tenant = tenantUpdate
 	}
 
 	srvInfoCtx, cancel := context.WithTimeout(context.Background(), 120*time.Second)


### PR DESCRIPTION
When update failed, tenant will reset to the default one without any information
```
minio-operator-bdb6b4f55-bkdg7 operator E0909 07:20:34.734171       1 main-controller.go:1570] error syncing '/': resource name may not be empty
minio-operator-bdb6b4f55-bkdg7 operator E0909 07:21:34.735160       1 main-controller.go:1570] error syncing '/': resource name may not be empty
minio-operator-bdb6b4f55-bkdg7 operator E0909 07:22:34.736224       1 main-controller.go:1570] error syncing '/': resource name may not be empty
minio-operator-bdb6b4f55-bkdg7 operator E0909 07:23:34.737242       1 main-controller.go:1570] error syncing '/': resource name may not be empty
minio-operator-bdb6b4f55-bkdg7 operator E0909 07:24:34.737571       1 main-controller.go:1570] error syncing '/': resource name may not be empty
```