### PR TITLE
fix: adding an environment value to enable the ignoring of the name, accessKey and secretKey in configSecret.

### DIFF
--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -17,11 +17,13 @@ stringData:
     export MINIO_ROOT_PASSWORD={{ .Values.tenant.configSecret.secretKey | quote }}
 
 {{- else }}
+{{- if eq .Values.tenant.environment "dev" }}
 {{- if (.Values.tenant.configSecret.accessKey) }}
 {{- fail "# ERROR: cannot set access-key when an existing secret is used" }}
 {{- end }}
 {{- if (.Values.tenant.configSecret.secretKey) }}
 {{- fail "# ERROR: cannot set secret-key when an existing secret is used" }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -71,6 +71,15 @@ tenant:
   # The secret is expected to have a key named config.env containing environment variables exports.
   configuration:
     name: myminio-env-configuration
+
+  ###
+  # The environment into which this tenant will be deployed.
+  # Valid options:
+  #
+  # environment: dev # will presume you are using the config secret in line as shown in the example below.
+  # environment: <anything else> # will ignore the name, accessKey and secretKey fields if provided and enable the existingSecret value to be used.
+  environment: dev
+
   ###
   # Root key for dynamically creating a secret for use with configuring root MinIO User
   # Specify the ``name`` and then a list of environment variables.


### PR DESCRIPTION
## Description

In version `6.0.4` the inclusion of [this check](https://github.com/minio/operator/pull/2299/files#diff-1320c71ce4251e5e50c3b17c8aee11659e44a7208d1ab8d5c4f68694c02d9e80R20-R25) broke the ability to pass the `existingSecret` value because the default values provided in the values.yaml file caused the error to trigger. It seems incorrect to have to provide the following to make it work:

```
  configSecret:
    name: ""
    accessKey: ""
    secretKey: ""
    existingSecret: true
```

Now we can presume that in `dev` the values will be provided in line as per the values file and in any other situation, they are provided via an existing secret.

There may be a better way than this, but I've rolled this out and it's fixed the problem I had when upgrading to `6.0.4`.

## Type of Change

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1. Roll out Minio chart with the existing secret as described above. Watch it fail.
2. Roll it out with this change with or without `.Values.tenant.environment` set as per the conditional, watch it succeed.

## Additional Notes / Context

<!-- Add any other context or details about the PR -->