### PR TITLE
log: send a event when secret is not found

### DIFF
--- a/pkg/controller/main-controller.go
+++ b/pkg/controller/main-controller.go
@@ -813,6 +813,10 @@ func (c *Controller) syncHandler(key string) (Result, error) {
 			c.recorder.Event(tenant, corev1.EventTypeWarning, "MissingCreds", "Tenant is missing root credentials")
 			return WrapResult(Result{}, nil)
 		}
+		if k8serrors.IsNotFound(err) {
+			// if secret is not found, send event
+			c.recorder.Event(tenant, corev1.EventTypeWarning, "NotFound", err.Error())
+		}
 		return WrapResult(Result{}, err)
 	}
 	// get existing configuration from config.env


### PR DESCRIPTION
## Description

log: send a event when secret is not found
if secret is not found, getting the operator log is the only way before.

<!-- Provide a short summary of the changes in this PR -->

Now we send a event to K8S as well

<!-- Add more context to facilitate the reviewing process if needed -->

## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [x] Other (please describe) ⬇️

log

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1. Deploy a tenant without secret
2. We can get the warnning by `kubectl get events -n namespace`

## Additional Notes / Context

<!-- Add any other context or details about the PR -->
