### PR TITLE
Update release scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ clean:
 	@rm -rf dist/
 
 regen-crd:
-	@go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
+	@go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
 	@${GOPATH}/bin/controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=$(KUSTOMIZE_CRDS)
 	@sed 's#namespace: minio-operator#namespace: {{ .Release.Namespace }}#g' resources/base/crds/minio.min.io_tenants.yaml > $(HELM_TEMPLATES)/minio.min.io_tenants.yaml
 	@sed 's#namespace: minio-operator#namespace: {{ .Release.Namespace }}#g' resources/base/crds/sts.min.io_policybindings.yaml > $(HELM_TEMPLATES)/sts.min.io_policybindings.yaml

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/google/go-containerregistry v0.19.2
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/release.sh
+++ b/release.sh
@@ -4,49 +4,52 @@ set -e
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --release-sidecar)
-            RELEASE_SIDECAR="$2"
-            shift 2
-            ;;
-        *)
-            ;;
-    esac
-    shift
+	case $1 in
+	--release-sidecar)
+		RELEASE_SIDECAR="$2"
+		shift 2
+		;;
+	*) ;;
+	esac
+	shift
 done
 
+sed_inplace() {
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		sed -i "" -E "$@"
+	else
+		sed -i -r "$@"
+	fi
+}
+
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-    grep '"tag_name":' |                                            # Get tag line
-    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+	curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+		grep '"tag_name":' |                                             # Get tag line
+		sed -E 's/.*"([^"]+)".*/\1/'                                     # Pluck JSON value
 }
 
 MINIO_RELEASE=$(get_latest_release minio/minio)
 KES_RELEASE=$(get_latest_release minio/kes)
-MC_RELEASE=$(get_latest_release minio/mc)
 
 MINIO_CURRENT_RELEASE=$(sed -nr 's/.*(minio\/minio\:)([v]?.*)"/\2/p' pkg/apis/minio.min.io/v2/constants.go)
 KES_CURRENT_RELEASE=$(sed -nr 's/.*(minio\/kes\:)([v]?.*)"/\2/p' pkg/apis/minio.min.io/v2/constants.go)
 
 files=(
-  "README.md"
-  "pkg/apis/job.min.io/v1alpha1/types.go"
-  "docs/tenant_crd.adoc"
-  "docs/policybinding_crd.adoc"
-  "docs/job_crd.adoc"
-  "docs/minio-job.md"
-  "docs/templates/asciidoctor/gv_list.tpl"
-  "examples/kustomization/base/tenant.yaml"
-  "examples/kustomization/tenant-certmanager-kes/tenant.yaml"
-  "examples/kustomization/tenant-kes-encryption/tenant.yaml"
-  "helm/operator/Chart.yaml"
-  "helm/operator/values.yaml"
-  "helm/tenant/Chart.yaml"
-  "helm/tenant/values.yaml"
-  "pkg/apis/minio.min.io/v2/constants.go"
-  "pkg/controller/operator.go"
-  "resources/base/deployment.yaml"
-  "testing/console-tenant+kes.sh"
+	"README.md"
+	"docs/tenant_crd.adoc"
+	"docs/policybinding_crd.adoc"
+	"docs/templates/asciidoctor/gv_list.tpl"
+	"examples/kustomization/base/tenant.yaml"
+	"examples/kustomization/tenant-certmanager-kes/tenant.yaml"
+	"examples/kustomization/tenant-kes-encryption/tenant.yaml"
+	"helm/operator/Chart.yaml"
+	"helm/operator/values.yaml"
+	"helm/tenant/Chart.yaml"
+	"helm/tenant/values.yaml"
+	"pkg/apis/minio.min.io/v2/constants.go"
+	"pkg/controller/operator.go"
+	"resources/base/deployment.yaml"
+	"testing/console-tenant+kes.sh"
 )
 
 CURRENT_RELEASE=$(get_latest_release minio/operator)
@@ -55,36 +58,33 @@ CURRENT_RELEASE="${CURRENT_RELEASE:1}"
 echo "Upgrade: $CURRENT_RELEASE => $RELEASE"
 echo "MinIO: $MINIO_RELEASE => $MINIO_RELEASE"
 echo "KES: $KES_CURRENT_RELEASE => $KES_RELEASE"
-echo "MC: $MC_CURRENT_RELEASE => $MC_RELEASE"
 
 if [ -z "$MINIO_RELEASE" ]; then
-  echo "\$MINIO_RELEASE is empty"
-  exit 0
+	echo "\$MINIO_RELEASE is empty"
+	exit 0
 fi
 
 for file in "${files[@]}"; do
-	sed -i -e "s/${KES_CURRENT_RELEASE}/${KES_RELEASE}/g" "$file"
-	sed -i -e "s/${MC_CURRENT_RELEASE}/${MC_RELEASE}/g" "$file"
-  sed -i -e "s/${CURRENT_RELEASE}/${RELEASE}/g" "$file"
-  sed -i -e "s/${MINIO_CURRENT_RELEASE}/${MINIO_RELEASE}/g" "$file"
+	sed_inplace "s/${KES_CURRENT_RELEASE}/${KES_RELEASE}/g" "$file"
+	sed_inplace "s/${CURRENT_RELEASE}/${RELEASE}/g" "$file"
+	sed_inplace "s/${MINIO_CURRENT_RELEASE}/${MINIO_RELEASE}/g" "$file"
 done
 
 annotations_files=(
-  "pkg/apis/job.min.io/v1alpha1/types.go"
-  "pkg/apis/minio.min.io/v2/types.go"
-  "pkg/apis/sts.min.io/v1beta1/types.go"
+	"pkg/apis/minio.min.io/v2/types.go"
+	"pkg/apis/sts.min.io/v1beta1/types.go"
 )
 
 for file in "${annotations_files[@]}"; do
-  sed -i -e "s~operator.min.io/version=.*~operator.min.io/version=v${RELEASE}~g" "$file"
+	sed_inplace "s~operator.min.io/version=.*~operator.min.io/version=v${RELEASE}~g" "$file"
 done
 
 # Update annotation in kustomization yaml
-sed -i -e "s~operator.min.io/version: .*~operator.min.io/version: v${RELEASE}~g" "resources/kustomization.yaml"
+sed_inplace "s~operator.min.io/version: .*~operator.min.io/version: v${RELEASE}~g" "resources/kustomization.yaml"
 
 if [ "${RELEASE_SIDECAR}" = "true" ]; then
 
-  sed -i -e 's~quay.io/minio/operator-sidecar:.*\"~quay.io/minio/operator-sidecar:v'$RELEASE'\"~g' "pkg/resources/statefulsets/minio-sidecar.go"
+	sed_inplace 's~quay.io/minio/operator-sidecar:.*\"~quay.io/minio/operator-sidecar:v'$RELEASE'\"~g' "pkg/resources/statefulsets/minio-sidecar.go"
 fi
 
 # Add all the generated files to git

--- a/sidecar/go.mod
+++ b/sidecar/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/sidecar/go.sum
+++ b/sidecar/go.sum
@@ -32,6 +32,8 @@ github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keL
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
+github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=


### PR DESCRIPTION
* Update controller-gen 0.16.5
* Add `sed_inplace` method in bash script to make the sed syntax compatible in Linux and MacOS
* Remove files that reference MCJob in release.sh
* Update `github.com/golang-jwt/jwt/v4` from v4.5.0 to github.com/golang-jwt/jwt/v4 v4.5.1 to fix `https://github.com/advisories/GHSA-29wx-vh33-7x7r`