### PR TITLE
fix: wrong indentation in env causing helm install failure

### DIFF
--- a/helm/operator/templates/operator-deployment.yaml
+++ b/helm/operator/templates/operator-deployment.yaml
@@ -50,8 +50,8 @@ spec:
             - controller
           env:
           {{- if .Values.operator.sidecarImage }}
-          - name: "OPERATOR_SIDECAR_IMAGE"
-            value: "{{ .Values.operator.sidecarImage.repository }}:{{ .Values.operator.sidecarImage.digest | default .Values.operator.sidecarImage.tag }}"
+            - name: "OPERATOR_SIDECAR_IMAGE"
+              value: "{{ .Values.operator.sidecarImage.repository }}:{{ .Values.operator.sidecarImage.digest | default .Values.operator.sidecarImage.tag }}"
           {{- end }}
           {{- with .Values.operator.env }}
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Description
The following `values.yaml` causes error in current helm chart on `main` branch:
```yaml
operator:
  image:
    repository: k3d-k3d.localhost:5005/minio-operator
    tag: unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e
  sidecarImage:
    repository: k3d-k3d.localhost:5005/minio-operator-sidecar
    tag: unused@sha256:08b374f20a4e67fbd8cb93aa76fabf8b9f50684dce356eccf2540a2c7a7a2237

```

Error:
```
Error: YAML parse error on operator/templates/operator-deployment.yaml: error converting YAML to JSON: yaml: line 49: did not find expected key
helm.go:86: 2025-04-21 23:07:23.590851 +0530 IST m=+0.087494917 [debug] error converting YAML to JSON: yaml: line 49: did not find expected key
YAML parse error on operator/templates/operator-deployment.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:144
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:104
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:168
```

Its because of this unintentional change in the chart: https://github.com/minio/operator/pull/2422#discussion_r2052743852

If I remove `operator.env` from `values.yaml`:
```yaml
operator:
  image:
    repository: k3d-k3d.localhost:5005/minio-operator
    tag: unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e
  sidecarImage:
    repository: k3d-k3d.localhost:5005/minio-operator-sidecar
    tag: unused@sha256:08b374f20a4e67fbd8cb93aa76fabf8b9f50684dce356eccf2540a2c7a7a2237
  env: ~

```
I get the following, chart:
```yaml
      containers:
        - name: operator
          image: "k3d-k3d.localhost:5005/minio-operator:unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e"
          imagePullPolicy: IfNotPresent
          args:
            - controller
          env:
          - name: "OPERATOR_SIDECAR_IMAGE"
            value: "k3d-k3d.localhost:5005/minio-operator-sidecar:unused@sha256:08b374f20a4e67fbd8cb93aa76fabf8b9f50684dce356eccf2540a2c7a7a2237"
```

If I remove the `operator.sidecarImage` from `values.yaml`:
```yaml
operator:
  image:
    repository: k3d-k3d.localhost:5005/minio-operator
    tag: unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e

```
I get the following:
```yaml
      containers:
        - name: operator
          image: "k3d-k3d.localhost:5005/minio-operator:unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e"
          imagePullPolicy: IfNotPresent
          args:
            - controller
          env:
            - name: OPERATOR_STS_ENABLED
              value: "on"
          resources:
```

These 2 envs are unmergable because of indentation.

This PR fixes this issue:
```yaml
      containers:
        - name: operator
          image: "k3d-k3d.localhost:5005/minio-operator:unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e"
          imagePullPolicy: IfNotPresent
          args:
            - controller
          env:
            - name: "OPERATOR_SIDECAR_IMAGE"
              value: "k3d-k3d.localhost:5005/minio-operator-sidecar:unused@sha256:08b374f20a4e67fbd8cb93aa76fabf8b9f50684dce356eccf2540a2c7a7a2237"
            - name: OPERATOR_STS_ENABLED
              value: "on"
```
<!-- Provide a short summary of the changes in this PR -->
<!-- Add more context to facilitate the reviewing process if needed -->

## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1. values.yaml
    ```yaml
    operator:
      image:
        repository: k3d-k3d.localhost:5005/minio-operator
        tag: unused@sha256:be331832f82ea2e0f1f1c33471b13187941ce17f0f02cc25a037aa51c0771b9e
      sidecarImage:
        repository: k3d-k3d.localhost:5005/minio-operator-sidecar
        tag: unused@sha256:08b374f20a4e67fbd8cb93aa76fabf8b9f50684dce356eccf2540a2c7a7a2237
     ```
2. Run: `helm template operator --namespace minio-operator --create-namespace ./helm/operator --values values.yaml --debug
`

## Additional Notes / Context

<!-- Add any other context or details about the PR -->
