### PR TITLE
Add details to Helm chart comments for tenant.user

### DIFF
--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -301,8 +301,9 @@ tenant:
   buckets: [ ]
   ###
   # Array of Kubernetes secrets from which the Operator generates MinIO users during tenant provisioning.
-  #
+  # Each element in the array is an object consisting of a key-value pair ``name: <string>``, where the ``<string>`` references an opaque Kubernetes secret.
   # Each secret should specify the ``CONSOLE_ACCESS_KEY`` and ``CONSOLE_SECRET_KEY`` as the access key and secret key for that user.
+  # The Operator creates each user with the ``consoleAdmin`` policy by default. You can change the assigned policy after the Tenant starts.
   users: [ ]
   ###
   # The `PodManagement <https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy>`__ policy for MinIO Tenant Pods. 


### PR DESCRIPTION
## Description

The comments did not adequately explain how to complete the `tenant.users` array. This adds missing details to the explanation for that line.

After merging, the docs will automatically pick this up on its next build to update https://docs.min.io/community/minio-object-store/reference/tenant-chart-values.html.

## Related Issue

Closes minio/docs#1362

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [x] Other (please describe) ⬇️
   Addresses user complaints of not knowing how to create users from the chart.


## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [ ] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1.
2.

## Additional Notes / Context

<!-- Add any other context or details about the PR -->
