### PR TITLE
feat: allow not recommended pool sizes

### DIFF
--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -552,6 +552,12 @@ The number of Persistent Volume Claims to generate for each MinIO server pod in 
 
 The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 
+|*`skipRecommendedPoolSizeValidation`* __boolean__
+|*Optional* +
+
+
+Allow 2 or 3 volumes per pool that is not recommended for production. Use at your own risk. +
+
 |*`volumeClaimTemplate`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#persistentvolumeclaim-v1-core[$$PersistentVolumeClaim$$]__ 
 |*Required* +
 

--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -3404,6 +3404,8 @@ spec:
                       x-kubernetes-validations:
                       - message: servers is immutable
                         rule: self == oldSelf
+                    skipRecommendedPoolSizeValidation:
+                      type: boolean
                     tolerations:
                       items:
                         properties:

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -42,6 +42,9 @@ spec:
     - servers: {{ .servers | default 4 }}
       name: {{ .name | default "" }}
       volumesPerServer: {{ .volumesPerServer | default 4 }}
+      {{- if .skipRecommendedPoolSizeValidation }}
+      skipRecommendedPoolSizeValidation: {{ .skipRecommendedPoolSizeValidation }}
+      {{- end }}
       {{- if .runtimeClassName }}
       runtimeClassName: {{ .runtimeClassName }}
       {{- end }}

--- a/pkg/apis/minio.min.io/v2/helper.go
+++ b/pkg/apis/minio.min.io/v2/helper.go
@@ -772,7 +772,7 @@ func (z *Pool) Validate(zi int) error {
 		return fmt.Errorf("pool #%d cannot have 0 volumes per server", zi)
 	}
 
-	if z.Servers*z.VolumesPerServer < 4 {
+	if !z.SkipRecommendedPoolSizeValidation && z.Servers*z.VolumesPerServer < 4 {
 		// Erasure coding has few requirements.
 		switch z.Servers {
 		case 2:

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -661,6 +661,11 @@ type Pool struct {
 	//
 	// The MinIO Operator requires a minimum of `4` volumes per pool. Specifically, the result of `pools.servers X pools.volumesPerServer` must be greater than `4`. +
 	VolumesPerServer int32 `json:"volumesPerServer"`
+	// *Optional* +
+	//
+	// Allow 2 or 3 volumes per pool that is not recommended for production. Use at your own risk. +
+	// +optional
+	SkipRecommendedPoolSizeValidation bool `json:"skipRecommendedPoolSizeValidation,omitempty"`
 	// *Required* +
 	//
 	// Specify the configuration options for the MinIO Operator to use when generating Persistent Volume Claims for the MinIO tenant. +

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3404,6 +3404,8 @@ spec:
                       x-kubernetes-validations:
                       - message: servers is immutable
                         rule: self == oldSelf
+                    skipRecommendedPoolSizeValidation:
+                      type: boolean
                     tolerations:
                       items:
                         properties:


### PR DESCRIPTION
## Description

I know that this is controversial topic and small setups are not primary focus of this project but I find that minio managing only 2 or 3 drives can still provide benefits. Even in such small setups it allows you to do maintenance without affecting users (in 3x1 case) or at least serving read operations (in 2x1 case) during it. And having a pool of 2 or 3 drives on different servers is still a bit more safe than a pool of 2 or 3 drives on one server (that is allowed by the operator). So maybe it would be enough to recommend minimum 4 drives per pool instead of requiring it?
This PR adds `skipRecommendedPoolSizeValidation` field to `Pool` type as a way for a user to explicitly take the risk of running minio with not recommended settings.

## Related Issue

relates: https://github.com/minio/minio/discussions/18572

## Type of Change

- [ ] Bug fix 🐛
- [x] New feature 🚀
- [ ] Breaking change 🚨
- [x] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Checklist

- [ ] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)
