### PR TITLE
Add `sideCars` to the MinIO tenant Helm chart

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -29,6 +29,9 @@ spec:
   {{- with (dig "initContainers" (list) .) }}
   initContainers: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with (dig "sideCars" (dict) .) }}
+  sideCars: {{- toYaml . | nindent 4 }}
+  {{- end }}
   ## Secret with default environment variable configurations
   configuration:
     name: {{ .configSecret.name }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -62,6 +62,41 @@ tenant:
   #
   initContainers: [ ]
   ###
+  #
+  # Specify `sideCars <https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/>`__ to perform setup or configuration tasks while the main Tenant pods are running.
+  # See https://github.com/minio/operator/blob/master/docs/tenant_crd.adoc#sidecars
+  #
+  # Example of sidecar container which simply prints the MinIO server info and summarized bucket usage while the MinIO Tenant is running:
+  #
+  # .. code-block:: yaml
+  #
+  #    sideCars:
+  #     containers:
+  #       - name: sidecar-show-server-info-and-buckets
+  #         image: quay.io/minio/mc
+  #         env:
+  #           - name: MC_CONFIG_DIR
+  #             value: /tmp/.mc
+  #           - name: MC_HOST_k8slocal
+  #             value: http://your_root_user:you_root_password@your-minio-tenant-name-hl.your-minio-ns.svc.cluster.local:9000
+  #         command:
+  #           - sh
+  #           - -c
+  #           - |
+  #             echo 'Waiting for MinIO server...'
+  #             mc ping --distributed --exit k8slocal
+  #             echo 'MinIO server is up :)'
+  #             while true; do
+  #               mc admin info k8slocal
+  #               mc ls --summarize k8slocal/
+  #               sleep 300
+  #             done
+  #     volumeClaimTemplates: [ ]
+  #     volumes: [ ]
+  #     resources: { }
+  #
+  sideCars: { }
+  ###
   # The Kubernetes `Scheduler <https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/>`__ to use for dispatching Tenant pods.
   #
   # Specify an empty dictionary ``{}`` to dispatch pods with the default scheduler.

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -63,37 +63,8 @@ tenant:
   initContainers: [ ]
   ###
   #
-  # Specify `sideCars <https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/>`__ to perform setup or configuration tasks while the main Tenant pods are running.
+  # Specify `sideCars <https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/>`__.
   # See https://github.com/minio/operator/blob/master/docs/tenant_crd.adoc#sidecars
-  #
-  # Example of sidecar container which simply prints the MinIO server info and summarized bucket usage while the MinIO Tenant is running:
-  #
-  # .. code-block:: yaml
-  #
-  #    sideCars:
-  #     containers:
-  #       - name: sidecar-show-server-info-and-buckets
-  #         image: quay.io/minio/mc
-  #         env:
-  #           - name: MC_CONFIG_DIR
-  #             value: /tmp/.mc
-  #           - name: MC_HOST_k8slocal
-  #             value: http://your_root_user:you_root_password@your-minio-tenant-name-hl.your-minio-ns.svc.cluster.local:9000
-  #         command:
-  #           - sh
-  #           - -c
-  #           - |
-  #             echo 'Waiting for MinIO server...'
-  #             mc ping --distributed --exit k8slocal
-  #             echo 'MinIO server is up :)'
-  #             while true; do
-  #               mc admin info k8slocal
-  #               mc ls --summarize k8slocal/
-  #               sleep 300
-  #             done
-  #     volumeClaimTemplates: [ ]
-  #     volumes: [ ]
-  #     resources: { }
   #
   sideCars: { }
   ###


### PR DESCRIPTION
## Description
This PR adds the ability to configure the `tenant` Helm chart `sideCars`.
____

With the replacement of the MinIO Console with the simple Object Browser, more and more administrative tasks like the creation of service accounts have to be done with the MinIO Client `mc` command, which is a good thing, as IaC is more in the focus instead of conveniently using a web UI.
This configuration can be done, for example, using a K8s sidecar using the `quay.io/minio/mc` container image.
The Operator Tenant CRD already supports `sideCars`, but the tenant Helm chart currently does not support them.

https://github.com/minio/operator/blob/v7.1.1/docs/tenant_crd.adoc#sidecars

https://github.com/minio/operator/blob/v7.1.1/resources/base/crds/minio.min.io_tenants.yaml#L3805
https://github.com/minio/operator/blob/v7.1.1/helm/operator/templates/minio.min.io_tenants.yaml#L3805
<img width="641" alt="image" src="https://github.com/user-attachments/assets/a71c71a7-b5b2-4386-8426-6d47bca582d2" />

<!-- Provide a short summary of the changes in this PR -->
<!-- Add more context to facilitate the reviewing process if needed -->

## Related Issue

fixes: #2465

## Type of Change

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [x] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️


## Checklist

- [x] I have tested these changes
- [x] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

1. Use the `sideCars` configuration example in `helm/tenant/values.yaml`, same as it was done with the `initContainers` example.