### PR TITLE
feat: optionally install CRD's based on helm value

### DIFF
--- a/helm/operator/templates/minio.min.io_tenants.yaml
+++ b/helm/operator/templates/minio.min.io_tenants.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.operator.installCRDs }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5754,3 +5755,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{ end }}

--- a/helm/operator/values.yaml
+++ b/helm/operator/values.yaml
@@ -75,6 +75,8 @@ operator:
   #      pullPolicy: IfNotPresent
   #
   sidecarImage: {}
+  # Install custom resource definitions
+  installCRDs: true
   ###
   #
   # An array of Kubernetes secrets to use for pulling images from a private ``image.repository``.


### PR DESCRIPTION
## Description

<!-- Provide a short summary of the changes in this PR -->
<!-- Add more context to facilitate the reviewing process if needed -->

We FluxCD to manage our infrastructure and have to install CRD's before we roll out charts, to do this we need a flag to disable the automatic installation. Currently we have a fork to be able to use this project. but it would be great if this could be included upstream.


## Related Issue

fixes: #2416
<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->

## Type of Change

- [ ] Bug fix 🐛
- [x] New feature 🚀
- [ ] Breaking change 🚨
- [ ] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Checklist

- [x] I have tested these changes
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)
