### PR TITLE
Fix issue with Helm configuration secret

### DIFF
--- a/helm/tenant/templates/checks.yaml
+++ b/helm/tenant/templates/checks.yaml
@@ -1,0 +1,24 @@
+{{- with .Values.tenant }}
+
+# If an existing secret is used, do not set access-key and secret-key explicitly
+# (note that we allow the default settings in values.yaml)
+{{- with .configSecret }}
+{{- if .existingSecret }}
+{{- if and .accessKey (ne .accessKey "minio") }}
+{{- fail "Cannot set access-key when an existing secret is used" }}
+{{- end }}
+{{- if and .secretKey (ne .secretKey "minio123") }}
+{{- fail "Cannot set secret-key when an existing secret is used" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+# If configuration.name is set and not the same as configSecret.name,
+# then we should raise an error and abort
+{{- if and .configuration .configuration.name }}
+{{- if and .configSecret (ne .configuration.name .configSecret.name) -}}
+{{- fail "configuration.name is deprecated and doesn't match .tenant.configSecret.name" }}
+{{- end -}}
+{{- end }}
+
+{{- end }}

--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -16,13 +16,6 @@ stringData:
     export MINIO_ROOT_USER={{ .Values.tenant.configSecret.accessKey | quote }}
     export MINIO_ROOT_PASSWORD={{ .Values.tenant.configSecret.secretKey | quote }}
 
-{{- else }}
-{{- if (.Values.tenant.configSecret.accessKey) }}
-{{- fail "# ERROR: cannot set access-key when an existing secret is used" }}
-{{- end }}
-{{- if (.Values.tenant.configSecret.secretKey) }}
-{{- fail "# ERROR: cannot set secret-key when an existing secret is used" }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -30,7 +30,7 @@ spec:
   {{- end }}
   ## Secret with default environment variable configurations
   configuration:
-    name: {{ .configuration.name }}
+    name: {{ .configSecret.name }}
   {{- if hasKey . "poolsMetadata" }}
   poolsMetadata: {{- if eq (len .poolsMetadata) 0 }} {} {{- end }}
   {{- with (dig "poolsMetadata" (dict) .) }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -67,11 +67,6 @@ tenant:
   # Specify an empty dictionary ``{}`` to dispatch pods with the default scheduler.
   scheduler: { }
   ###
-  # The Kubernetes secret name that contains MinIO environment variable configurations.
-  # The secret is expected to have a key named config.env containing environment variables exports.
-  configuration:
-    name: myminio-env-configuration
-  ###
   # Root key for dynamically creating a secret for use with configuring root MinIO User
   # Specify the ``name`` and then a list of environment variables.
   #


### PR DESCRIPTION
## Description
This PR fixes a problem that was introduced with #2299. There were two issues:
1. The values in `.tenant.configuration.name` and `.tenant.configSecret.name` needed to match exactly, otherwise the tenant wouldn't start.
2. When `.tenant.configSecret.existingSecret` was set, then the access-key and secret-key needed to be set to empty values explicitly.

This PR makes the following two changes:
1. The `.tenant.configuration.name` has been removed. If it is set, then it should be the same value as `.tenant.configSecret.name`. We sill raise an error if it's not (previously this would not generate an error, but would cause a tenant that wouldn't start).
2. It doesn't require the access-key and secret-key to be set anymore. If you do explicitly set it (to values different then the default values), then we raise an error to prevent mistakes.

## Type of Change

- [X] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Checklist

- [X] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

Create a tenant with the following secret:
```yaml
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: config-secret
  namespace: minio-ns
data:
  config.env: ZXhwb3J0IE1JTklPX1JPT1RfVVNFUj0ibWluaW8iCmV4cG9ydCBNSU5JT19ST09UX1BBU1NXT1JEPSJtaW5pbzEyMyI=
```
Then create a tenant using the following values:
```yaml
tenant:
  configSecret:
    existingSecret: true
    name: config-secret
```