### PR TITLE
fix: pipeline mc config not found

### DIFF
--- a/testing/console-tenant+kes.sh
+++ b/testing/console-tenant+kes.sh
@@ -112,9 +112,8 @@ function test_kes_tenant() {
   PASSWORD=$(kubectl -n tenant-kms-encrypted get secrets "$TENANT_CONFIG_SECRET" -o go-template='{{index .data "config.env"|base64decode }}' | grep 'export MINIO_ROOT_PASSWORD="' | sed -e 's/export MINIO_ROOT_PASSWORD="//g' | sed -e 's/"//g')
 
   totalwait=0
-  until (mc config host add kestest https://localhost:9000 $USER $PASSWORD --insecure); do
+  until (mc alias set kestest https://localhost:9000 $USER $PASSWORD --insecure); do
     echo "...waiting... for 5secs" && sleep 5
-
     totalwait=$((totalwait + 5))
     if [ "$totalwait" -gt 305 ]; then
       echo "Unable to register mc tenant after 5 minutes, exiting."


### PR DESCRIPTION
fix: pipeline mc config not found

## Description

<!-- Provide a short summary of the changes in this PR -->
<!-- Add more context to facilitate the reviewing process if needed -->
fix: https://github.com/minio/operator/actions/runs/15109422363/job/43003394128?pr=2454
```log
Done.
Port Forwarding tenant
Forwarding from 127.0.0.1:9000 -> 9000
Forwarding from [::1]:9000 -> 9000

mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag. 
...waiting... for 5secs
...
...waiting... for 5secs

mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag. 
...waiting... for 5secs
Unable to register mc tenant after 5 minutes, exiting.
```

## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [ ] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1.
2.

## Additional Notes / Context

<!-- Add any other context or details about the PR -->
