### PR TITLE
Add storageLabels value to tenant chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -42,6 +42,9 @@ spec:
       {{- with (dig "storageAnnotations" (dict) .) }}
           annotations: {{- toYaml . | nindent 12 }}
       {{- end }}
+      {{- with (dig "storageLabels" (dict) .) }}
+          labels: {{- toYaml . | nindent 12 }}
+      {{- end }}
         spec:
           {{- if dig "storageClassName" "" . }}
           storageClassName: {{ dig "storageClassName" "" . }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -115,6 +115,9 @@ tenant:
       # Specify `storageAnnotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`__ to associate to PVCs.
       storageAnnotations: { }
       ###
+      # Specify `storageLabels <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>`__ to associate to PVCs.
+      storageLabels: { }
+      ###
       # Specify `annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>`__ to associate to Tenant pods.
       annotations: { }
       ###


### PR DESCRIPTION
There is already `storageAnnotations` in place, but sometimes it's required to use labels, e.g. configuring PVC backups via longhorn is [based on labels](https://longhorn.io/docs/1.7.1/snapshots-and-backups/scheduling-backups-and-snapshots/#with-persistentvolumeclam-using-the-kubectl-command).