### PR TITLE
Update default operator podAntiAffinity

### DIFF
--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -157,10 +157,10 @@ operator:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: name
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
-                  - minio-operator
+                  - operator
           topologyKey: kubernetes.io/hostname
   ###
   #


### PR DESCRIPTION
## Description

Target the actual existing deployment pod labels.

There is no `name` label on the operator pods.
Additionally the label value was changed 4 years ago in https://github.com/minio/operator/commit/dd62a262d168474692785cb8e4c6524133b38dee from `minio-operator` to `operator`.


## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [x] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1.
2.

## Additional Notes / Context


Having the current `app.kubernetes.io/name: operator` label should probably be adjusted as well since this may collide with other pods.
The original label before the above change was `app.kubernetes.io/name: minio-operator`.
