### PR TITLE
Use `.Release.namespace` in tenant Helm chart

### DIFF
--- a/helm/tenant/templates/api-ingress.yaml
+++ b/helm/tenant/templates/api-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.tenant.name }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.api.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/tenant/templates/console-ingress.yaml
+++ b/helm/tenant/templates/console-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.tenant.name }}-console
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.console.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/tenant/templates/kes-configuration-secret.yaml
+++ b/helm/tenant/templates/kes-configuration-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kes-configuration
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
   server-config.yaml: {{ .Values.tenant.kes.configuration | toYaml | indent 2 }}

--- a/helm/tenant/templates/tenant-configuration.yaml
+++ b/helm/tenant/templates/tenant-configuration.yaml
@@ -10,6 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ dig "tenant" "configSecret" "name" "" (.Values | merge (dict)) }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
   config.env: |-

--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -3,6 +3,7 @@ apiVersion: minio.min.io/v2
 kind: Tenant
 metadata:
   name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
   ## Optionally pass labels to be applied to the statefulset pods
   labels:
     app: minio


### PR DESCRIPTION
## Description
Tenant Helm chart should respect the `--namespace` setting.

## Related Issue
Fixes https://github.com/minio/operator/issues/2453

## Type of Change

- [X] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Checklist

- [X] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

1. Install tenant chart in a customized namespace: `helm install --create-namespace -n tenant1 tenant1 ./helm/tenant`.
2. Check if tenant is installed in the specified namespace and is running.