### PR TITLE
Update MinIO and KES base images.

### DIFF
--- a/docs/policybinding_crd.adoc
+++ b/docs/policybinding_crd.adoc
@@ -4,7 +4,7 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2025-03-12T18-04-18Z]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2025-04-03T14-56-28Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2025-03-12T09-35-18Z]
 :mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:RELEASE.2024-10-02T08-27-28Z]
 

--- a/docs/templates/asciidoctor/gv_list.tpl
+++ b/docs/templates/asciidoctor/gv_list.tpl
@@ -7,7 +7,7 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2025-03-12T18-04-18Z]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2025-04-03T14-56-28Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2025-03-12T09-35-18Z]
 :mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:RELEASE.2024-10-02T08-27-28Z]
 

--- a/docs/tenant_crd.adoc
+++ b/docs/tenant_crd.adoc
@@ -4,7 +4,7 @@
 [id="{p}-api-reference"]
 == API Reference
 
-:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2025-03-12T18-04-18Z]
+:minio-image: https://hub.docker.com/r/minio/minio/tags[minio/minio:RELEASE.2025-04-03T14-56-28Z]
 :kes-image: https://hub.docker.com/r/minio/kes/tags[minio/kes:2025-03-12T09-35-18Z]
 :mc-image: https://hub.docker.com/r/minio/mc/tags[minio/mc:RELEASE.2024-10-02T08-27-28Z]
 

--- a/examples/kustomization/base/tenant.yaml
+++ b/examples/kustomization/base/tenant.yaml
@@ -144,7 +144,7 @@ spec:
   ## https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
   externalClientCertSecrets: [ ]
   ## Registry location and Tag to download MinIO Server image
-  image: quay.io/minio/minio:RELEASE.2025-03-12T18-04-18Z
+  image: quay.io/minio/minio:RELEASE.2025-04-03T14-56-28Z
   imagePullSecret: { }
   ## Mount path where PV will be mounted inside container(s).
   mountPath: /export

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -15,7 +15,7 @@ tenant:
   # 
   #    image:
   #       repository: quay.io/minio/minio
-  #       tag: RELEASE.2025-03-12T18-04-18Z
+  #       tag: RELEASE.2025-04-03T14-56-28Z
   #       pullPolicy: IfNotPresent
   #
   # The chart also supports specifying an image based on digest value:
@@ -30,7 +30,7 @@ tenant:
   #
   image:
     repository: quay.io/minio/minio
-    tag: RELEASE.2025-03-12T18-04-18Z
+    tag: RELEASE.2025-04-03T14-56-28Z
     pullPolicy: IfNotPresent
   ###
   #

--- a/pkg/apis/minio.min.io/v2/constants.go
+++ b/pkg/apis/minio.min.io/v2/constants.go
@@ -106,7 +106,7 @@ const MinIOVolumeMountPath = "/export"
 const MinIOVolumeSubPath = ""
 
 // DefaultMinIOImage specifies the default MinIO Docker hub image
-const DefaultMinIOImage = "minio/minio:RELEASE.2025-03-12T18-04-18Z"
+const DefaultMinIOImage = "minio/minio:RELEASE.2025-04-03T14-56-28Z"
 
 // DefaultMinIOUpdateURL specifies the default MinIO URL where binaries are
 // pulled from during MinIO upgrades


### PR DESCRIPTION
## Description

Update MinIO an KES base images, ensuring the latest release of [minio](https://github.com/minio/minio) is used by default.

## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [x] Other (please describe) ⬇️

Version update to ensure a MinIO version with a fix for [CVE-2025-31489](https://github.com/minio/minio/security/advisories/GHSA-wg47-6jq2-q2hh) is used by default.


## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [ ] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [x] I have added necessary unit tests (if applicable)