### PR TITLE
Fix base example url

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ We provide a variety of examples for creating MinIO Tenants in the `examples` di
 4-node MinIO Tenant with 4 volumes per node:
 
 ```yaml
-kubectl apply -k github.com/minio/operator/examples/kustomization/bases
+kubectl apply -k github.com/minio/operator/examples/kustomization/base
 ```
 
 ### 3) Connect to the Tenant


### PR DESCRIPTION
I was following the instructions in the README.md as I'm trying out minio operator for the first time and I got hung up on this url being off for a little until I checked out the repo and realized the issue.