### PR TITLE
fix: incorrect error log `Waiting for MinIO to be ready: %!s(<nil>)`

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1348,7 +1348,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 	// Stay in this state until minio is ready
 	if tenant.Status.HealthStatus != miniov2.HealthStatusGreen {
 		c.updateTenantStatus(ctx, tenant, StatusWaitingMinIOIsHealthy, 0)
-		c.recorder.Event(tenant, corev1.EventTypeWarning, WaitingMinIOIsHealthyReason, fmt.Sprintf("Waiting for MinIO to be ready: %s", err))
+		c.recorder.Event(tenant, corev1.EventTypeWarning, WaitingMinIOIsHealthyReason, fmt.Sprintf("Waiting for MinIO(%s/%s) to be ready", tenant.Namespace, tenant.Name))
 		// retry after 5sec
 		return WrapResult(Result{RequeueAfter: time.Second * 5}, nil)
 	}

--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -1348,7 +1348,7 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 	// Stay in this state until minio is ready
 	if tenant.Status.HealthStatus != miniov2.HealthStatusGreen {
 		c.updateTenantStatus(ctx, tenant, StatusWaitingMinIOIsHealthy, 0)
-		c.recorder.Event(tenant, corev1.EventTypeWarning, WaitingMinIOIsHealthyReason, fmt.Sprintf("Waiting for MinIO(%s/%s) to be ready", tenant.Namespace, tenant.Name))
+		c.recorder.Event(tenant, corev1.EventTypeWarning, WaitingMinIOIsHealthyReason, "Waiting for MinIO to be ready")
 		// retry after 5sec
 		return WrapResult(Result{RequeueAfter: time.Second * 5}, nil)
 	}


### PR DESCRIPTION
fix: incorrect error log
`Waiting for MinIO to be ready: %!s(<nil>)`
fix #2308