### PR TITLE
Bugfix: error applying `operator.sidecarImage`

### DIFF
--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -48,12 +48,13 @@ spec:
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:
             - controller
-          {{- with .Values.operator.env }}
-          env: {{- toYaml . | nindent 12 }}
-          {{- end }}
+          env:
           {{- if .Values.operator.sidecarImage }}
-            - name: "OPERATOR_SIDECAR_IMAGE"
-              value: "{{ .Values.operator.sidecarImage.repository }}:{{ .Values.operator.sidecarImage.digest | default .Values.operator.sidecarImage.tag }}"
+          - name: "OPERATOR_SIDECAR_IMAGE"
+            value: "{{ .Values.operator.sidecarImage.repository }}:{{ .Values.operator.sidecarImage.digest | default .Values.operator.sidecarImage.tag }}"
+          {{- end }}
+          {{- with .Values.operator.env }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.operator.resources | nindent 12 }}
           {{- with .Values.operator.containerSecurityContext }}


### PR DESCRIPTION
## Description

If `operator.env` and `operator.sidecarImage` are set output syntax is incorrect causing error:

```
Error: UPGRADE FAILED: cannot patch "minio-operator" with kind Deployment:  "" is invalid: patch: Invalid value:
...
json: cannot unmarshal object into Go struct field Container.spec.template.spec.containers.args of type string
```

## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1. Set in values.yaml
```yaml

operator:
  sidecarImage:
    repository: "fb01dvmehbr01.fig.3.uk/minio/operator-sidecar"
    tag: "v7.0.1"
    pullPolicy: IfNotPresent

2. install helm chart helm upgrade operator minio/operator --version 7.0.1 -n minio-operator -f values.yaml
3.  Error because an invalid Deployment is generated shows as follows:

```
Error: UPGRADE FAILED: cannot patch "minio-operator" with kind Deployment:  "" is invalid: patch: Invalid value:
...
json: cannot unmarshal object into Go struct field Container.spec.template.spec.containers.args of type string
```
