### PR TITLE
Always renew certificate if it can't be checked for renewal

### DIFF
--- a/pkg/controller/minio.go
+++ b/pkg/controller/minio.go
@@ -124,7 +124,8 @@ func (c *Controller) checkMinIOCertificatesStatus(ctx context.Context, tenant *m
 
 		needsRenewal, err := c.certNeedsRenewal(tlsSecret)
 		if err != nil {
-			return err
+			klog.Warningf("Cannot check secret %s/%s for renewal (will be renewing): %v", tlsSecret.Namespace, tlsSecret.Name, err)
+			needsRenewal = true
 		}
 
 		if needsRenewal {


### PR DESCRIPTION
This PR will always renew the private key/certificate if it cannot check if the certficate should be renewed. The only reasons why this check fails is:
- TLS private key cannot be parsed.
- TLS certificate cannot be parsed.
- The private key and certificate don't have matching private/public keys.

All reasons are valid reasons to renew the private key and certificate.