### PR TITLE
Fix Policy Binding test

### DIFF
--- a/examples/kustomization/sts-example/sample-clients/aws-sdk/python/Dockerfile
+++ b/examples/kustomization/sts-example/sample-clients/aws-sdk/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM python:3
 
 RUN \
     apt-get update && \


### PR DESCRIPTION
## Description
Fix Policy Binding test:

`ubuntu:latest` do not have python 3 installed by default, changing the base image to `python:3` ensures python is available.

## Related Issue

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [x] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [ ] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [] I have added necessary unit tests (if applicable)