### PR TITLE
fix: multi controller run concurrently after leadership lost

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -569,7 +569,10 @@ func (c *Controller) Start(threadiness int, stopCh <-chan struct{}) error {
 					c.kubeClientSet.CoreV1().Pods(leaseLockNamespace).Patch(ctx, c.podName, types.JSONPatchType, payloadBytes, metav1.PatchOptions{})
 				}
 				c.Stop()
-				cancel()
+
+				if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+					klog.Errorf("error sending SIGTERM: %v", err)
+				}
 			},
 			OnNewLeader: func(identity string) {
 				// we're notified when new leader elected


### PR DESCRIPTION
The previous PR, available at [this link](https://github.com/minio/operator/pull/2309), addresses the issue of multiple controllers in an unstable API server environment.

However, in [this commit](https://github.com/minio/operator/commit/6cd2041e1af9a5fcb8b2e6171becde226d9638d0#diff-42fe67b1ed31cb18adfb7c7238731d06a36cdce9813d735f89a19a9e24630c0fL602-L604), a critical line of code has been replaced with the cancel() method, which does not fully resolve the issue.

This is because the context associated with cancel() is not passed as an argument into runWorker().