### PR TITLE
docs: fix kes link and update other link notations for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Use of MinIO Operator is governed by the GNU AGPLv3 or later, found in the [LICE
 [Github Resources](https://github.com/minio/operator/blob/master/docs/)
 
 - [Examples for MinIO Tenant Settings](https://github.com/minio/operator/blob/master/docs/examples.md)
-- [Custom Hostname Discovery](https://github.com/minio/operator/blob/master/docs/custom-name-templates.md).
-- [Apply PodSecurityPolicy](https://github.com/minio/operator/blob/master/docs/pod-security-policy.md).
-- [Deploy MinIO Tenant with KES](shttps://github.com/minio/operator/blob/master/docs/kes.md).
+- [Custom Hostname Discovery](https://github.com/minio/operator/blob/master/docs/custom-name-templates.md)
+- [Apply PodSecurityPolicy](https://github.com/minio/operator/blob/master/docs/pod-security-policy.md)
+- [Deploy MinIO Tenant with KES](https://github.com/minio/operator/blob/master/docs/kes.md)
 - [Tenant API Documentation](docs/tenant_crd.adoc)
 - [Policy Binding API Documentation](docs/policybinding_crd.adoc)


### PR DESCRIPTION
## Description

The link to docs/kes.md contained a typo causing not rendering the link. There was also some differentiation in how links where notated in terms of the ending `.`.

As other links in the docs are without an ending `.` I removed them but let me know if it's preferred to do otherwise.

## Type of Change

- [ ] Bug fix 🐛
- [ ] New feature 🚀
- [ ] Breaking change 🚨
- [x] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️
