### PR TITLE
Add initContainers to tenant Helm Chart 

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -25,6 +25,9 @@ spec:
   imagePullSecret:
     name: {{ dig "imagePullSecret" "name" "" . }}
   {{- end }}
+  {{- with (dig "initContainers" (list) .) }}
+  initContainers: {{- toYaml . | nindent 4 }}
+  {{- end }}
   ## Secret with default environment variable configurations
   configuration:
     name: {{ .configuration.name }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -38,6 +38,30 @@ tenant:
   # Only one array element is supported at this time.
   imagePullSecret: { }
   ###
+  #
+  # Specify `initContainers <https://kubernetes.io/docs/concepts/workloads/pods/init-containers/>`__ to perform setup or configuration tasks before the main Tenant pods starts.
+  #
+  # Example of init container which waits for idenity provider to be reachable before starting MinIO Tenant:
+  # 
+  # .. code-block:: yaml
+  #
+  # initContainers:
+  #  - name: wait-for-idp
+  #    image: busybox
+  #    command:
+  #      - sh
+  #      - -c
+  #      - |
+  #        URL="https://idp-url"
+  #        echo "Checking IdP reachability (${URL})"
+  #        until $(wget -q -O "/dev/null" ${URL}) ; do
+  #          echo "IdP (${URL}) not reachable. Waiting to be reachable..."
+  #          sleep 5
+  #        done
+  #        echo "IdP (${URL}) reachable. Starting MinIO..."
+  #
+  initContainers: [ ]
+  ###
   # The Kubernetes `Scheduler <https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/>`__ to use for dispatching Tenant pods.
   #
   # Specify an empty dictionary ``{}`` to dispatch pods with the default scheduler.


### PR DESCRIPTION
This PR adds support in the Helm chart to configure initContainers for tenant pods.
Although initContainers were already supported by CRD, they can now be specified through Helm.
A comment with an example usage of initContainers has been addedd in values.yaml to address an issue noted in GitHub issue https://github.com/minio/minio/issues/20118.

As requested by @pjuarezd in #2354 i moved my commits to a dedicated branch.