### PR TITLE
Allow more customization of kes section in tenant

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -184,22 +184,24 @@ spec:
     {{- end }}
     ## Key name to be created on the KMS, default is "my-minio-key"
     keyName: {{ .kes.keyName | quote }}
-    {{- with (dig "resources" (dict) .) }}
-    resources: {{- toYaml . | nindent 4 }}
+    {{- with (dig "kes" "resources" (dict) .) }}
+    resources: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with (dig "nodeSelector" (dict) .) }}
-    nodeSelector: {{- toYaml . | nindent 4 }}
+    {{- with (dig "kes" "nodeSelector" (dict) .) }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     affinity:
-      nodeAffinity: {}
-      podAffinity: {}
-      podAntiAffinity: {}
-    tolerations: []
-    {{- with (dig "annotations" (dict) .) }}
-    annotations: {{- toYaml . | nindent 4 }}
+      nodeAffinity: {{- (dig "kes" "nodeAffinity" (dict) .) | toYaml | nindent 8 }}
+      podAffinity: {{- (dig "kes" "podAffinity" (dict) .) | toYaml | nindent 8 }}
+      podAntiAffinity: {{- (dig "kes" "podAntiAffinity" (dict) .) | toYaml | nindent 8 }}
+    {{- with (dig "kes" "tolerations" (list) .) }}
+    tolerations: {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "labels" (dict) .) }}
-    labels: {{- toYaml . | nindent 4 }}
+    {{- with (dig "kes" "annotations" (dict) .) }}
+    annotations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with (dig "kes" "labels" (dict) .) }}
+    labels: {{- toYaml . | nindent 6 }}
     {{- end }}
     serviceAccountName: {{ .kes.serviceAccountName | quote }}
     {{- if hasKey .kes "securityContext" }}
@@ -214,5 +216,8 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- end }}
+  {{- end }}
+  {{- with (dig "sideCars" (dict) .) }}
+  sideCars: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -191,9 +191,9 @@ spec:
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     affinity:
-      nodeAffinity: {{- (dig "kes" "nodeAffinity" (dict) .) | toYaml | nindent 8 }}
-      podAffinity: {{- (dig "kes" "podAffinity" (dict) .) | toYaml | nindent 8 }}
-      podAntiAffinity: {{- (dig "kes" "podAntiAffinity" (dict) .) | toYaml | nindent 8 }}
+      nodeAffinity: {{- (dig "kes" "affinity" "nodeAffinity" (dict) .) | toYaml | nindent 8 }}
+      podAffinity: {{- (dig "kes" "affinity" "podAffinity" (dict) .) | toYaml | nindent 8 }}
+      podAntiAffinity: {{- (dig "kes" "affinity" "podAntiAffinity" (dict) .) | toYaml | nindent 8 }}
     {{- with (dig "kes" "tolerations" (list) .) }}
     tolerations: {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -184,10 +184,10 @@ spec:
     {{- end }}
     ## Key name to be created on the KMS, default is "my-minio-key"
     keyName: {{ .kes.keyName | quote }}
-    {{- with (dig "kes" "resources" (dict) .) }}
+    {{- with (dig "kes" "resources" (dict) .) | default (dig "resources" (dict) .)}}
     resources: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with (dig "kes" "nodeSelector" (dict) .) }}
+    {{- with (dig "kes" "nodeSelector" (dict) .) | default (dig "nodeSelector" (dict) .) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     affinity:
@@ -197,10 +197,10 @@ spec:
     {{- with (dig "kes" "tolerations" (list) .) }}
     tolerations: {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with (dig "kes" "annotations" (dict) .) }}
+    {{- with (dig "kes" "annotations" (dict) .) | default (dig "annotations" (dict) .) }}
     annotations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with (dig "kes" "labels" (dict) .) }}
+    {{- with (dig "kes" "labels" (dict) .) | default (dig "labels" (dict) .) }}
     labels: {{- toYaml . | nindent 6 }}
     {{- end }}
     serviceAccountName: {{ .kes.serviceAccountName | quote }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -480,8 +480,8 @@ tenant:
   #        - ALL
   #    seccompProfile:
   #      type: RuntimeDefault
-  #  sideCars:
-  #    resources: { }
+  #sideCars:
+  #  resources: { }
 
 ###
 # Configures `Ingress <https://kubernetes.io/docs/concepts/services-networking/ingress/>`__ for the Tenant S3 API and Console.

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -480,6 +480,9 @@ tenant:
   #        - ALL
   #    seccompProfile:
   #      type: RuntimeDefault
+
+  ###
+  # Customize sideCars, as defined in https://min.io/docs/minio/kubernetes/upstream/reference/operator-crd.html#sidecars
   #sideCars:
   #  resources: { }
 

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -480,6 +480,8 @@ tenant:
   #        - ALL
   #    seccompProfile:
   #      type: RuntimeDefault
+  #  sideCars:
+  #    resources: { }
 
 ###
 # Configures `Ingress <https://kubernetes.io/docs/concepts/services-networking/ingress/>`__ for the Tenant S3 API and Console.


### PR DESCRIPTION
## Description

This small PR extends the available values in kes objects to improve (and correct) the customzation of the kes section in the tenant helm chart.

- Some values were hardcoded, they are now configurable
- Some values are available in the tenant CRD, but not available in the chart
- Some values where not searched (dug) at the right place in the values.yaml file.

## Type of Change

- [X] Bug fix 🐛 and improvments
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Checklist

- [X] I have tested these changes
- [X] I have updated relevant documentation (if applicable)
- [X] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1. Uncomment kes section in the helm/tenantvalues.yaml file
2. Change some values
3. run helm template
4. Make sure the change are reflected properly

## Additional Notes / Context

<!-- Add any other context or details about the PR -->
