### PR TITLE
Add hostAliases support for Tenant

### DIFF
--- a/helm/tenant/templates/tenant.yaml
+++ b/helm/tenant/templates/tenant.yaml
@@ -157,6 +157,9 @@ spec:
   {{- with (dig "env" (list) .) }}
   env: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with (dig "hostAliases" (list) .) }}
+  hostAliases: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if dig "priorityClassName" "" . }}
   priorityClassName: {{ dig "priorityClassName" "" . }}
   {{- end }}

--- a/helm/tenant/values.yaml
+++ b/helm/tenant/values.yaml
@@ -362,6 +362,17 @@ tenant:
   # Add environment variables to be set in MinIO container (https://github.com/minio/minio/tree/master/docs/config)
   env: [ ]
   ###
+  # Add custom host aliases to MinIO pods.
+  #
+  # Example:
+  #
+  # .. code-block:: yaml
+  #
+  #    - ip: "10.10.10.10"
+  #      hostnames:
+  #      - "internal.example.local"
+  hostAliases: [ ]
+  ###
   # PriorityClassName indicates the Pod priority and hence importance of a Pod relative to other Pods.
   # This is applied to MinIO pods only.
   # Refer Kubernetes documentation for details https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass/

--- a/pkg/apis/minio.min.io/v2/types.go
+++ b/pkg/apis/minio.min.io/v2/types.go
@@ -298,6 +298,11 @@ type TenantSpec struct {
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// *Optional* +
 	//
+	// Maps IP addresses to hostnames at the pod level. Entries are added to the `/etc/hosts` file on each MinIO pod.
+	// +optional
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
+	// *Optional* +
+	//
 	// The pull policy for the MinIO Docker image. Specify one of the following: +
 	//
 	// * `Always` +

--- a/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/minio.min.io/v2/zz_generated.deepcopy.go
@@ -837,6 +837,13 @@ func (in *TenantSpec) DeepCopyInto(out *TenantSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]v1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/client/applyconfiguration/minio.min.io/v2/tenantspec.go
+++ b/pkg/client/applyconfiguration/minio.min.io/v2/tenantspec.go
@@ -51,6 +51,7 @@ type TenantSpecApplyConfiguration struct {
 	PrometheusOperatorScrapeMetricsPaths []string                                     `json:"prometheusOperatorScrapeMetricsPaths,omitempty"`
 	ServiceAccountName                   *string                                      `json:"serviceAccountName,omitempty"`
 	PriorityClassName                    *string                                      `json:"priorityClassName,omitempty"`
+	HostAliases                          []v1.HostAlias                               `json:"hostAliases,omitempty"`
 	ImagePullPolicy                      *v1.PullPolicy                               `json:"imagePullPolicy,omitempty"`
 	SideCars                             *SideCarsApplyConfiguration                  `json:"sideCars,omitempty"`
 	ExposeServices                       *ExposeServicesApplyConfiguration            `json:"exposeServices,omitempty"`
@@ -284,6 +285,16 @@ func (b *TenantSpecApplyConfiguration) WithServiceAccountName(value string) *Ten
 // If called multiple times, the PriorityClassName field is set to the value of the last call.
 func (b *TenantSpecApplyConfiguration) WithPriorityClassName(value string) *TenantSpecApplyConfiguration {
 	b.PriorityClassName = &value
+	return b
+}
+
+// WithHostAliases adds the given value to the HostAliases field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the HostAliases field.
+func (b *TenantSpecApplyConfiguration) WithHostAliases(values ...v1.HostAlias) *TenantSpecApplyConfiguration {
+	for i := range values {
+		b.HostAliases = append(b.HostAliases, values[i])
+	}
 	return b
 }
 

--- a/pkg/resources/statefulsets/minio-statefulset.go
+++ b/pkg/resources/statefulsets/minio-statefulset.go
@@ -659,6 +659,7 @@ func NewPool(args *NewPoolArgs) *appsv1.StatefulSet {
 					SecurityContext:               poolSecurityContext(pool, poolStatus),
 					ServiceAccountName:            t.Spec.ServiceAccountName,
 					PriorityClassName:             t.Spec.PriorityClassName,
+					HostAliases:                   t.Spec.HostAliases,
 					TerminationGracePeriodSeconds: pool.TerminationGracePeriodSeconds,
 				},
 			},

--- a/resources/base/crds/minio.min.io_tenants.yaml
+++ b/resources/base/crds/minio.min.io_tenants.yaml
@@ -3778,6 +3778,18 @@ spec:
                 type: boolean
               serviceAccountName:
                 type: string
+              hostAliases:
+                items:
+                  properties:
+                    hostnames:
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ip:
+                      type: string
+                  type: object
+                type: array
               serviceMetadata:
                 properties:
                   consoleServiceAnnotations:


### PR DESCRIPTION
## Description

<!-- Provide a short summary of the changes in this PR -->
<!-- Add more context to facilitate the reviewing process if needed -->

Add support for `spec.hostAliases` in `Tenant` (`apiVersion: minio.min.io/v2`) so custom `/etc/hosts` entries can be configured for MinIO pods.

Changes included:
- Added `HostAliases []corev1.HostAlias` to `TenantSpec`
- Propagated `hostAliases` into MinIO StatefulSet PodSpec
- Updated CRD schema (`resources/base/crds/minio.min.io_tenants.yaml`)
- Updated Helm chart:
  - new `tenant.hostAliases` in `helm/tenant/values.yaml`
  - render `spec.hostAliases` in `helm/tenant/templates/tenant.yaml`
- Synced related generated paths used in repo:
  - deepcopy handling
  - applyconfiguration (`WithHostAliases`)

## Related Issue

<!-- Reference the issue this PR addresses (e.g., fixes: #123, closes: #123, relates: #12312) -->
relates: #1965

## Type of Change

- [ ] Bug fix 🐛
- [X] New feature 🚀
- [ ] Breaking change 🚨
- [X] Documentation update 📖
- [ ] Refactor 🔨
- [ ] Other (please describe) ⬇️

## Screenshots (if applicable e.g before/after)

<!-- Add screenshots or GIFs to illustrate changes if necessary -->

## Checklist

- [X] I have tested these changes
- [X] I have updated relevant documentation (if applicable)
- [ ] I have added necessary unit tests (if applicable)

## Test Steps

<!-- Be as descriptive as possible to facilitate the reviewing process -->

1. Apply/update CRD from this branch.
2. Create/update a `Tenant` with:
   ```yaml
   spec:
     hostAliases:
       - ip: "10.10.10.10"
         hostnames:
           - "internal.example.local"
   ```
3. Wait until MinIO `StatefulSet` is reconciled.
4. Verify pod spec contains `hostAliases`
5. Verify inside pod `/etc/hosts` contains the configured hostname mapping.

## Additional Notes / Context

<!-- Add any other context or details about the PR -->
- `gofmt` was applied.
- `go test` was applied for 
   - ./pkg/apis/minio.min.io/v2
   - ./pkg/client/applyconfiguration/minio.min.io/v2
   - ./pkg/resources/statefulsets
- `helm template` confirmed rendering `spec.hostAliases`

## Use case:
Deployed in minikube `istio+minio+keycloak` and configure `hosted local domain zone` (e.g. `pdnsutil zone`).
The issue is to setup `oauth2` at minio via keycloak (Own OIDC Provider):

You can not use internal address `.svc.cluster.local` because redirect url at browser will not resolve internal kubernetes address.
So you are using `hosted local zone` e.g. `keycloak.dev.local`, but it will be resolved to 127.0.0.1 - this is wrong and this is why we must have `hostAliases` to configure hostname `keycloak.dev.local` to `istio ingress gateway cluster IP`.