### PR TITLE
Add `helm template` validation

### DIFF
--- a/testing/common.sh
+++ b/testing/common.sh
@@ -558,7 +558,12 @@ function install_operator() {
     echo "Change the version accordingly for image to be found within the cluster"
     yq -i '.operator.image.repository = "minio/operator"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
     yq -i '.operator.image.tag = "noop"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
-    yq -i '.operator.env += [{"name": "OPERATOR_SIDECAR_IMAGE", "value": "'$SIDECAR_TAG'"}]' "${SCRIPT_DIR}/../helm/operator/values.yaml"
+    yq -i '.operator.sidecarImage.repository = "minio/operator-sidecar"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
+    yq -i '.operator.sidecarImage.tag = "noop"' "${SCRIPT_DIR}/../helm/operator/values.yaml"
+
+		try helm lint "${SCRIPT_DIR}/../helm/operator" --quiet
+		try helm template operator --namespace minio-operator --create-namespace "${SCRIPT_DIR}/../helm/operator" --debug
+
     echo "Installing Current Operator via HELM"
     create_restricted_namespace minio-operator
     helm install \
@@ -792,6 +797,7 @@ function install_tenant() {
     yq -i eval 'del(.tenant.kes)' "${SCRIPT_DIR}/../helm/tenant/values.yaml"
 
     try helm lint "${SCRIPT_DIR}/../helm/tenant" --quiet
+    try helm template operator --namespace minio-operator --create-namespace "${SCRIPT_DIR}/../helm/tenant" --debug
 
     namespace=default
     key=v1.min.io/tenant


### PR DESCRIPTION
## Description

Add `helm template` validation to the Operator and tenant helm chart, this will help ensure that the resulting chart is being verified.

Previously only `helm lint` validation was ran, but this is not enough, `helm lint` runs a syntactic and semantic check but doesn't fully render templates with values, so it might miss invalid YAML caused by `{{ }}` blocks or templating errors.

`helm template` will render the templates fully with values and show the exact output causing the YAML parse failure (exit code different than `0`).


## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [x] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [x] I have added necessary unit tests (if applicable)

## Test Steps

`Tenant Tests On Kind / helm` Github action will exit now if the template rendering is not sucessful.
